### PR TITLE
Phase 6i: add publish-go (completes Phase 6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,9 @@
 # Phase 6f adds build-python-wheels + publish-python.
 # Phase 6g adds build-nodejs-binaries + publish-nodejs.
 # Phase 6h adds publish-wasm.
-# Phase 6i adds publish-go.
+# Phase 6i adds publish-go (no registry — git tag + GitHub Release
+# with the FFI tarballs attached for users who want prebuilt
+# libsqlrite_c alongside `go get`).
 #
 # Design doc: docs/release-plan.md.
 # One-time registry / branch-protection setup: docs/release-secrets.md.
@@ -128,6 +130,7 @@ jobs:
             "sqlrite-py-v$V"
             "sqlrite-node-v$V"
             "sqlrite-wasm-v$V"
+            "sdk/go/v$V"
             "v$V"
           )
           for tag in "${TAGS[@]}"; do
@@ -1075,6 +1078,144 @@ jobs:
           generate_release_notes: true
 
   # ---------------------------------------------------------------------------
+  # Step 3i: publish the Go SDK. (Phase 6i.)
+  #
+  # Go's distribution model is unique among our publish channels:
+  # there's NO central registry. Go modules pull straight from VCS
+  # via tag, and `go get github.com/joaoh82/rust_sqlite/sdk/go@v0.X.Y`
+  # works the moment a `sdk/go/v0.X.Y` tag is on the remote (modulo
+  # ~minutes of cache lag at proxy.golang.org). The tag is created
+  # by `tag-all` upstream of this job — there's nothing to upload.
+  #
+  # **What this job DOES do:** the binding uses cgo against
+  # `libsqlrite_c` (the C FFI from sqlrite-ffi), so end users
+  # need that shared library on their system to run anything.
+  # We pull the per-platform tarballs that publish-ffi already
+  # uploaded to its release and re-attach them to the Go release
+  # page so Go users have a one-stop-shop:
+  #
+  #   `go get github.com/joaoh82/rust_sqlite/sdk/go@vX.Y.Z`
+  #   download `libsqlrite_c-<platform>.tar.gz` from the same
+  #   release page → set CGO_LDFLAGS / CGO_CFLAGS → `go build`.
+  #
+  # **Tag with slashes:** Go's submodule tag convention is
+  # `<subpath>/vX.Y.Z` — for our module path
+  # `github.com/joaoh82/rust_sqlite/sdk/go`, the canonical tag is
+  # `sdk/go/vX.Y.Z` (slashes intact). GitHub Releases handle
+  # slash-bearing tags fine; the URL just URL-encodes them.
+  publish-go:
+    name: Publish Go SDK GitHub Release
+    needs: [detect, tag-all, publish-ffi]
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      # For softprops/action-gh-release + gh CLI release-download.
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full tag history to verify tag-all's `sdk/go/v$V`
+          # is on the remote.
+          fetch-depth: 0
+
+      # Cheap consistency check that tag-all did its job. If this
+      # fires, something's wrong upstream and the human should
+      # know before we cut a confusingly-named GitHub Release.
+      - name: Verify Go module tag exists
+        run: |
+          V="${{ needs.detect.outputs.version }}"
+          TAG="sdk/go/v$V"
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG not found — tag-all should have created + pushed it"
+            exit 1
+          fi
+          echo "Tag $TAG exists at $(git rev-parse --short $TAG)"
+
+      # Pull the tarballs publish-ffi already attached to the
+      # sqlrite-ffi-v<V> release. The `gh release download` flow
+      # avoids re-running the whole publish-ffi build matrix just
+      # to get the artifacts here — it's a single API call with
+      # the workflow's auto-injected GITHUB_TOKEN.
+      - name: Download FFI tarballs from this release wave
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          V="${{ needs.detect.outputs.version }}"
+          mkdir -p ffi-tarballs
+          gh release download "sqlrite-ffi-v$V" \
+            --repo joaoh82/rust_sqlite \
+            --dir ffi-tarballs \
+            --pattern '*.tar.gz'
+          echo "--- FFI tarballs downloaded ---"
+          ls -la ffi-tarballs/
+
+      # Cut the Go release page. Tag has slashes — softprops handles
+      # that correctly (URL-encodes the slashes in the resulting
+      # release URL).
+      - name: GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: sdk/go/v${{ needs.detect.outputs.version }}
+          name: Go SDK v${{ needs.detect.outputs.version }}
+          body: |
+            ```bash
+            go get github.com/joaoh82/rust_sqlite/sdk/go@v${{ needs.detect.outputs.version }}
+            ```
+
+            ```go
+            package main
+
+            import (
+                "database/sql"
+                "fmt"
+
+                _ "github.com/joaoh82/rust_sqlite/sdk/go"  // registers "sqlrite" driver
+            )
+
+            func main() {
+                db, _ := sql.Open("sqlrite", ":memory:")
+                defer db.Close()
+
+                _, _ = db.Exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+                _, _ = db.Exec("INSERT INTO users (name) VALUES ('alice')")
+
+                rows, _ := db.Query("SELECT id, name FROM users")
+                defer rows.Close()
+                for rows.Next() {
+                    var id int64
+                    var name string
+                    rows.Scan(&id, &name)
+                    fmt.Printf("%d: %s\n", id, name)
+                }
+            }
+            ```
+
+            ## Prebuilt `libsqlrite_c` (cgo dependency)
+
+            The Go binding uses cgo against the `libsqlrite_c` shared library shipped by [`sqlrite-ffi`](https://github.com/joaoh82/rust_sqlite/tree/main/sqlrite-ffi). The tarballs attached below are the same ones from this release wave's [C FFI release](../../releases/tag/sqlrite-ffi-v${{ needs.detect.outputs.version }}) — provided here so Go users have a one-stop-shop:
+
+            - `sqlrite-ffi-v${{ needs.detect.outputs.version }}-linux-x86_64.tar.gz`
+            - `sqlrite-ffi-v${{ needs.detect.outputs.version }}-linux-aarch64.tar.gz`
+            - `sqlrite-ffi-v${{ needs.detect.outputs.version }}-macos-aarch64.tar.gz`
+            - `sqlrite-ffi-v${{ needs.detect.outputs.version }}-windows-x86_64.tar.gz`
+
+            Extract for your platform, then point cgo at it:
+
+            ```bash
+            tar xzf sqlrite-ffi-v${{ needs.detect.outputs.version }}-<platform>.tar.gz
+            export CGO_CFLAGS="-I$(pwd)/sqlrite-ffi-v${{ needs.detect.outputs.version }}-<platform>/include"
+            export CGO_LDFLAGS="-L$(pwd)/sqlrite-ffi-v${{ needs.detect.outputs.version }}-<platform>/lib -lsqlrite_c"
+            export LD_LIBRARY_PATH="$(pwd)/sqlrite-ffi-v${{ needs.detect.outputs.version }}-<platform>/lib"
+            go build ./...
+            ```
+
+            (On macOS use `DYLD_LIBRARY_PATH` instead of `LD_LIBRARY_PATH`. On Windows, place the `.dll` next to your binary or on `%PATH%`.)
+
+            See the umbrella release [v${{ needs.detect.outputs.version }}](../../releases/tag/v${{ needs.detect.outputs.version }}) for the full changelog.
+          files: ffi-tarballs/*.tar.gz
+          generate_release_notes: true
+
+  # ---------------------------------------------------------------------------
   # Step 4: create the umbrella GitHub Release. Runs after all
   # publish-* jobs succeed. Uses GitHub's native auto-generated
   # release notes so the changelog is "everything between the
@@ -1082,7 +1223,7 @@ jobs:
   # config if we add one later.
   finalize:
     name: Finalize umbrella release
-    needs: [detect, publish-crate, publish-ffi, publish-desktop, publish-python, publish-nodejs, publish-wasm]
+    needs: [detect, publish-crate, publish-ffi, publish-desktop, publish-python, publish-nodejs, publish-wasm, publish-go]
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -1106,8 +1247,7 @@ jobs:
             - 🐍 [Python](../../releases/tag/sqlrite-py-v${{ needs.detect.outputs.version }}) → [PyPI](https://pypi.org/project/sqlrite/${{ needs.detect.outputs.version }}/) — abi3-py38 wheels for Linux x86_64/aarch64, macOS aarch64, Windows x86_64 + sdist
             - 🟢 [Node.js](../../releases/tag/sqlrite-node-v${{ needs.detect.outputs.version }}) → [npm](https://www.npmjs.com/package/@joaoh82/sqlrite/v/${{ needs.detect.outputs.version }}) — N-API bindings with prebuilt `.node` binaries for Linux x86_64/aarch64, macOS aarch64, Windows x86_64
             - 🌐 [WASM](../../releases/tag/sqlrite-wasm-v${{ needs.detect.outputs.version }}) → [npm](https://www.npmjs.com/package/@joaoh82/sqlrite-wasm/v/${{ needs.detect.outputs.version }}) — browser/bundler-target WebAssembly build via wasm-pack
-
-            _Go SDK lands as its publish job comes online (Phase 6i)._
+            - 🐹 [Go SDK](../../releases/tag/sdk%2Fgo%2Fv${{ needs.detect.outputs.version }}) → `go get github.com/joaoh82/rust_sqlite/sdk/go@v${{ needs.detect.outputs.version }}` — `database/sql` driver via cgo against `libsqlrite_c`
 
             ---
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Lockstep versioning — one dispatch bumps every product to the same `vX.Y.Z`. T
 - [ ] **6f — Python SDK publish**: `maturin-action` → abi3 wheels for manylinux x86_64/aarch64 + macOS universal + Windows x86_64 → PyPI via OIDC
 - [ ] **6g — Node.js SDK publish**: `@napi-rs/cli` → `.node` binaries per platform → npm via OIDC
 - [x] **6h — WASM publish**: `wasm-pack build --target bundler --scope joaoh82` + `npm publish --provenance` (OIDC) → `@joaoh82/sqlrite-wasm` on npm. Single job, no matrix (WebAssembly is universal). `.wasm` also attached to the `sqlrite-wasm-v<V>` GitHub Release.
-- [ ] **6i — Go SDK publish**: `sdk/go/vX.Y.Z` git tag + attach FFI tarballs to the Go GitHub Release for `go get` users who want prebuilt `libsqlrite_c`
+- [x] **6i — Go SDK publish**: `sdk/go/vX.Y.Z` git tag (Go modules pull straight from VCS, no registry); GitHub Release at that tag with the FFI tarballs from `publish-ffi` re-attached so Go users have a one-stop-shop. `go get github.com/joaoh82/rust_sqlite/sdk/go@vX.Y.Z` works as soon as the tag is pushed.
 
 **Phase 6.1 — Code signing** *(follow-up)*
 - [ ] macOS Apple Developer ID cert → `codesign` + `notarytool` in `tauri-action`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -441,9 +441,19 @@ The `.wasm` binary is also attached to the `sqlrite-wasm-vX.Y.Z` GitHub Release 
 
 `docs/release-secrets.md` §3 now covers both scoped npm packages with the bootstrap-then-add-trusted-publisher flow we settled on after the v0.1.5–v0.1.7 publish-nodejs debugging cycle.
 
-### Phase 6i — Go SDK publish
+### ✅ Phase 6i — Go SDK publish
 
-Adds `publish-go` job. No registry — tags `sdk/go/vX.Y.Z`; attaches the FFI tarballs (from `publish-ffi`) to the Go GitHub Release for users who want prebuilt `libsqlrite_c`.
+Adds `publish-go` job. **No registry to publish to** — Go modules pull straight from VCS via tag (`go get …@vX.Y.Z` resolves the moment the tag is on GitHub, modulo proxy.golang.org cache lag). The job's actual work:
+
+1. Verifies `tag-all` pushed `sdk/go/v<V>` (the slash-bearing submodule tag Go modules require for the path `github.com/joaoh82/rust_sqlite/sdk/go`).
+2. Downloads the per-platform `libsqlrite_c-*.tar.gz` tarballs that `publish-ffi` already uploaded to its release.
+3. Re-attaches them to a fresh Go GitHub Release at the `sdk/go/v<V>` tag, so Go users have one page with both the `go get` instructions AND the cgo dependency tarballs.
+
+The release body documents the cgo wiring (`CGO_CFLAGS` / `CGO_LDFLAGS` / `LD_LIBRARY_PATH` per platform).
+
+**Why this can't fail in interesting ways:** no registry auth, no OIDC, no cross-platform build matrix, no npm-similarity-check theater. Just a tag check + a file download + a release create. The big hidden cost was getting the *upstream* (publish-ffi) right months earlier; this job is mostly orchestration on top.
+
+With 6i done, **Phase 6 is complete** — every product distribution channel ships on every release with one human action (Release PR review + merge).
 
 ### Phase 6.1 — Code signing *(follow-up)*
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -24,7 +24,7 @@ cargo build --release -p sqlrite-ffi   # produces target/release/libsqlrite_c.{s
 go get github.com/joaoh82/rust_sqlite/sdk/go
 ```
 
-Phase 6e will publish prebuilt `libsqlrite_c` binaries as GitHub Release assets so end users consuming the Go module don't need the Rust toolchain.
+Phase 6i ships prebuilt `libsqlrite_c` tarballs as GitHub Release assets on every release, so end users consuming the Go module don't need the Rust toolchain. Each release at `sdk/go/v<V>` includes per-platform tarballs (Linux x86_64/aarch64, macOS aarch64, Windows x86_64) you can extract and point cgo at via `CGO_CFLAGS` / `CGO_LDFLAGS`.
 
 ## Quick tour
 


### PR DESCRIPTION
## Summary

The simplest job in the publish family — Go has no central registry, so this is just orchestration on top of `tag-all` + `publish-ffi`.

| Job | Cells | Role |
|---|---|---|
| `publish-go` | 1 (single ubuntu-latest) | Verify `sdk/go/v<V>` tag exists; download FFI tarballs from `sqlrite-ffi-v<V>` release; create Go GitHub Release with the tarballs re-attached + cgo wiring docs |

## Why it's so small

Go modules pull straight from VCS. The moment `tag-all` pushes `sdk/go/v0.1.X`, `go get github.com/joaoh82/rust_sqlite/sdk/go@v0.1.X` works (modulo proxy.golang.org cache lag). There's no `cargo publish` / `npm publish` / `pip upload` equivalent — the tag IS the publish event.

What `publish-go` adds on top of that:
1. **Sanity check** that `tag-all` did its job (cheap; fails loudly if upstream broke).
2. **One-stop-shop GitHub Release** — re-attaches the FFI tarballs from `publish-ffi`'s release so Go users get the cgo dependency on the same page as the `go get` instructions.
3. **Cgo wiring docs** in the release body (`CGO_CFLAGS`, `CGO_LDFLAGS`, per-platform library path).

## Tag-with-slashes

Go submodule tag convention requires `<subpath>/vX.Y.Z` for module paths with subpaths. Our path is `github.com/joaoh82/rust_sqlite/sdk/go`, so the canonical tag is `sdk/go/v<V>` with slashes intact. `softprops/action-gh-release` handles this fine; the umbrella release body uses URL-encoded `sdk%2Fgo%2Fv<V>` for the link.

## Wiring

- `tag-all` → adds `sdk/go/v<V>` to TAGS array
- `finalize.needs` → extended with `publish-go`
- Umbrella release body → 🐹 Go SDK entry

## Test plan

- [x] YAML parses
- [x] Cargo files unchanged (Go is its own world)
- [ ] CI on this PR
- [ ] After merge: dispatch v0.1.9 canary. publish-go has no auth complexity (no registry, no OIDC, no tokens) — only failure modes are (a) tag-all upstream broke or (b) the sqlrite-ffi-v<V> release doesn't have the expected tarballs. Both surface clearly in the verify-tag-exists or gh-release-download steps.
- [ ] After v0.1.9 lands: try `go get github.com/joaoh82/rust_sqlite/sdk/go@v0.1.9` from a fresh module to verify the proxy.golang.org caching works as expected.

## What this completes

**Phase 6 done end-to-end.** Every product distribution channel ships on every release with one human action (Release PR review + merge):

| Channel | Tag | Where |
|---|---|---|
| 🦀 Rust engine | `sqlrite-v<V>` | crates.io (`sqlrite-engine`) + GitHub Release |
| 🔧 C FFI | `sqlrite-ffi-v<V>` | GitHub Release (4 platform tarballs) |
| 🖥️ Desktop | `sqlrite-desktop-v<V>` | GitHub Release (7 installer formats) |
| 🐍 Python | `sqlrite-py-v<V>` | PyPI (`sqlrite`) + GitHub Release |
| 🟢 Node.js | `sqlrite-node-v<V>` | npm (`@joaoh82/sqlrite`) + GitHub Release |
| 🌐 WASM | `sqlrite-wasm-v<V>` | npm (`@joaoh82/sqlrite-wasm`) + GitHub Release |
| 🐹 Go | `sdk/go/v<V>` | GitHub Release (with FFI tarballs) — proxy.golang.org pulls direct from tag |
| umbrella | `v<V>` | GitHub Release (auto-generated changelog) |

Phase 7 (AI-era extensions) is next, on a fresh branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)