### PR TITLE
release.yml: restore --provenance flag + add OIDC diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -821,32 +821,61 @@ jobs:
           name: nodejs-dispatcher
           path: sdk/nodejs
 
-      - name: List publish payload
+      - name: List publish payload + OIDC env diagnostics
         working-directory: sdk/nodejs
         run: |
           ls -la
           echo "---"
           npm --version
           echo "---"
+          # Confirm the OIDC env vars GitHub Actions auto-sets when
+          # `permissions: id-token: write` is granted. If either of
+          # these is empty, OIDC token exchange CAN'T happen and
+          # npm publish will fall back to "no auth available".
+          # Just print whether they're set, not their values
+          # (the URL has a trailing token-issuance path; treat as
+          # sensitive).
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL  is set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}${ACTIONS_ID_TOKEN_REQUEST_URL:-NO}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN is set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-NO}"
+          echo "---"
           # Dry-run the pack to see exactly what ends up in the
           # published tarball. A missing .node file or a stray
           # devDep pulled in by accident would be visible here.
           npm pack --dry-run
 
-      # Single atomic publish via OIDC trusted publisher. No
-      # `--provenance` flag and no env block — npm 11.5+ adds
-      # provenance automatically when the publish runs over OIDC,
-      # and an explicit `--provenance` flag combined with no
-      # auth token would actually error out under the older
-      # token-auth pathway.
+      # Single atomic publish via OIDC trusted publisher.
+      #
+      # The `--provenance` flag is what tells npm CLI to use the
+      # OIDC code path. Without it, npm only checks for `_authToken`
+      # config and gives up with ENEEDAUTH (this happened on the
+      # v0.1.6 canary attempt that ran without the flag — npm
+      # never even tried OIDC). With it, npm:
+      #   1. Reads ACTIONS_ID_TOKEN_REQUEST_URL +
+      #      ACTIONS_ID_TOKEN_REQUEST_TOKEN from the GHA env
+      #   2. Mints an OIDC token bearing the workflow's identity
+      #      claims (repo, environment, workflow filename, etc.)
+      #   3. Exchanges it at npm for a one-time publish token
+      #   4. Publishes the package + attaches a sigstore-signed
+      #      provenance attestation linking the artifact to this
+      #      exact workflow run
+      #
+      # The previous v0.1.5 failure with `--provenance` set was a
+      # different bug — `registry-url` on setup-node was generating
+      # an `.npmrc` that forced token-auth and bypassed OIDC. With
+      # registry-url removed (this file's previous fix) and
+      # `--provenance` restored, both bugs are addressed.
       #
       # `--access public` is REQUIRED because `@joaoh82/sqlrite`
-      # is a scoped package and scoped packages default to
-      # private; without the flag, npm rejects the upload for a
-      # free-tier account that can't host private packages.
+      # is a scoped package and scoped packages default to private;
+      # without the flag, npm rejects the upload for a free-tier
+      # account that can't host private packages.
+      #
+      # `--loglevel verbose` makes auth/transport errors
+      # diagnosable from the run log without re-running with
+      # debug-on. Cheap insurance against another silent failure.
       - name: Publish to npm
         working-directory: sdk/nodejs
-        run: npm publish --access public
+        run: npm publish --access public --provenance --loglevel verbose
 
       - name: GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## What broke (again)

The v0.1.6 canary's publish-nodejs failed with a different error than v0.1.5:

```
npm 11.13.0
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

Progress vs. v0.1.5: npm 11.13 was correctly used (so the `npm install -g npm@latest` step works), and the previous `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` red herring is gone (so dropping `registry-url` worked). But npm CLI **didn't even try OIDC** — it just looked for a configured `_authToken`, found none, and gave up.

## Diagnosis

I had removed the `--provenance` flag in PR #32 based on npm's docs claiming "trusted publishers auto-detect, no flags needed". Empirically, that's wrong — `--provenance` is what tells npm CLI to use the OIDC code path. Without it, npm only checks token-based auth and bails with ENEEDAUTH.

Other npm-OIDC-publishing projects (Prettier, ESLint, …) all use `--provenance` explicitly. I should have copied them, not the docs.

## What changes

| Before (v0.1.6) | After |
|---|---|
| `npm publish --access public` | `npm publish --access public --provenance --loglevel verbose` |
| (no diagnostics) | New step prints whether `ACTIONS_ID_TOKEN_REQUEST_URL` + `ACTIONS_ID_TOKEN_REQUEST_TOKEN` are set |
| Comment claimed `--provenance` was redundant | Comment now captures the *combined* truth: drop `registry-url` AND keep `--provenance` — both required, neither alone works |

`--loglevel verbose` is cheap insurance: if there's a third bug hiding behind this one, the next failure log will have enough detail to diagnose without re-running.

## v0.1.6 wave status

Same partial-state as v0.1.5: 4 of 5 packages shipped, npm one missing. After this PR merges I'll cut **v0.1.7**. The previous failed npm tag (`sqlrite-node-v0.1.6`) and missing umbrella (`v0.1.6`) stay as they are per never-reuse-a-version policy.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — YAML parses
- [ ] CI on this PR
- [ ] After merge: dispatch v0.1.7. Watch for:
  - `ACTIONS_ID_TOKEN_REQUEST_URL is set: yes` in the diagnostics step (confirms GHA injected the OIDC env)
  - npm publish succeeds → `@joaoh82/sqlrite@0.1.7` on npm
  - `npm view @joaoh82/sqlrite` shows the new version
  - `npm audit signatures` passes against the sigstore attestation

If publish-nodejs fails *again*, the verbose npm log will show exactly what npm tried (token vs OIDC) and where it failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)