### PR TITLE
Phase 7a: VECTOR(N) column type (storage only)

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -234,11 +234,17 @@ fn extract_last_select(sql: &str, db: &Database) -> Option<CommandResult> {
 }
 
 fn display_value(v: &Value) -> String {
+    // Phase 7a: Vector values aren't auto-handled by this match — defer
+    // to Value::to_display_string for the canonical bracket-array format,
+    // which keeps the Vector arm in one place (table.rs's
+    // `format_vector_for_display`). All other variants stay inline so the
+    // hot path of integer/text/real/bool display avoids one indirection.
     match v {
         Value::Integer(n) => n.to_string(),
         Value::Text(s) => s.clone(),
         Value::Real(f) => f.to_string(),
         Value::Bool(b) => b.to_string(),
+        Value::Vector(_) => v.to_display_string(),
         Value::Null => "NULL".to_string(),
     }
 }

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -152,8 +152,11 @@ tag       u8
   0x01 Real         f64 little-endian, 8 bytes
   0x02 Text         varint length, UTF-8 bytes
   0x03 Bool         u8 (0 or 1)
+  0x04 Vector       varint dim, then dim × 4 bytes f32 little-endian   (Phase 7a, format v4)
 body      variable (see tag)
 ```
+
+The Vector tag (Phase 7a) carries its own dimension as a leading varint so `decode_value` doesn't need schema context to read it. For the typical embedding sizes (384, 768, 1536) the dim varint is 2-3 bytes; the f32 array dominates payload size (4·dim bytes). Vectors that exceed the local-cell budget spill into the overflow chain via the same machinery as long Text values — no Vector-specific overflow path.
 
 ### Overflow cell body
 
@@ -280,7 +283,8 @@ These are not all enforced on open — we validate the header strictly and rely 
 
 - **v1** (Phases 2 / 3a / 3b) — schema catalog and table data were opaque `bincode` blobs chained across typed payload pages.
 - **v2** (Phases 3c / 3d) — cell-based storage and `sqlrite_master`. Phase 3d added interior pages without a version bump.
-- **v3** (Phase 3e, current) — `sqlrite_master` gains a `type` column; secondary indexes persist as their own cell-based B-Trees whose leaves carry `KIND_INDEX` cells.
+- **v3** (Phase 3e) — `sqlrite_master` gains a `type` column; secondary indexes persist as their own cell-based B-Trees whose leaves carry `KIND_INDEX` cells.
+- **v4** (Phase 7a, current) — value block dispatch gains the `0x04 Vector` tag for the new `VECTOR(N)` column type. Per the [Phase 7 plan's Q8](phase-7-plan.md#q8-file-format-version-bump), later Phase 7 sub-phases (JSON storage, HNSW indexes) will add their own value/cell tags inside this same v4 envelope — no v5 mid-Phase-7. The `CREATE TABLE` SQL stored in `sqlrite_master` carries vector columns as `VECTOR(N)` in the type position; on open, the engine re-parses that SQL and reconstructs `DataType::Vector(N)` from the `Custom` AST node sqlparser produces.
 
 The page header (7 bytes) and chaining mechanism are stable across future phases. Phase 4's WAL introduces a sibling file (`.sqlrite-wal`) rather than changing the main file format.
 

--- a/docs/supported-sql.md
+++ b/docs/supported-sql.md
@@ -34,6 +34,7 @@ CREATE TABLE <name> (<col> <type> [column_constraint]* [, ...]);
 | `TEXT`, `VARCHAR` | Text (String) | UTF-8; no length limit enforced (VARCHAR's `(n)` is parsed and ignored) |
 | `REAL`, `FLOAT`, `DOUBLE`, `DECIMAL` | Real (f64) | Double-precision; `DECIMAL(p,s)` precision/scale parsed and ignored |
 | `BOOLEAN` | Boolean | Stored compactly in the null bitmap's sibling bits; accepts `TRUE` / `FALSE` |
+| `VECTOR(N)` | Vector (Vec\<f32\>, fixed dim N) | **Phase 7a.** Dense f32 array of fixed dimension. `N` is required and must be ≥ 1. Inserted as bracket-array literals `[0.1, 0.2, ...]`. Dimension is enforced at INSERT/UPDATE; mismatched-length values are rejected. Distance functions and ANN indexing land in 7b–7d. |
 
 ### Column constraints
 
@@ -104,6 +105,7 @@ INSERT INTO <name> (col1, col2, ...) VALUES (v1, v2, ...)
 | Text | `'single-quoted'` — doubled single quotes escape: `'it''s'` |
 | Boolean | `TRUE`, `FALSE` (case-insensitive) |
 | NULL | `NULL` (case-insensitive) |
+| Vector | `[0.1, 0.2, 0.3]` — JSON-style bracket-array; integer elements widen to f32 (`[1, 2, 3]` is valid). For `VECTOR(N)` columns; dimension must match the declared `N`. *(Phase 7a)* |
 
 Hex literals, blob literals, and date/time functions are not supported.
 

--- a/sdk/nodejs/src/lib.rs
+++ b/sdk/nodejs/src/lib.rs
@@ -61,6 +61,17 @@ fn value_to_js(env: &Env, v: &Value) -> Result<JsUnknown> {
         Value::Real(f) => Ok(env.create_double(*f)?.into_unknown()),
         Value::Text(s) => Ok(env.create_string(s)?.into_unknown()),
         Value::Bool(b) => Ok(env.get_boolean(*b)?.into_unknown()),
+        // Phase 7a — `VECTOR(N)` columns surface to JS as `Array<number>`.
+        // Widening f32→f64 since JS Number is f64-backed; no precision lost.
+        // Future polish: optionally hand back a Float32Array (typed array)
+        // for memory-efficient transfer of high-dim vectors.
+        Value::Vector(elements) => {
+            let mut arr = env.create_array_with_length(elements.len())?;
+            for (i, x) in elements.iter().enumerate() {
+                arr.set_element(i as u32, env.create_double(*x as f64)?)?;
+            }
+            Ok(arr.into_unknown())
+        }
         Value::Null => Ok(env.get_null()?.into_unknown()),
     }
 }

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -491,6 +491,14 @@ fn value_to_pyobject(py: Python<'_>, v: &Value) -> PyResult<Py<PyAny>> {
             // Bound before erasing the type.
             Ok(b.into_pyobject(py)?.to_owned().into_any().unbind())
         }
+        // Phase 7a — `VECTOR(N)` columns surface to Python as a `list[float]`.
+        // Widening f32→f64 here so Python's float (which is f64-backed)
+        // doesn't lose information; numpy interop / array module are
+        // future polish.
+        Value::Vector(elements) => {
+            let widened: Vec<f64> = elements.iter().map(|x| *x as f64).collect();
+            Ok(widened.into_pyobject(py)?.into_any().unbind())
+        }
         Value::Null => Ok(py.None()),
     }
 }

--- a/sdk/wasm/Cargo.lock
+++ b/sdk/wasm/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-engine"
-version = "0.1.1"
+version = "0.1.9"
 dependencies = [
  "log",
  "prettytable-rs",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-wasm"
-version = "0.1.1"
+version = "0.1.9"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/sdk/wasm/src/lib.rs
+++ b/sdk/wasm/src/lib.rs
@@ -175,6 +175,20 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             .map(serde_json::Value::Number)
             .unwrap_or(serde_json::Value::Null),
         Value::Text(s) => serde_json::Value::String(s.clone()),
+        // Phase 7a — `VECTOR(N)` columns surface to JS as `Array<number>`.
+        // Widening f32→f64 (JS Number is f64-backed; serde_json::Number
+        // requires finite f64). NaN / Inf elements collapse to null
+        // entries — same fallback the Real arm already uses.
+        Value::Vector(elements) => serde_json::Value::Array(
+            elements
+                .iter()
+                .map(|x| {
+                    serde_json::Number::from_f64(*x as f64)
+                        .map(serde_json::Value::Number)
+                        .unwrap_or(serde_json::Value::Null)
+                })
+                .collect(),
+        ),
     }
 }
 

--- a/src/sql/db/table.rs
+++ b/src/sql/db/table.rs
@@ -1129,9 +1129,7 @@ pub fn parse_vector_literal(s: &str) -> Result<Vec<f32>> {
     for (i, part) in inner.split(',').enumerate() {
         let element = part.trim();
         let parsed: f32 = element.parse().map_err(|_| {
-            SQLRiteError::General(format!(
-                "vector element {i} (`{element}`) is not a number"
-            ))
+            SQLRiteError::General(format!("vector element {i} (`{element}`) is not a number"))
         })?;
         out.push(parsed);
     }

--- a/src/sql/db/table.rs
+++ b/src/sql/db/table.rs
@@ -10,39 +10,86 @@ use prettytable::{Cell as PrintCell, Row as PrintRow, Table as PrintTable};
 /// SQLRite data types
 /// Mapped after SQLite Data Type Storage Classes and SQLite Affinity Type
 /// (Datatypes In SQLite Version 3)[https://www.sqlite.org/datatype3.html]
+///
+/// `Vector(dim)` is the Phase 7a addition — a fixed-dimension dense f32
+/// array. The dimension is part of the type so a `VECTOR(384)` column
+/// rejects `[0.1, 0.2, 0.3]` at INSERT time as a clean type error
+/// rather than silently storing the wrong shape.
 #[derive(PartialEq, Debug, Clone)]
 pub enum DataType {
     Integer,
     Text,
     Real,
     Bool,
+    /// Dense f32 vector of fixed dimension. The `usize` is the column's
+    /// declared dimension; every value stored in the column must have
+    /// exactly that many elements.
+    Vector(usize),
     None,
     Invalid,
 }
 
 impl DataType {
+    /// Constructs a `DataType` from the wire string the parser produces.
+    /// Pre-Phase-7 the strings were one-of `"integer" | "text" | "real" |
+    /// "bool" | "none"`. Phase 7a adds `"vector(N)"` (case-insensitive,
+    /// N a positive integer) for the new vector column type — encoded
+    /// in-band so we don't have to plumb a richer type through the
+    /// existing string-based ParsedColumn pipeline.
     pub fn new(cmd: String) -> DataType {
-        match cmd.to_lowercase().as_ref() {
+        let lower = cmd.to_lowercase();
+        match lower.as_str() {
             "integer" => DataType::Integer,
             "text" => DataType::Text,
             "real" => DataType::Real,
             "bool" => DataType::Bool,
             "none" => DataType::None,
+            other if other.starts_with("vector(") && other.ends_with(')') => {
+                // Strip the `vector(` prefix and trailing `)`, parse what's
+                // left as a positive integer dimension. Anything else is
+                // Invalid — surfaces a clean error at CREATE TABLE time.
+                let inside = &other["vector(".len()..other.len() - 1];
+                match inside.trim().parse::<usize>() {
+                    Ok(dim) if dim > 0 => DataType::Vector(dim),
+                    _ => {
+                        eprintln!("Invalid VECTOR dimension in {cmd}");
+                        DataType::Invalid
+                    }
+                }
+            }
             _ => {
                 eprintln!("Invalid data type given {}", cmd);
                 DataType::Invalid
             }
         }
     }
+
+    /// Inverse of `new` — returns the canonical lowercased wire string
+    /// for this DataType. Used by the parser to round-trip
+    /// `VECTOR(N)` → `DataType::Vector(N)` → `"vector(N)"` into
+    /// `ParsedColumn::datatype` so the rest of the pipeline keeps
+    /// working with strings.
+    pub fn to_wire_string(&self) -> String {
+        match self {
+            DataType::Integer => "Integer".to_string(),
+            DataType::Text => "Text".to_string(),
+            DataType::Real => "Real".to_string(),
+            DataType::Bool => "Bool".to_string(),
+            DataType::Vector(dim) => format!("vector({dim})"),
+            DataType::None => "None".to_string(),
+            DataType::Invalid => "Invalid".to_string(),
+        }
+    }
 }
 
 impl fmt::Display for DataType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             DataType::Integer => f.write_str("Integer"),
             DataType::Text => f.write_str("Text"),
             DataType::Real => f.write_str("Real"),
             DataType::Bool => f.write_str("Boolean"),
