### PR TITLE
Rename crate to sqlrite-engine on crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,12 +152,13 @@ jobs:
         run: |
           # `--no-verify` skips the rebuild+test that publish does
           # by default — CI already ran on the same commit on the
-          # Release PR, so re-running here is duplicate work. Also
-          # `-p sqlrite` is explicit about which workspace member
-          # we're publishing (could be omitted since sqlrite is the
-          # root package, but being explicit protects against
-          # future layout changes).
-          cargo publish -p sqlrite --no-verify
+          # Release PR, so re-running here is duplicate work.
+          #
+          # Package name on crates.io is `sqlrite-engine`, not
+          # `sqlrite` — the latter was taken by an unrelated project
+          # (see root Cargo.toml for context). The [lib] name is
+          # still `sqlrite`, so downstream code writes `use sqlrite::…`.
+          cargo publish -p sqlrite-engine --no-verify
 
       - name: GitHub Release
         uses: softprops/action-gh-release@v2
@@ -165,11 +166,17 @@ jobs:
           tag_name: sqlrite-v${{ needs.detect.outputs.version }}
           name: Rust engine v${{ needs.detect.outputs.version }}
           body: |
-            Published to crates.io: https://crates.io/crates/sqlrite/${{ needs.detect.outputs.version }}
+            Published to crates.io: https://crates.io/crates/sqlrite-engine/${{ needs.detect.outputs.version }}
 
             ```toml
             [dependencies]
-            sqlrite = "${{ needs.detect.outputs.version }}"
+            sqlrite-engine = "${{ needs.detect.outputs.version }}"
+            ```
+
+            ```rust
+            // The [lib] name stays `sqlrite`, so the import alias is
+            // the short one even though the package name is longer.
+            use sqlrite::{Database, ExecutionResult};
             ```
 
             See the umbrella release [v${{ needs.detect.outputs.version }}](../../releases/tag/v${{ needs.detect.outputs.version }}) for the full changelog.
@@ -295,7 +302,7 @@ jobs:
 
             Per-product releases in this wave:
 
