### PR TITLE
release.yml: accept GitHub squash-merge (#N) suffix in detect regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,12 @@ jobs:
             exit 0
           fi
 
-          MSG=$(git log -1 --pretty=%s)
+          # GitHub's default squash-merge title is `<PR title> (#N)` —
+          # e.g. `release: v0.1.2 (#18)`. Strip the trailing ` (#N)` so
+          # the regex matches both the squash-merge form and the
+          # stripped-title form (we still recommend editing to the
+          # latter, but should-just-work beats should-remember).
+          MSG=$(git log -1 --pretty=%s | sed -E 's/ \(#[0-9]+\)$//')
           if [[ "$MSG" =~ ^release:\ v([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)$ ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

GitHub's default squash-merge title is `<PR title> (#N)`. So when a Release PR titled `release: v0.1.2` gets squash-merged, the commit on main is `release: v0.1.2 (#18)`. The old anchored regex (`$` at the end) rejected that, and the workflow silently no-op'd.

That just happened on the v0.1.2 canary — had to kick `release.yml` via `workflow_dispatch` as a manual workaround. This fixes it so future canaries detect + publish automatically.

## What changes

- `.github/workflows/release.yml`: strip trailing ` (#N)` from the commit subject before the regex test.

Editing the squash-merge title to drop the suffix still works; it just isn't required anymore.

## Test plan

- [x] Verified against both forms locally:
  ```
  echo 'release: v0.1.2' | sed -E 's/ \(#[0-9]+\)$//' # → 'release: v0.1.2'
  echo 'release: v0.1.2 (#18)' | sed -E 's/ \(#[0-9]+\)$//' # → 'release: v0.1.2'
  ```
- [ ] CI passes on this PR
- [ ] Next canary (v0.1.3+) merges cleanly with no manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)