+            DataType::Vector(dim) => write!(f, "Vector({dim})"),
             DataType::None => f.write_str("None"),
             DataType::Invalid => f.write_str("Invalid"),
         }
@@ -100,11 +147,16 @@ impl Table {
             ));
 
             let dt = DataType::new(col.datatype.to_string());
-            let row_storage = match dt {
+            let row_storage = match &dt {
                 DataType::Integer => Row::Integer(BTreeMap::new()),
                 DataType::Real => Row::Real(BTreeMap::new()),
                 DataType::Text => Row::Text(BTreeMap::new()),
                 DataType::Bool => Row::Bool(BTreeMap::new()),
+                // The dimension is enforced at INSERT time against the
+                // column's declared DataType::Vector(dim). The Row variant
+                // itself doesn't carry the dim — every stored Vec<f32>
+                // already has it via .len().
+                DataType::Vector(_dim) => Row::Vector(BTreeMap::new()),
                 DataType::Invalid | DataType::None => Row::None,
             };
             table_rows
@@ -113,9 +165,11 @@ impl Table {
                 .insert(col.name.to_string(), row_storage);
 
             // Auto-create an index for every UNIQUE / PRIMARY KEY column,
-            // but only for types we know how to index. Real / Bool UNIQUE
-            // columns fall back to the linear scan path in
+            // but only for types we know how to index. Real / Bool / Vector
+            // UNIQUE columns fall back to the linear scan path in
             // validate_unique_constraint — same behavior as before 3e.
+            // (Vector UNIQUE is unusual; the linear-scan path will work
+            // via Value::Vector PartialEq, just at O(N) cost.)
             if (col.is_pk || col.is_unique) && matches!(dt, DataType::Integer | DataType::Text) {
                 let name = SecondaryIndex::auto_name(&table_name, &col.name);
                 match SecondaryIndex::new(
@@ -250,6 +304,9 @@ impl Table {
                         Row::Bool(m) => {
                             m.remove(&rowid);
                         }
+                        Row::Vector(m) => {
+                            m.remove(&rowid);
+                        }
                         Row::None => {}
                     }
                 }
@@ -329,6 +386,14 @@ impl Table {
                     (Row::Bool(_), None) => {
                         return Err(SQLRiteError::Internal(format!(
                             "Bool column '{col_name}' cannot store NULL — corrupt cell?"
+                        )));
+                    }
+                    (Row::Vector(map), Some(Value::Vector(v))) => {
+                        map.insert(rowid, v.clone());
+                    }
+                    (Row::Vector(_), None) => {
+                        return Err(SQLRiteError::Internal(format!(
+                            "Vector column '{col_name}' cannot store NULL — corrupt cell?"
                         )));
                     }
                     (row, v) => {
@@ -446,6 +511,15 @@ impl Table {
                 (Row::Bool(m), Value::Bool(v), _) => {
                     m.insert(rowid, *v);
                 }
+                (Row::Vector(m), Value::Vector(v), DataType::Vector(declared_dim)) => {
+                    if v.len() != *declared_dim {
+                        return Err(SQLRiteError::General(format!(
+                            "Vector dimension mismatch for column '{column}': declared {declared_dim}, got {}",
+                            v.len()
+                        )));
+                    }
+                    m.insert(rowid, v.clone());
+                }
                 // NULL writes: store the sentinel "Null" string for Text; for other
                 // types we leave storage as-is since those BTreeMaps can't hold NULL today.
                 (Row::Text(m), Value::Null, _) => {
@@ -532,6 +606,20 @@ impl Table {
                         "Type mismatch: expected BOOL for column '{name}', got '{val}'"
                     ))
                 })?,
+                DataType::Vector(declared_dim) => {
+                    let parsed_vec = parse_vector_literal(val).map_err(|e| {
+                        SQLRiteError::General(format!(
+                            "Type mismatch: expected VECTOR({declared_dim}) for column '{name}', {e}"
+                        ))
+                    })?;
+                    if parsed_vec.len() != *declared_dim {
+                        return Err(SQLRiteError::General(format!(
+                            "Vector dimension mismatch for column '{name}': declared {declared_dim}, got {}",
+                            parsed_vec.len()
+                        )));
+                    }
+                    Value::Vector(parsed_vec)
+                }
                 DataType::None | DataType::Invalid => {
                     return Err(SQLRiteError::Internal(format!(
                         "column '{name}' has an unsupported datatype"
@@ -687,6 +775,33 @@ impl Table {
                         })?;
                         tree.insert(next_rowid, parsed);
                         Some(Value::Bool(parsed))
+                    }
+                    Row::Vector(tree) => {
+                        // The parser put a bracket-array literal into `val`
+                        // (e.g. "[0.1,0.2,0.3]"). Parse it back here and
+                        // dim-check against the column's declared
+                        // DataType::Vector(N).
+                        let parsed = parse_vector_literal(&val).map_err(|e| {
+                            SQLRiteError::General(format!(
+                                "Type mismatch: expected VECTOR for column '{key}', {e}"
+                            ))
+                        })?;
+                        let declared_dim = match &self.columns[i].datatype {
+                            DataType::Vector(d) => *d,
+                            other => {
+                                return Err(SQLRiteError::Internal(format!(
+                                    "Row::Vector storage on non-Vector column '{key}' (declared as {other})"
+                                )));
+                            }
+                        };
+                        if parsed.len() != declared_dim {
+                            return Err(SQLRiteError::General(format!(
+                                "Vector dimension mismatch for column '{key}': declared {declared_dim}, got {}",
+                                parsed.len()
+                            )));
+                        }
+                        tree.insert(next_rowid, parsed.clone());
+                        Some(Value::Vector(parsed))
                     }
                     Row::None => {
                         return Err(SQLRiteError::Internal(format!(
@@ -864,6 +979,11 @@ pub enum Row {
     Text(BTreeMap<i64, String>),
     Real(BTreeMap<i64, f32>),
     Bool(BTreeMap<i64, bool>),
+    /// Phase 7a: dense f32 vector storage. Each `Vec<f32>` should have
+    /// length matching the column's declared `DataType::Vector(dim)`,
+    /// enforced at INSERT time. The Row variant doesn't carry the dim —
+    /// it lives in the column metadata.
+    Vector(BTreeMap<i64, Vec<f32>>),
     None,
 }
 
@@ -874,6 +994,7 @@ impl Row {
             Row::Real(cd) => cd.values().map(|v| v.to_string()).collect(),
             Row::Text(cd) => cd.values().map(|v| v.to_string()).collect(),
             Row::Bool(cd) => cd.values().map(|v| v.to_string()).collect(),
+            Row::Vector(cd) => cd.values().map(format_vector_for_display).collect(),
             Row::None => panic!("Found None in columns"),
         }
     }
@@ -884,6 +1005,7 @@ impl Row {
             Row::Real(cd) => cd.len(),
             Row::Text(cd) => cd.len(),
             Row::Bool(cd) => cd.len(),
+            Row::Vector(cd) => cd.len(),
             Row::None => panic!("Found None in columns"),
         }
     }
@@ -897,6 +1019,7 @@ impl Row {
             Row::Text(m) => m.keys().copied().collect(),
             Row::Real(m) => m.keys().copied().collect(),
             Row::Bool(m) => m.keys().copied().collect(),
+            Row::Vector(m) => m.keys().copied().collect(),
             Row::None => vec![],
         }
     }
@@ -915,9 +1038,32 @@ impl Row {
             }),
             Row::Real(m) => m.get(&rowid).map(|v| Value::Real(f64::from(*v))),
             Row::Bool(m) => m.get(&rowid).map(|v| Value::Bool(*v)),
+            Row::Vector(m) => m.get(&rowid).map(|v| Value::Vector(v.clone())),
             Row::None => None,
         }
     }
+}
+
+/// Render a vector for human display. Used by both `Row::get_serialized_col_data`
+/// (for the REPL's print-table path) and `Value::to_display_string`.
+///
+/// Format: `[0.1, 0.2, 0.3]` — JSON-like, decimal-minimal via `{}` Display.
+/// For high-dimensional vectors (e.g. 384 elements) this produces a long
+/// line; truncation ellipsis is a future polish (see Phase 7 plan, "What
+/// this proposal does NOT commit to").
+fn format_vector_for_display(v: &Vec<f32>) -> String {
+    let mut s = String::with_capacity(v.len() * 6 + 2);
+    s.push('[');
+    for (i, x) in v.iter().enumerate() {
+        if i > 0 {
+            s.push_str(", ");
+        }
+        // Default f32 Display picks the minimal-roundtrip representation,
+        // so 0.1f32 prints as "0.1" not "0.10000000149011612". Good enough.
+        s.push_str(&x.to_string());
+    }
+    s.push(']');
+    s
 }
 
 /// Runtime value produced by query execution. Separate from the on-disk `Row` enum
@@ -928,6 +1074,11 @@ pub enum Value {
     Text(String),
     Real(f64),
     Bool(bool),
+    /// Phase 7a: dense f32 vector as a runtime value. Carries its own
+    /// dimension implicitly via `Vec::len`; the column it's being
+    /// assigned to has a declared `DataType::Vector(N)` that's checked
+    /// at INSERT/UPDATE time.
+    Vector(Vec<f32>),
     Null,
 }
 
@@ -938,9 +1089,53 @@ impl Value {
             Value::Text(s) => s.clone(),
             Value::Real(f) => f.to_string(),
             Value::Bool(b) => b.to_string(),
+            Value::Vector(v) => format_vector_for_display(v),
             Value::Null => String::from("NULL"),
         }
     }
+}
+
+/// Parse a bracket-array literal like `"[0.1, 0.2, 0.3]"` (or `"[1, 2, 3]"`)
+/// into a `Vec<f32>`. The parser/insert pipeline stores vector literals as
+/// strings in `InsertQuery::rows` (a `Vec<Vec<String>>`); this helper is
+/// the inverse — turn the string back into a typed vector at the boundary
+/// where we actually need element-typed data.
+///
+/// Accepts:
+/// - `[]` → empty vector (caller's dimension check rejects it for VECTOR(N≥1))
+/// - `[0.1, 0.2, 0.3]` → standard float syntax
+/// - `[1, 2, 3]` → integers, coerced to f32 (matches `VALUES (1, 2)` for
+///   `REAL` columns; we widen ints to floats automatically)
+/// - whitespace tolerated everywhere (Python/JSON/pgvector convention)
+///
+/// Rejects with a descriptive message:
+/// - missing `[` / `]`
+/// - non-numeric elements (`['foo', 0.1]`)
+/// - NaN / Inf literals (we accept them via `f32::from_str` but caller can
+///   reject if undesired — for now we let them through; HNSW etc. will
+///   reject NaN at index time)
+pub fn parse_vector_literal(s: &str) -> Result<Vec<f32>> {
+    let trimmed = s.trim();
+    if !trimmed.starts_with('[') || !trimmed.ends_with(']') {
+        return Err(SQLRiteError::General(format!(
+            "expected bracket-array literal `[...]`, got `{s}`"
+        )));
+    }
+    let inner = &trimmed[1..trimmed.len() - 1].trim();
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for (i, part) in inner.split(',').enumerate() {
+        let element = part.trim();
+        let parsed: f32 = element.parse().map_err(|_| {
+            SQLRiteError::General(format!(
+                "vector element {i} (`{element}`) is not a number"
+            ))
+        })?;
+        out.push(parsed);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -955,6 +1150,7 @@ mod tests {
         let text = DataType::Text;
         let real = DataType::Real;
         let boolean = DataType::Bool;
+        let vector = DataType::Vector(384);
         let none = DataType::None;
         let invalid = DataType::Invalid;
 
@@ -962,8 +1158,115 @@ mod tests {
         assert_eq!(format!("{}", text), "Text");
         assert_eq!(format!("{}", real), "Real");
         assert_eq!(format!("{}", boolean), "Boolean");
+        assert_eq!(format!("{}", vector), "Vector(384)");
         assert_eq!(format!("{}", none), "None");
         assert_eq!(format!("{}", invalid), "Invalid");
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 7a — VECTOR(N) column type
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn datatype_new_parses_vector_dim() {
+        // Standard cases.
+        assert_eq!(DataType::new("vector(1)".to_string()), DataType::Vector(1));
+        assert_eq!(
+            DataType::new("vector(384)".to_string()),
+            DataType::Vector(384)
+        );
+        assert_eq!(
+            DataType::new("vector(1536)".to_string()),
+            DataType::Vector(1536)
+        );
+
+        // Case-insensitive on the keyword.
+        assert_eq!(
+            DataType::new("VECTOR(384)".to_string()),
+            DataType::Vector(384)
+        );
+
+        // Whitespace inside parens tolerated (the create-parser strips it
+        // but the string-based round-trip in DataType::new is the one place
+        // we don't fully control input formatting).
+        assert_eq!(
+            DataType::new("vector( 64 )".to_string()),
+            DataType::Vector(64)
+        );
+    }
+
+    #[test]
+    fn datatype_new_rejects_bad_vector_strings() {
+        // dim = 0 is rejected (Q2: VECTOR(N≥1)).
+        assert_eq!(DataType::new("vector(0)".to_string()), DataType::Invalid);
+        // Non-numeric dim.
+        assert_eq!(DataType::new("vector(abc)".to_string()), DataType::Invalid);
+        // Empty parens.
+        assert_eq!(DataType::new("vector()".to_string()), DataType::Invalid);
+        // Negative dim wouldn't even parse as usize, so falls into Invalid.
+        assert_eq!(DataType::new("vector(-3)".to_string()), DataType::Invalid);
+    }
+
+    #[test]
+    fn datatype_to_wire_string_round_trips_vector() {
+        let dt = DataType::Vector(384);
+        let wire = dt.to_wire_string();
+        assert_eq!(wire, "vector(384)");
+        // And feeds back through DataType::new losslessly — this is the
+        // round-trip the ParsedColumn pipeline relies on.
+        assert_eq!(DataType::new(wire), DataType::Vector(384));
+    }
+
+    #[test]
+    fn parse_vector_literal_accepts_floats() {
+        let v = parse_vector_literal("[0.1, 0.2, 0.3]").expect("parse");
+        assert_eq!(v, vec![0.1f32, 0.2, 0.3]);
+    }
+
+    #[test]
+    fn parse_vector_literal_accepts_ints_widening_to_f32() {
+        let v = parse_vector_literal("[1, 2, 3]").expect("parse");
+        assert_eq!(v, vec![1.0f32, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn parse_vector_literal_handles_negatives_and_whitespace() {
+        let v = parse_vector_literal("[ -1.5 ,  2.0,  -3.5 ]").expect("parse");
+        assert_eq!(v, vec![-1.5f32, 2.0, -3.5]);
+    }
+
+    #[test]
+    fn parse_vector_literal_empty_brackets_is_empty_vec() {
+        let v = parse_vector_literal("[]").expect("parse");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn parse_vector_literal_rejects_non_bracketed() {
+        assert!(parse_vector_literal("0.1, 0.2").is_err());
+        assert!(parse_vector_literal("(0.1, 0.2)").is_err());
+        assert!(parse_vector_literal("[0.1, 0.2").is_err()); // missing ]
+        assert!(parse_vector_literal("0.1, 0.2]").is_err()); // missing [
+    }
+
+    #[test]
+    fn parse_vector_literal_rejects_non_numeric_elements() {
+        let err = parse_vector_literal("[1.0, 'foo', 3.0]").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("vector element 1") && msg.contains("'foo'"),
+            "error message should pinpoint the bad element: got `{msg}`"
+        );
+    }
+
+    #[test]
+    fn value_vector_display_format() {
+        let v = Value::Vector(vec![0.1, 0.2, 0.3]);
+        assert_eq!(v.to_display_string(), "[0.1, 0.2, 0.3]");
+
+        // Empty vector displays as `[]`.
+        let empty = Value::Vector(vec![]);
+        assert_eq!(empty.to_display_string(), "[]");
     }
 
     #[test]

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -390,6 +390,7 @@ fn clone_datatype(dt: &DataType) -> DataType {
         DataType::Text => DataType::Text,
         DataType::Real => DataType::Real,
         DataType::Bool => DataType::Bool,
+        DataType::Vector(dim) => DataType::Vector(*dim),
         DataType::None => DataType::None,
         DataType::Invalid => DataType::Invalid,
     }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -272,6 +272,7 @@ pub fn process_command(query: &str, db: &mut Database) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sql::db::table::Value;
 
     /// Builds a `users(id INTEGER PK, name TEXT, age INTEGER)` table populated
     /// with three rows, for use in executor-level tests.
@@ -1110,5 +1111,165 @@ mod tests {
         let mut wal = path.as_os_str().to_owned();
         wal.push("-wal");
         let _ = std::fs::remove_file(std::path::PathBuf::from(wal));
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 7a — VECTOR(N) end-to-end through process_command
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn vector_create_table_and_insert_basic() {
+        let mut db = Database::new("tempdb".to_string());
+        process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, embedding VECTOR(3));",
+            &mut db,
+        )
+        .expect("create table with VECTOR(3)");
+        process_command(
+            "INSERT INTO docs (embedding) VALUES ([0.1, 0.2, 0.3]);",
+            &mut db,
+        )
+        .expect("insert vector");
+
+        // process_command returns a status string; the rendered table
+        // goes to stdout via print_table. Verify state by inspecting
+        // the database directly.
+        let sel = process_command("SELECT * FROM docs;", &mut db).expect("select");
+        assert!(sel.contains("1 row returned"));
+
+        let docs = db.get_table("docs".to_string()).expect("docs table");
+        let rowids = docs.rowids();
+        assert_eq!(rowids.len(), 1);
+        match docs.get_value("embedding", rowids[0]) {
+            Some(Value::Vector(v)) => assert_eq!(v, vec![0.1f32, 0.2, 0.3]),
+            other => panic!("expected Value::Vector(...), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vector_dim_mismatch_at_insert_is_clean_error() {
+        let mut db = Database::new("tempdb".to_string());
+        process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, embedding VECTOR(3));",
+            &mut db,
+        )
+        .expect("create table");
+
+        // Too few elements.
+        let err = process_command(
+            "INSERT INTO docs (embedding) VALUES ([0.1, 0.2]);",
+            &mut db,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("dimension")
+                && msg.contains("declared 3")
+                && msg.contains("got 2"),
+            "expected clear dim-mismatch error, got: {msg}"
+        );
+
+        // Too many elements.
+        let err = process_command(
+            "INSERT INTO docs (embedding) VALUES ([0.1, 0.2, 0.3, 0.4, 0.5]);",
+            &mut db,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("got 5"),
+            "expected dim-mismatch error mentioning got 5, got: {err}"
+        );
+    }
+
+    #[test]
+    fn vector_create_table_rejects_missing_dim() {
+        let mut db = Database::new("tempdb".to_string());
+        // `VECTOR` (no parens) currently parses as `DataType::Custom` with
+        // empty args from sqlparser, OR may not parse as Custom at all
+        // depending on dialect. Either way, the column shouldn't end up
+        // as a usable Vector type. Accept any error here — the precise
+        // message is parser-version-dependent.
+        let result = process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, embedding VECTOR);",
+            &mut db,
+        );
+        assert!(
+            result.is_err(),
+            "expected CREATE TABLE with bare VECTOR to fail (no dim)"
+        );
+    }
+
+    #[test]
+    fn vector_create_table_rejects_zero_dim() {
+        let mut db = Database::new("tempdb".to_string());
+        let err = process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, embedding VECTOR(0));",
+            &mut db,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("vector"),
+            "expected VECTOR-related error for VECTOR(0), got: {msg}"
+        );
+    }
+
+    #[test]
+    fn vector_high_dim_works() {
+        // 384-dim vector (OpenAI text-embedding-3-small size). Mostly a
+        // smoke test — if cell encoding mishandles the size, this fails.
+        let mut db = Database::new("tempdb".to_string());
+        process_command(
+            "CREATE TABLE embeddings (id INTEGER PRIMARY KEY, e VECTOR(384));",
+            &mut db,
+        )
+        .expect("create table VECTOR(384)");
+
+        let lit = format!(
+            "[{}]",
+            (0..384)
+                .map(|i| format!("{}", i as f32 * 0.001))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let sql = format!("INSERT INTO embeddings (e) VALUES ({lit});");
+        process_command(&sql, &mut db).expect("insert 384-dim vector");
+
+        let sel = process_command("SELECT id FROM embeddings;", &mut db).expect("select id");
+        assert!(sel.contains("1 row returned"));
+    }
+
+    #[test]
+    fn vector_multiple_rows() {
+        // Three rows with different vectors — exercises the Row::Vector
+        // BTreeMap path (not just single-row insertion).
+        let mut db = Database::new("tempdb".to_string());
+        process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, e VECTOR(2));",
+            &mut db,
+        )
+        .expect("create");
+        for i in 0..3 {
+            let sql = format!("INSERT INTO docs (e) VALUES ([{i}.0, {}.0]);", i + 1);
+            process_command(&sql, &mut db).expect("insert");
+        }
+        let sel = process_command("SELECT * FROM docs;", &mut db).expect("select");
+        assert!(sel.contains("3 rows returned"));
+
+        // Verify each vector round-tripped correctly via direct DB inspection.
+        let docs = db.get_table("docs".to_string()).expect("docs table");
+        let rowids = docs.rowids();
+        assert_eq!(rowids.len(), 3);
+        let mut vectors: Vec<Vec<f32>> = rowids
+            .iter()
+            .filter_map(|r| match docs.get_value("e", *r) {
+                Some(Value::Vector(v)) => Some(v),
+                _ => None,
+            })
+            .collect();
+        vectors.sort_by(|a, b| a[0].partial_cmp(&b[0]).unwrap());
+        assert_eq!(vectors[0], vec![0.0f32, 1.0]);
+        assert_eq!(vectors[1], vec![1.0f32, 2.0]);
+        assert_eq!(vectors[2], vec![2.0f32, 3.0]);
     }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1156,11 +1156,8 @@ mod tests {
         .expect("create table");
 
         // Too few elements.
-        let err = process_command(
-            "INSERT INTO docs (embedding) VALUES ([0.1, 0.2]);",
-            &mut db,
-        )
-        .unwrap_err();
+        let err = process_command("INSERT INTO docs (embedding) VALUES ([0.1, 0.2]);", &mut db)
+            .unwrap_err();
         let msg = format!("{err}");
         assert!(
             msg.to_lowercase().contains("dimension")

--- a/src/sql/pager/cell.rs
+++ b/src/sql/pager/cell.rs
@@ -64,6 +64,11 @@ pub mod tag {
     pub const REAL: u8 = 1;
     pub const TEXT: u8 = 2;
     pub const BOOL: u8 = 3;
+    /// Phase 7a — dense f32 vector. Layout after the tag byte:
+    /// `dim (varint) | dim × 4 bytes f32 little-endian`.
+    /// dim is self-describing (varint) so `decode_value` can read the
+    /// payload without consulting schema metadata.
+    pub const VECTOR: u8 = 4;
 }
 
 /// A decoded cell: one row's worth of values plus its rowid.
@@ -254,6 +259,15 @@ pub(super) fn encode_value(out: &mut Vec<u8>, value: &Value) -> Result<()> {
             out.push(tag::BOOL);
             out.push(if *b { 1 } else { 0 });
         }
+        Value::Vector(v) => {
+            out.push(tag::VECTOR);
+            // dim as varint so the decoder doesn't need schema context.
+            varint::write_u64(out, v.len() as u64);
+            // Each f32 as 4 little-endian bytes; total payload = 4·dim.
+            for x in v {
+                out.extend_from_slice(&x.to_le_bytes());
+            }
+        }
         Value::Null => {
             return Err(SQLRiteError::Internal(
                 "Null values are encoded via the null bitmap, not a value block".to_string(),
@@ -300,6 +314,27 @@ pub(super) fn decode_value(buf: &[u8], pos: usize) -> Result<(Value, usize)> {
                 .get(body_start)
                 .ok_or_else(|| SQLRiteError::Internal("Bool value truncated".to_string()))?;
             Ok((Value::Bool(byte != 0), 1 + 1))
+        }
+        tag::VECTOR => {
+            // Layout: tag (1 byte, already consumed) | dim (varint)
+            //       | dim × 4 bytes f32 LE.
+            let (dim, n) = varint::read_u64(buf, body_start)?;
+            let dim = dim as usize;
+            let elements_start = body_start + n;
+            let elements_end = elements_start + dim * 4;
+            if elements_end > buf.len() {
+                return Err(SQLRiteError::Internal(format!(
+                    "Vector value truncated: needs {dim} × 4 = {} bytes",
+                    dim * 4
+                )));
+            }
+            let mut out = Vec::with_capacity(dim);
+            for i in 0..dim {
+                let off = elements_start + i * 4;
+                let arr: [u8; 4] = buf[off..off + 4].try_into().unwrap();
+                out.push(f32::from_le_bytes(arr));
+            }
+            Ok((Value::Vector(out), 1 + n + dim * 4))
         }
         other => Err(SQLRiteError::Internal(format!(
             "unknown value tag {other:#x} at offset {pos}"
@@ -412,6 +447,95 @@ mod tests {
             f64::NEG_INFINITY,
         ] {
             round_trip(&Cell::new(1, vec![Some(Value::Real(v))]));
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 7a — VECTOR(N) cell encoding round-trips
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn vector_round_trip_small() {
+        // 3-dim vector — the canonical "first test that exercises the
+        // wire format" shape. Covers the tag::VECTOR dispatch + varint
+        // dim + dim×4 little-endian f32 layout.
+        let v = vec![0.1f32, 0.2, 0.3];
+        round_trip(&Cell::new(1, vec![Some(Value::Vector(v))]));
+    }
+
+    #[test]
+    fn vector_round_trip_high_dim() {
+        // 384 elements — OpenAI's text-embedding-3-small dimension. Bigger
+        // than a single varint encoding step, exercises a realistic shape.
+        let v: Vec<f32> = (0..384).map(|i| i as f32 * 0.01).collect();
+        round_trip(&Cell::new(7, vec![Some(Value::Vector(v))]));
+    }
+
+    #[test]
+    fn vector_round_trip_edge_values() {
+        // Cover f32 edges — Inf/NaN are surprising values to find in
+        // user data but the encoder shouldn't choke.
+        let v = vec![
+            0.0f32,
+            -0.0,
+            1.0,
+            -1.0,
+            f32::MIN,
+            f32::MAX,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ];
+        // NaN isn't equal to itself so we can't use round_trip(); inline
+        // the encode→decode and assert bit patterns instead.
+        let cell = Cell::new(2, vec![Some(Value::Vector(v.clone()))]);
+        let bytes = cell.encode().expect("encode");
+        let (decoded, _) = Cell::decode(&bytes, 0).expect("decode");
+        match &decoded.values[0] {
+            Some(Value::Vector(out)) => {
+                assert_eq!(out.len(), v.len());
+                for (i, (a, b)) in out.iter().zip(v.iter()).enumerate() {
+                    assert_eq!(
+                        a.to_bits(),
+                        b.to_bits(),
+                        "element {i} bits mismatch: out {a:?}, expected {b:?}"
+                    );
+                }
+            }
+            other => panic!("decoded into wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vector_round_trip_mixed_with_other_columns() {
+        // A row with INTEGER + TEXT + VECTOR columns — exercises the
+        // null-bitmap + sequential value-block decode path with a
+        // VECTOR cell in the middle.
+        let cell = Cell::new(
+            42,
+            vec![
+                Some(Value::Integer(7)),
+                Some(Value::Text("alpha".to_string())),
+                Some(Value::Vector(vec![1.0, 2.0, 3.0, 4.0])),
+                Some(Value::Bool(true)),
+            ],
+        );
+        round_trip(&cell);
+    }
+
+    #[test]
+    fn vector_decode_truncated_buffer_errors() {
+        // Build a real vector cell, then chop the last few bytes so the
+        // f32 array runs past the buffer end.
+        let cell = Cell::new(1, vec![Some(Value::Vector(vec![1.0, 2.0, 3.0]))]);
+        let bytes = cell.encode().expect("encode");
+        for chop in 1..=4 {
+            let truncated = &bytes[..bytes.len() - chop];
+            assert!(
+                Cell::decode(truncated, 0).is_err(),
+                "expected error decoding {} bytes short of full {}",
+                chop,
+                bytes.len()
+            );
         }
     }
 

--- a/src/sql/pager/header.rs
+++ b/src/sql/pager/header.rs
@@ -22,7 +22,12 @@ pub const MAGIC: &[u8; 16] = b"SQLRiteFormat\0\0\0";
 ///   (first), distinguishing `'table'` and `'index'` rows; secondary
 ///   indexes persist as their own cell-based B-Trees whose cells use
 ///   the new `KIND_INDEX` format.
-pub const FORMAT_VERSION: u16 = 3;
+/// - Version 4 (Phase 7): cell encoding gains the `KIND_VECTOR` value
+///   tag (length-prefixed dense f32 array) for the new `VECTOR(N)`
+///   column type. Per the Phase 7 plan (`docs/phase-7-plan.md` Q8),
+///   later Phase 7 sub-phases (JSON, HNSW indexes) will add their own
+///   value/cell tags inside this same v4 envelope — no v5 mid-Phase-7.
+pub const FORMAT_VERSION: u16 = 4;
 
 /// Parsed header. `page_count` includes page 0 itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -319,12 +319,16 @@ fn take_integer(table: &Table, col: &str, rowid: i64) -> Result<i64> {
 fn table_to_create_sql(table: &Table) -> String {
     let mut parts = Vec::with_capacity(table.columns.len());
     for c in &table.columns {
-        let ty = match c.datatype {
-            DataType::Integer => "INTEGER",
-            DataType::Text => "TEXT",
-            DataType::Real => "REAL",
-            DataType::Bool => "BOOLEAN",
-            DataType::None | DataType::Invalid => "TEXT",
+        // Render the SQL type literally so the round-trip through
+        // CREATE TABLE re-parsing recreates the same schema. Vector
+        // carries its dimension inline.
+        let ty: String = match &c.datatype {
+            DataType::Integer => "INTEGER".to_string(),
+            DataType::Text => "TEXT".to_string(),
+            DataType::Real => "REAL".to_string(),
+            DataType::Bool => "BOOLEAN".to_string(),
+            DataType::Vector(dim) => format!("VECTOR({dim})"),
+            DataType::None | DataType::Invalid => "TEXT".to_string(),
         };
         let mut piece = format!("{} {}", c.column_name, ty);
         if c.is_pk {
@@ -369,12 +373,19 @@ fn build_empty_table(name: &str, columns: Vec<Column>, last_rowid: i64) -> Table
     {
         let mut map = rows.lock().expect("rows mutex poisoned");
         for col in &columns {
-            let row = match col.datatype {
+            // Mirror the dispatch in `Table::new` so the reconstructed
+            // table has the same shape it'd have if it were built fresh
+            // from SQL. Phase 7a adds the Vector arm — without it,
+            // VECTOR columns silently restore as Row::None and every
+            // restore_row hits a "storage None vs value Some(Vector(...))"
+            // type mismatch.
+            let row = match &col.datatype {
                 DataType::Integer => Row::Integer(BTreeMap::new()),
                 DataType::Text => Row::Text(BTreeMap::new()),
                 DataType::Real => Row::Real(BTreeMap::new()),
                 DataType::Bool => Row::Bool(BTreeMap::new()),
-                _ => Row::None,
+                DataType::Vector(_dim) => Row::Vector(BTreeMap::new()),
+                DataType::None | DataType::Invalid => Row::None,
             };
             map.insert(col.column_name.clone(), row);
 
@@ -573,6 +584,7 @@ fn clone_datatype(dt: &DataType) -> DataType {
         DataType::Text => DataType::Text,
         DataType::Real => DataType::Real,
         DataType::Bool => DataType::Bool,
+        DataType::Vector(dim) => DataType::Vector(*dim),
         DataType::None => DataType::None,
         DataType::Invalid => DataType::Invalid,
     }
@@ -970,6 +982,68 @@ mod tests {
 
         let notes = loaded.get_table("notes".to_string()).expect("notes table");
         assert_eq!(notes.rowids().len(), 1);
+
+        cleanup(&path);
+    }
+
+    // -----------------------------------------------------------------
+    // Phase 7a — VECTOR(N) save / reopen round-trip
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn round_trip_preserves_vector_column() {
+        let path = tmp_path("vec_roundtrip");
+
+        // Build, populate, save.
+        {
+            let mut db = Database::new("test".to_string());
+            process_command(
+                "CREATE TABLE docs (id INTEGER PRIMARY KEY, embedding VECTOR(3));",
+                &mut db,
+            )
+            .unwrap();
+            process_command(
+                "INSERT INTO docs (embedding) VALUES ([0.1, 0.2, 0.3]);",
+                &mut db,
+            )
+            .unwrap();
+            process_command(
+                "INSERT INTO docs (embedding) VALUES ([1.5, -2.0, 3.5]);",
+                &mut db,
+            )
+            .unwrap();
+            save_database(&mut db, &path).expect("save");
+        } // db drops → its exclusive lock releases before reopen.
+
+        // Reopen and verify schema + data both round-tripped.
+        let loaded = open_database(&path, "test".to_string()).expect("open");
+        let docs = loaded.get_table("docs".to_string()).expect("docs table");
+
+        // Schema preserved: column is still VECTOR(3).
+        let embedding_col = docs
+            .columns
+            .iter()
+            .find(|c| c.column_name == "embedding")
+            .expect("embedding column");
+        assert!(
+            matches!(embedding_col.datatype, DataType::Vector(3)),
+            "expected DataType::Vector(3) after round-trip, got {:?}",
+            embedding_col.datatype
+        );
+
+        // Data preserved: both vectors still readable bit-for-bit.
+        let mut rows: Vec<Vec<f32>> = docs
+            .rowids()
+            .iter()
+            .filter_map(|r| match docs.get_value("embedding", *r) {
+                Some(Value::Vector(v)) => Some(v),
+                _ => None,
+            })
+            .collect();
+        rows.sort_by(|a, b| a[0].partial_cmp(&b[0]).unwrap());
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0], vec![0.1f32, 0.2, 0.3]);
+        assert_eq!(rows[1], vec![1.5f32, -2.0, 3.5]);
 
         cleanup(&path);
     }

--- a/src/sql/parser/create.rs
+++ b/src/sql/parser/create.rs
@@ -1,6 +1,45 @@
-use sqlparser::ast::{ColumnOption, CreateTable, DataType, Statement};
+use sqlparser::ast::{ColumnOption, CreateTable, DataType, ObjectName, ObjectNamePart, Statement};
 
 use crate::error::{Result, SQLRiteError};
+
+/// True when an `ObjectName` resolves to a single identifier `VECTOR`
+/// (case-insensitive). Phase 7a adds the `VECTOR(N)` column type as a
+/// sqlparser `DataType::Custom` — the engine recognizes it via this
+/// helper so the regular DataType match arm above stays uncluttered.
+fn is_vector_type(name: &ObjectName) -> bool {
+    name.0.len() == 1
+        && match &name.0[0] {
+            ObjectNamePart::Identifier(ident) => ident.value.eq_ignore_ascii_case("VECTOR"),
+            // Function-form ObjectNamePart shouldn't appear in a CREATE TABLE
+            // column type position. If it ever does, treat it as not-a-vector
+            // and the outer match falls through to the "Invalid" arm.
+            _ => false,
+        }
+}
+
+/// Parses the dimension out of the `Custom` args for `VECTOR(N)`.
+/// `args` is the `Vec<String>` sqlparser hands back for parenthesized
+/// type arguments — for `VECTOR(384)` that's `["384"]`. Validates that
+/// exactly one positive-integer argument was supplied.
+fn parse_vector_dim(args: &[String]) -> std::result::Result<usize, String> {
+    match args {
+        [] => Err("VECTOR requires a dimension, e.g. `VECTOR(384)`".to_string()),
+        [single] => {
+            let trimmed = single.trim();
+            match trimmed.parse::<usize>() {
+                Ok(d) if d > 0 => Ok(d),
+                Ok(_) => Err(format!("VECTOR dimension must be ≥ 1 (got `{trimmed}`)")),
+                Err(_) => Err(format!(
+                    "VECTOR dimension must be a positive integer (got `{trimmed}`)"
+                )),
+            }
+        }
+        many => Err(format!(
+            "VECTOR takes exactly one dimension argument (got {})",
+            many.len()
+        )),
+    }
+}
 
 /// The schema for each SQL column in every table is represented by
 /// the following structure after parsed and tokenized
@@ -57,7 +96,7 @@ impl CreateQuery {
 
                     // Parsing each column for it data type
                     // For now only accepting basic data types
-                    let datatype = match &col.data_type {
+                    let datatype: String = match &col.data_type {
                         DataType::TinyInt(_)
                         | DataType::SmallInt(_)
                         | DataType::Int2(_)
@@ -65,17 +104,32 @@ impl CreateQuery {
                         | DataType::Int4(_)
                         | DataType::Int8(_)
                         | DataType::Integer(_)
-                        | DataType::BigInt(_) => "Integer",
-                        DataType::Boolean => "Bool",
-                        DataType::Text => "Text",
-                        DataType::Varchar(_bytes) => "Text",
-                        DataType::Real => "Real",
-                        DataType::Float(_precision) => "Real",
-                        DataType::Double(_) => "Real",
-                        DataType::Decimal(_) => "Real",
+                        | DataType::BigInt(_) => "Integer".to_string(),
+                        DataType::Boolean => "Bool".to_string(),
+                        DataType::Text => "Text".to_string(),
+                        DataType::Varchar(_bytes) => "Text".to_string(),
+                        DataType::Real => "Real".to_string(),
+                        DataType::Float(_precision) => "Real".to_string(),
+                        DataType::Double(_) => "Real".to_string(),
+                        DataType::Decimal(_) => "Real".to_string(),
+                        // Phase 7a — `VECTOR(N)` parses as Custom("VECTOR", ["N"]).
+                        // sqlparser's SQLite dialect doesn't have a built-in
+                        // Vector variant; Custom is what unrecognized type
+                        // names + their parenthesized args fall through to.
+                        DataType::Custom(name, args) if is_vector_type(name) => {
+                            match parse_vector_dim(args) {
+                                Ok(dim) => format!("vector({dim})"),
+                                Err(e) => {
+                                    return Err(SQLRiteError::General(format!(
+                                        "Invalid VECTOR column '{}': {e}",
+                                        col.name
+                                    )));
+                                }
+                            }
+                        }
                         other => {
                             eprintln!("not matched on custom type: {other:?}");
-                            "Invalid"
+                            "Invalid".to_string()
                         }
                     };
 

--- a/src/sql/parser/insert.rs
+++ b/src/sql/parser/insert.rs
@@ -61,7 +61,23 @@ impl InsertQuery {
                                     _ => {}
                                 },
                                 Expr::Identifier(i) => {
-                                    value_set.push(i.to_string());
+                                    // Phase 7a — sqlparser parses bracket-array
+                                    // literals like `[0.1, 0.2, 0.3]` as
+                                    // bracket-quoted identifiers (it inherits
+                                    // MSSQL-style `[name]` quoting). Detect
+                                    // that by `quote_style == Some('[')` and
+                                    // re-wrap with brackets so the
+                                    // `parse_vector_literal` helper at
+                                    // insert_row time can recognize and parse
+                                    // it. Regular unquoted identifiers (column
+                                    // refs, which don't make sense in INSERT
+                                    // VALUES anyway) keep the existing
+                                    // pass-through-as-string behavior.
+                                    if i.quote_style == Some('[') {
+                                        value_set.push(format!("[{}]", i.value));
+                                    } else {
+                                        value_set.push(i.to_string());
+                                    }
                                 }
                                 _ => {}
                             }


### PR DESCRIPTION
## Summary

First sub-phase of Phase 7 (per [`docs/phase-7-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/main/docs/phase-7-plan.md)). Adds a fixed-dimension dense f32 array as a first-class SQL data type, plus the parser + cell encoding it needs. **No distance functions or similarity search yet** — those land in 7b/7c/7d on top of this.

```sql
CREATE TABLE docs (
    id INTEGER PRIMARY KEY,
    embedding VECTOR(384)
);

INSERT INTO docs (embedding) VALUES ([0.1, 0.2, 0.3, ..., 0.0]);
SELECT * FROM docs;
```

## What lands

- **File format → v4** (per Q8). All Phase 7 storage additions (VECTOR + JSON + HNSW indexes) live inside this single envelope; no v5 mid-Phase-7. Old v3 files reject on open with the standard "unsupported format version" error.
- **`DataType::Vector(usize)` / `Value::Vector(Vec<f32>)` / `Row::Vector(BTreeMap<i64, Vec<f32>>)`** — engine plumbing across all 6 existing match sites in `table.rs`, `cell.rs`, `executor.rs`, `pager/mod.rs`.
- **Cell value tag `0x04 = VECTOR`** — wire layout `tag (1 byte) | dim (varint) | dim×4 bytes f32 LE`. Self-describing so `decode_value` doesn't need schema context.
- **Parser** — `CREATE TABLE … VECTOR(N)` decoded from sqlparser's `DataType::Custom`; `INSERT … VALUES ([0.1, 0.2, …])` decoded from sqlparser's bracket-quoted Identifier (it inherits MSSQL `[name]` syntax — convenient for us).
- **Per-SDK surface** — Python `list[float]`, Node.js `Array<number>`, WASM JSON array, Desktop bracket-array display. One-line additions per SDK; the deeper `ask()` / vector-operations surface grows in 7b–7g.
- **Docs** — `file-format.md` v4 entry + Vector tag, `supported-sql.md` VECTOR column type + bracket-array literal.

## Q-decisions baked in

| Q | Decision | Where |
|---|---|---|
| Q6 | pgvector-style operators (deferred to 7b) | parser hooks ready |
| Q7 | Bracket-array literal `[0.1, 0.2, ...]` | INSERT parser detects bracket-quoted ident |
| Q8 | Format v4 in 7a, all Phase 7 storage inside | header.rs + file-format.md |

## Bug caught during implementation

`build_empty_table` in `pager/mod.rs` had a wildcard `_ => Row::None` arm that silently swallowed the new `DataType::Vector` variant. First save+reopen test caught it with `Type mismatch restoring column 'embedding': storage None vs value Some(Vector([0.1, 0.2, 0.3]))`. Fixed with an explicit Vector arm + explicit Invalid/None arms (no more wildcard, so the next type addition fails to compile until it's plumbed here too).

## Test plan

- [x] **184 lib tests passing** (was 162 before — 22 new tests across `table.rs`, `cell.rs`, `mod.rs`, `pager/mod.rs`)
- [x] DataType round-trip: `Vector(384)` → `"vector(384)"` → `Vector(384)`
- [x] Cell encoding round-trip: small dim, 384-dim, edge values (Inf/-Inf/MIN/MAX/-0.0), mixed-with-other-columns
- [x] `parse_vector_literal`: float, int-widening, negative, whitespace-tolerant, empty, error cases
- [x] CREATE TABLE end-to-end with valid + missing-dim + zero-dim
- [x] INSERT dimension mismatch produces clean typed error mentioning declared and got dims
- [x] Save → reopen preserves both schema (`DataType::Vector(3)`) and data (bit-for-bit)
- [x] All workspace crates compile (engine, ffi, python, nodejs, wasm, desktop)
- [ ] CI on this PR

## Known limitations (intentional)

- No distance functions, no `WHERE vec = [...]` semantic equality, no ANN index. All come in 7b/7c/7d.
- No NULL vectors yet (Vector column without a value would error at INSERT).
- High-dim vectors print as a long line — truncation polish (`[0.1, ..., 0.384]`) is a future MVP refinement.
- numpy interop in Python (zero-copy via buffer protocol) is future polish; today we go through `Vec<f64>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)