-            - 🦀 [Rust engine](../../releases/tag/sqlrite-v${{ needs.detect.outputs.version }}) → [crates.io](https://crates.io/crates/sqlrite/${{ needs.detect.outputs.version }})
+            - 🦀 [Rust engine](../../releases/tag/sqlrite-v${{ needs.detect.outputs.version }}) → [crates.io](https://crates.io/crates/sqlrite-engine/${{ needs.detect.outputs.version }})
             - 🔧 [C FFI](../../releases/tag/sqlrite-ffi-v${{ needs.detect.outputs.version }}) — prebuilt `libsqlrite_c` for Linux x86_64/aarch64, macOS aarch64, Windows x86_64
 
             _Python / Node.js / WASM / Go / desktop SDKs land as their publish jobs come online (Phases 6e–6i)._

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,7 +3735,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlrite"
+name = "sqlrite-desktop"
+version = "0.1.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sqlrite-engine",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+]
+
+[[package]]
+name = "sqlrite-engine"
 version = "0.1.1"
 dependencies = [
  "clap",
@@ -3750,23 +3762,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlrite-desktop"
-version = "0.1.1"
-dependencies = [
- "serde",
- "serde_json",
- "sqlrite",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
-]
-
-[[package]]
 name = "sqlrite-ffi"
 version = "0.1.1"
 dependencies = [
  "cbindgen",
- "sqlrite",
+ "sqlrite-engine",
 ]
 
 [[package]]
@@ -3776,7 +3776,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "sqlrite",
+ "sqlrite-engine",
 ]
 
 [[package]]
@@ -3784,7 +3784,7 @@ name = "sqlrite-python"
 version = "0.1.1"
 dependencies = [
  "pyo3",
- "sqlrite",
+ "sqlrite-engine",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,25 @@ members = [".", "desktop/src-tauri", "sqlrite-ffi", "sdk/python", "sdk/nodejs"]
 resolver = "3"
 
 [package]
-name = "sqlrite"
+# Published to crates.io as `sqlrite-engine` because `sqlrite` was
+# already taken (unrelated project — RAG-oriented SQLite wrapper). The
+# lib target below keeps `name = "sqlrite"`, so downstream Rust code
+# still writes `use sqlrite::…` — only the `cargo add` line and the
+# dependency declaration change:
+#
+#     [dependencies]
+#     sqlrite-engine = "0.1"
+#     # then in code: use sqlrite::{Database, …};
+#
+# Any workspace member here that depends on the engine uses the
+# `package =` key so the import name stays `sqlrite` internally:
+#     sqlrite = { package = "sqlrite-engine", path = "…" }
+name = "sqlrite-engine"
 version = "0.1.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
-description = "Light version of SQLite developed with Rust"
+description = "Light version of SQLite developed with Rust. Published as `sqlrite-engine` on crates.io; import as `use sqlrite::…`."
 repository = "https://github.com/joaoh82/rust_sqlite"
 license = "MIT"
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -21,7 +21,9 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 # Engine lives at the workspace root; reference it by path. Version
 # pinning can wait for a proper release cut.
-sqlrite = { path = "../.." }
+# `package = "sqlrite-engine"` — crates.io name — with an import alias
+# of `sqlrite` so Tauri command code can keep saying `use sqlrite::…`.
+sqlrite = { package = "sqlrite-engine", path = "../.." }
 
 tauri = { version = "2", features = [] }
 # Tauri 2 plugins must be opted into explicitly; the dialog plugin

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -215,7 +215,7 @@ A fix in the Rust engine propagates through one wrapper update per language rath
 
 Phase 6 lands GitHub Actions CI + release automation:
 
-- **crates.io** — `sqlrite` crate
+- **crates.io** — `sqlrite-engine` crate (published under a different name from the `sqlrite` lib target because the short name was already taken; users `cargo add sqlrite-engine` but still write `use sqlrite::…`)
 - **PyPI** — `sqlrite` wheels (manylinux x86_64/aarch64, macOS universal, Windows x86_64)
 - **npm** — `sqlrite` (Node) + `sqlrite-wasm` (browser) packages
 - **Go modules** — `sdk/go/v*` git tags

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -208,8 +208,12 @@ The "publish" half. Auto-fires on the release commit.
     them. Runs *before* the publish jobs — if a tag already exists
     (accidental re-run, cosmic ray), the whole workflow aborts
     cleanly.
-  - **publish-crate** — `cargo publish` the root crate to crates.io.
-    Creates GitHub Release `sqlrite-vX.Y.Z`.
+  - **publish-crate** — `cargo publish -p sqlrite-engine` the root
+    crate to crates.io. (The crates.io name is `sqlrite-engine`, not
+    `sqlrite`, because the short name was already taken by an
+    unrelated project; the `[lib] name = "sqlrite"` keeps `use
+    sqlrite::…` valid at import sites.) Creates GitHub Release
+    `sqlrite-vX.Y.Z`.
   - **publish-ffi** — matrix build of `libsqlrite_c` for
     `{linux-x86_64, linux-aarch64, macos-universal, windows-x86_64}`.
     Packages each as a tarball containing the `.so`/`.dylib`/`.dll`,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -387,13 +387,15 @@ Jobs wired up in Phase 6d:
 
 1. **detect** — parse version from commit message or dispatch input. Outputs `version` + `should_release`.
 2. **tag-all** — idempotent: creates `sqlrite-vX.Y.Z`, `sqlrite-ffi-vX.Y.Z`, and umbrella `vX.Y.Z`; skips any tag that already exists so "Re-run failed jobs" works cleanly after a partial-failure scenario.
-3. **publish-crate** — `cargo publish -p sqlrite --no-verify` using `CRATES_IO_TOKEN` from the `release` environment (required-reviewer gate applies). Creates the per-product GitHub Release `sqlrite-vX.Y.Z`.
+3. **publish-crate** — `cargo publish -p sqlrite-engine --no-verify` using `CRATES_IO_TOKEN` from the `release` environment (required-reviewer gate applies). Creates the per-product GitHub Release `sqlrite-vX.Y.Z`. The crates.io name is `sqlrite-engine` because the short `sqlrite` name was taken by an unrelated project; the `[lib] name = "sqlrite"` preserves `use sqlrite::…` at the import site.
 4. **publish-ffi** — matrix build of `libsqlrite_c` on Linux x86_64 (`ubuntu-latest`), Linux aarch64 (`ubuntu-24.04-arm`), macOS aarch64 (`macos-latest`), Windows x86_64 (`windows-latest`). Packages the cdylib + staticlib + `sqlrite.h` + README stub into a tarball, uploads to the `sqlrite-ffi-vX.Y.Z` GitHub Release. macOS universal (x86_64 + aarch64 lipo'd together) is a follow-up — MVP ships aarch64-only for Mac; add `macos-13` to the matrix if x86 demand materializes.
 5. **finalize** — creates the umbrella `vX.Y.Z` GitHub Release with GitHub's native auto-generated notes (`generate_release_notes: true`). Body links to every per-product release from this wave.
 
 Products whose publish jobs land in later phases (desktop, Python, Node.js, WASM, Go) aren't tagged yet — `tag-all` only creates tags for products that have an active publish job. Cleaner than creating empty releases for products we can't actually ship.
 
-**Verification path**: push this branch → merge → dispatch `release-pr.yml` with version `0.1.1` → review the auto-opened PR → merge → approve the `release` environment prompt → watch crates.io show `sqlrite 0.1.1` + Release page show two per-product releases + umbrella release. Once that works end-to-end, 6e lands the desktop publish, and we bump to `v0.1.2` for the next canary.
+**Verification path**: push this branch → merge → dispatch `release-pr.yml` with version `0.1.1` → review the auto-opened PR → merge → approve the `release` environment prompt → watch crates.io show `sqlrite-engine 0.1.1` + Release page show two per-product releases + umbrella release. Once that works end-to-end, 6e lands the desktop publish, and we bump to `v0.1.2` for the next canary.
+
+> **v0.1.1 canary retrospective** *(2026-04-22)* — first publish attempt failed on `cargo publish` with a 403 because the `sqlrite` crate name on crates.io is owned by an unrelated RAG-SQLite project. Renamed the package to `sqlrite-engine` (lib / bin names unchanged, so `use sqlrite::…` still works for consumers). Tags `sqlrite-v0.1.1` / `sqlrite-ffi-v0.1.1` / `v0.1.1` stay on main per the never-reuse-a-tag policy; the next canary cuts `v0.1.2` under the new crate name.
 
 ### Phase 6e — Desktop publish
 

--- a/sdk/nodejs/Cargo.toml
+++ b/sdk/nodejs/Cargo.toml
@@ -22,7 +22,11 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-sqlrite = { path = "../.." }
+# `package = "sqlrite-engine"` — crates.io name — with an import alias
+# of `sqlrite` so src/ code can keep saying `use sqlrite::…`. See root
+# Cargo.toml for the full story on why the package name differs from
+# the lib name.
+sqlrite = { package = "sqlrite-engine", path = "../.." }
 
 # napi-rs 2.x — mature + widely deployed (used by prisma, swc,
 # lightningcss, etc.). Version 2.16 adds `serde-json` features we

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -23,7 +23,11 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]
-sqlrite = { path = "../.." }
+# `package = "sqlrite-engine"` — crates.io name — with an import alias
+# of `sqlrite` so src/ code can keep saying `use sqlrite::…`. See root
+# Cargo.toml for the full story on why the package name differs from
+# the lib name.
+sqlrite = { package = "sqlrite-engine", path = "../.." }
 
 # PyO3 with the `abi3-py38` feature so one wheel works on every
 # CPython 3.8+ release — no per-Python-version rebuild.

--- a/sdk/wasm/Cargo.lock
+++ b/sdk/wasm/Cargo.lock
@@ -368,8 +368,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlrite"
-version = "0.1.0"
+name = "sqlrite-engine"
+version = "0.1.1"
 dependencies = [
  "log",
  "prettytable-rs",
@@ -379,14 +379,14 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "sqlrite",
+ "sqlrite-engine",
  "wasm-bindgen",
 ]
 

--- a/sdk/wasm/Cargo.toml
+++ b/sdk/wasm/Cargo.toml
@@ -30,7 +30,9 @@ crate-type = ["cdylib", "rlib"]
 # Engine as a path dep. `default-features = false` disables both
 # `cli` (rustyline + clap + env_logger — not wasm-safe) and
 # `file-locks` (fs2 — doesn't exist on wasm32-unknown-unknown).
-sqlrite = { path = "../..", default-features = false }
+# `package = "sqlrite-engine"` — crates.io name — with an import alias
+# of `sqlrite` so src/ code can keep saying `use sqlrite::…`.
+sqlrite = { package = "sqlrite-engine", path = "../..", default-features = false }
 
 # wasm-bindgen + friends. `serde-serialize` on wasm-bindgen gives
 # us `serde_wasm_bindgen` interop for structured row objects.

--- a/sqlrite-ffi/Cargo.toml
+++ b/sqlrite-ffi/Cargo.toml
@@ -27,7 +27,11 @@ path = "src/lib.rs"
 [dependencies]
 # The engine we're wrapping. Taken from the workspace root via a path dep so
 # the FFI layer always tracks HEAD — no version-lock drift between the two.
-sqlrite = { path = ".." }
+# `package = "sqlrite-engine"` because the crate is published under that
+# name on crates.io (the `sqlrite` name was taken by another project); the
+# `sqlrite = …` key keeps the import alias as `sqlrite` so `use sqlrite::…`
+# in src/ still resolves.
+sqlrite = { package = "sqlrite-engine", path = ".." }
 
 # Build-time C header generation. `cbindgen` walks this crate's extern "C"
 # declarations and emits `sqlrite.h`. We invoke it from build.rs so callers


### PR DESCRIPTION
## Why

The v0.1.1 canary release failed at `cargo publish` with a 403:

> error: failed to publish sqlrite v0.1.1 to registry at https://crates.io.
> Caused by: the remote server responded with an error (status 403 Forbidden): this crate exists but you don't seem to be an owner.

The `sqlrite` name on crates.io was already taken by an unrelated project (RAG-oriented SQLite wrapper). `sqlrite-engine` is available, so this PR renames the published package and paves the way for a v0.1.2 canary retry.

## What changes

- Root `Cargo.toml`: `[package] name = "sqlrite-engine"`. The `[lib] name = "sqlrite"` and `[[bin]] name = "sqlrite"` are **unchanged** — downstream code still writes `use sqlrite::…` and the REPL is still `sqlrite`.
- All workspace-member engine deps use the `package =` key so the import alias stays `sqlrite`:
  ```toml
  sqlrite = { package = "sqlrite-engine", path = "…" }
  ```
  This touches `sqlrite-ffi`, `sdk/python`, `sdk/nodejs`, `sdk/wasm`, `desktop/src-tauri`.
- `release.yml`: `cargo publish -p sqlrite-engine`, updated crates.io URL + TOML snippet in the per-release body, plus umbrella release body's crates.io link.
- Docs: `release-plan.md`, `roadmap.md`, `embedding.md` updated with the new crate name + the reason for the rename.

## What doesn't change

- Published **tag** names (`sqlrite-vX.Y.Z`) — they reference the product, not the crate name.
- Rust source code — zero `.rs` files touched.
- PyPI / npm / Go module names (those are independent registries, no conflicts).

## Tags from the failed v0.1.1 canary

`sqlrite-v0.1.1`, `sqlrite-ffi-v0.1.1`, `v0.1.1` already exist on main (the tag-all step ran before publish-crate failed). Per the never-reuse-a-tag policy, they stay; the retry canary bumps to **v0.1.2**.

## Test plan

- [x] `cargo check --workspace --exclude sqlrite-python --exclude sqlrite-nodejs` — clean
- [x] `cargo check -p sqlrite-python -p sqlrite-nodejs` — clean
- [x] `cargo check` inside `sdk/wasm/` — clean (unrelated unused-mut warnings pre-exist)
- [x] `cargo test -p sqlrite-engine --lib` — 162 passed
- [ ] CI runs on this branch
- [ ] After merge: dispatch `release-pr.yml` at `0.1.2` → review Release PR → merge → approve `release` env → watch `sqlrite-engine 0.1.1` — **wait, 0.1.2** — appear on crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)