### PR TITLE
docs: Ask feature reference + backend proxy templates + WASM Ask demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ println!("Why: {}",          resp.explanation);
 
 In the REPL: `.ask <question>`. From an open `Connection` (this section). Per-product wrappers — desktop "Ask" button, `conn.ask()` in the Python / Node / Go SDKs, MCP `ask` tool, WASM with a JS-callback shape so the API key never enters the browser — ship in **7g.3-7g.8** as follow-up sub-phases. See [`docs/phase-7-plan.md`](docs/phase-7-plan.md) §7g for the full surface plan.
 
+For the canonical Ask reference covering every surface (REPL, desktop, Rust library, Python / Node / Go / WASM), env vars, defaults, prompt caching, and the security model — read [`docs/ask.md`](docs/ask.md). For copy-paste backend proxy templates the WASM SDK needs (Cloudflare Workers, Vercel Edge, Deno Deploy, Firebase, AWS Lambda, Express), see [`docs/ask-backend-examples.md`](docs/ask-backend-examples.md).
+
 ### Roadmap
 
 The project is staged in phases, each independently shippable. A finished phase is committed to `main` before the next one starts.

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -18,6 +18,11 @@ A small, hand-written guide to the SQLRite codebase — how it's structured, how
 - [Embedding](embedding.md) — the public `Connection` / `Statement` / `Rows` API (Phase 5a) and where the non-Rust SDKs plug in (Phase 5b – 5g)
 - [`examples/`](../examples/) — runnable Rust quickstart (`cargo run --example quickstart`); language-specific subdirectories fill in as each 5x sub-phase lands
 
+## Phase 7 — AI-era extensions
+
+- [Ask — natural-language → SQL](ask.md) — the canonical reference for the `ask()` feature across every product surface (REPL, desktop, Rust library, Python / Node / Go / WASM SDKs); env vars, defaults, prompt caching, security
+- [Ask backend proxy templates](ask-backend-examples.md) — copy-paste backend examples for the WASM SDK's split design: Cloudflare Workers, Vercel Edge, Deno Deploy, Firebase Functions, AWS Lambda, Express, pure Node
+
 ## Internals
 
 These documents go into the implementation of each subsystem.

--- a/docs/ask-backend-examples.md
+++ b/docs/ask-backend-examples.md
@@ -1,0 +1,411 @@
+# Backend proxy templates for the WASM SDK's `ask` flow
+
+The WASM SDK builds the LLM-API request body in the browser, but [doesn't make the HTTP call itself](ask.md#wasm-sdk-the-different-one) — CORS plus API-key exposure rule that out. Instead, the browser POSTs the request body to a small backend you control, which adds the API key and forwards to Anthropic.
+
+This page is a copy-paste catalog of that backend on the platforms most people reach for. Every template:
+
+- Accepts a `POST` with the JSON payload `db.askPrompt(...)` produces.
+- Reads `ANTHROPIC_API_KEY` from the platform's secrets / env mechanism.
+- Forwards to `https://api.anthropic.com/v1/messages` with the right headers.
+- Pipes the upstream status + body straight back to the browser, so `db.askParse()` sees Anthropic's exact response shape.
+
+Pick whichever platform you're already on; the shape is identical.
+
+> **Security recap.** The whole point of the proxy is to keep the API key on the server. Never echo the key into the response body, never log full request/response bodies in production (the user's question may contain PII), and lock the route down with whatever auth your app already uses (cookie session, signed origin check, etc.) — these templates are intentionally unauthenticated so they stay readable, but a public unauthenticated proxy is a free Anthropic credit faucet for anyone who finds the URL.
+
+---
+
+## Table of contents
+
+- [Cloudflare Workers](#cloudflare-workers)
+- [Vercel Edge Functions](#vercel-edge-functions)
+- [Deno Deploy](#deno-deploy)
+- [Firebase Cloud Functions (v2)](#firebase-cloud-functions-v2)
+- [AWS Lambda (Function URLs)](#aws-lambda-function-urls)
+- [Node + Express (self-hosted)](#node--express-self-hosted)
+- [Pure Node (zero-dep, the demo template)](#pure-node-zero-dep-the-demo-template)
+- [Calling from a different origin (CORS)](#calling-from-a-different-origin-cors)
+- [Locking down the proxy](#locking-down-the-proxy)
+
+---
+
+## Cloudflare Workers
+
+**Where the key lives:** `wrangler secret put ANTHROPIC_API_KEY` (encrypted, never in the dashboard or git).
+
+**`wrangler.toml`:**
+
+```toml
+name = "sqlrite-ask-proxy"
+main = "src/worker.js"
+compatibility_date = "2024-12-01"
+```
+
+**`src/worker.js`:**
+
+```js
+export default {
+  async fetch(request, env) {
+    if (request.method !== "POST") {
+      return new Response("method not allowed", { status: 405 });
+    }
+    const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": env.ANTHROPIC_API_KEY,
+        "anthropic-version": "2023-06-01",
+      },
+      body: request.body,
+    });
+    // Pass through the upstream status + body verbatim so the browser's
+    // db.askParse() sees Anthropic's exact response (and 4xx/5xx errors
+    // surface as-is rather than being remapped).
+    return new Response(upstream.body, {
+      status: upstream.status,
+      headers: { "content-type": "application/json" },
+    });
+  },
+};
+```
+
+Deploy:
+
+```sh
+wrangler secret put ANTHROPIC_API_KEY      # paste your sk-ant-…
+wrangler deploy
+```
+
+In your WASM page, point `fetch` at the Worker URL: `fetch('https://sqlrite-ask-proxy.<you>.workers.dev', …)`. If the Worker is on a different origin from the WASM page, see [Calling from a different origin (CORS)](#calling-from-a-different-origin-cors).
+
+---
+
+## Vercel Edge Functions
+
+**Where the key lives:** Vercel dashboard → Project → Settings → Environment Variables → `ANTHROPIC_API_KEY` (Production / Preview / Development as needed).
+
+**`api/llm/complete.js`** (or `app/api/llm/complete/route.js` on App Router):
+
+```js
+export const config = { runtime: "edge" };
+
+export default async function handler(request) {
+  if (request.method !== "POST") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: request.body,
+  });
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: { "content-type": "application/json" },
+  });
+}
+```
+
+App Router variant (`app/api/llm/complete/route.js`):
+
+```js
+export const runtime = "edge";
+
+export async function POST(request) {
+  const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: request.body,
+  });
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: { "content-type": "application/json" },
+  });
+}
+```
+
+The browser then `fetch('/api/llm/complete', …)` — no CORS dance because the page and the function share the origin.
+
+---
+
+## Deno Deploy
+
+**Where the key lives:** Deno Deploy dashboard → Project → Settings → Environment Variables → `ANTHROPIC_API_KEY`.
+
+**`main.ts`:**
+
+```ts
+Deno.serve(async (request) => {
+  if (request.method !== "POST") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": Deno.env.get("ANTHROPIC_API_KEY") ?? "",
+      "anthropic-version": "2023-06-01",
+    },
+    body: request.body,
+  });
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: { "content-type": "application/json" },
+  });
+});
+```
+
+Deploy:
+
+```sh
+deployctl deploy --project=sqlrite-ask-proxy main.ts
+```
+
+Local development:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-… deno run --allow-net --allow-env main.ts
+```
+
+---
+
+## Firebase Cloud Functions (v2)
+
+**Where the key lives:** Firebase Secret Manager — `firebase functions:secrets:set ANTHROPIC_API_KEY` (NOT `functions.config()`, which is deprecated for v2).
+
+**`functions/index.js`:**
+
+```js
+import { onRequest } from "firebase-functions/v2/https";
+import { defineSecret } from "firebase-functions/params";
+
+const anthropicKey = defineSecret("ANTHROPIC_API_KEY");
+
+export const llmComplete = onRequest(
+  { secrets: [anthropicKey], cors: true, region: "us-central1" },
+  async (request, response) => {
+    if (request.method !== "POST") {
+      response.status(405).send("method not allowed");
+      return;
+    }
+    const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": anthropicKey.value(),
+        "anthropic-version": "2023-06-01",
+      },
+      // request.rawBody is a Buffer; pass it through verbatim so we
+      // don't re-serialize and accidentally change byte ordering
+      // (which would invalidate Anthropic's prompt cache).
+      body: request.rawBody,
+    });
+    response.status(upstream.status);
+    response.set("content-type", "application/json");
+    response.send(await upstream.text());
+  },
+);
+```
+
+**`functions/package.json`:**
+
+```json
+{
+  "type": "module",
+  "engines": { "node": "20" },
+  "dependencies": { "firebase-functions": "^5.0.0" }
+}
+```
+
+Deploy:
+
+```sh
+firebase functions:secrets:set ANTHROPIC_API_KEY
+firebase deploy --only functions:llmComplete
+```
+
+The function URL is printed at the end of `firebase deploy` — point your browser `fetch` at it.
+
+---
+
+## AWS Lambda (Function URLs)
+
+A Lambda Function URL gives you an HTTPS endpoint without dragging API Gateway in. **Where the key lives:** Lambda Console → Configuration → Environment variables → `ANTHROPIC_API_KEY` (and consider switching to AWS Secrets Manager for production).
+
+**`index.mjs`** (Node 20+ runtime):
+
+```js
+export const handler = async (event) => {
+  if (event.requestContext?.http?.method !== "POST") {
+    return { statusCode: 405, body: "method not allowed" };
+  }
+  // Function URLs base64-encode the body when it's "binary"; for JSON
+  // POSTs Lambda hands it through as a string. Handle both.
+  const body = event.isBase64Encoded
+    ? Buffer.from(event.body, "base64").toString("utf-8")
+    : event.body;
+
+  const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body,
+  });
+  return {
+    statusCode: upstream.status,
+    headers: { "content-type": "application/json" },
+    body: await upstream.text(),
+  };
+};
+```
+
+Set the Function URL auth type to `NONE` (or wire it behind your own auth — see [Locking down the proxy](#locking-down-the-proxy)). Browser calls the printed URL directly; if the Lambda lives on a different origin from your WASM page you'll need to enable CORS on the Function URL config.
+
+---
+
+## Node + Express (self-hosted)
+
+For a long-running Node server (Render, Fly.io, your own VPS):
+
+```js
+import express from "express";
+
+const app = express();
+app.use(express.json({ limit: "256kb" }));
+
+app.post("/api/llm/complete", async (req, res) => {
+  const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": process.env.ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(req.body),
+  });
+  res.status(upstream.status);
+  res.set("content-type", "application/json");
+  res.send(await upstream.text());
+});
+
+app.listen(3000, () => console.log("Ask proxy on :3000"));
+```
+
+Run:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-… node server.js
+```
+
+---
+
+## Pure Node (zero-dep, the demo template)
+
+The runnable [`examples/wasm/server.mjs`](../examples/wasm/server.mjs) is exactly this — no npm install, ~70 LOC. Reproduced here for completeness:
+
+```js
+import { createServer } from "node:http";
+
+const PORT = process.env.PORT || 8080;
+const KEY = process.env.ANTHROPIC_API_KEY;
+
+createServer(async (req, res) => {
+  if (req.method !== "POST" || req.url !== "/api/llm/complete") {
+    res.writeHead(404).end();
+    return;
+  }
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  const body = Buffer.concat(chunks).toString("utf-8");
+
+  const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": KEY,
+      "anthropic-version": "2023-06-01",
+    },
+    body,
+  });
+  res.writeHead(upstream.status, { "content-type": "application/json" });
+  res.end(await upstream.text());
+}).listen(PORT, () => console.log(`Ask proxy on :${PORT}`));
+```
+
+Run:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-… node server.mjs
+```
+
+The full [`examples/wasm/server.mjs`](../examples/wasm/server.mjs) also serves the static demo (HTML + WASM) on the same port and adds a 256 KiB body cap + path sandboxing — worth a look as a "minimum production-shaped" template.
+
+---
+
+## Calling from a different origin (CORS)
+
+When the WASM page and the proxy are on different origins (page on `app.example.com`, Worker on `proxy.example.workers.dev`), the browser will reject the response unless the proxy returns the right CORS headers.
+
+Add this to any of the templates above:
+
+```js
+// At the start of the handler:
+if (request.method === "OPTIONS") {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "access-control-allow-origin": "https://app.example.com",
+      "access-control-allow-methods": "POST, OPTIONS",
+      "access-control-allow-headers": "content-type",
+      "access-control-max-age": "86400",
+    },
+  });
+}
+
+// After building the upstream response:
+return new Response(upstream.body, {
+  status: upstream.status,
+  headers: {
+    "content-type": "application/json",
+    "access-control-allow-origin": "https://app.example.com",
+  },
+});
+```
+
+**Don't use `*` for `access-control-allow-origin` on the proxy in production** — it lets any site on the internet burn your API quota by hitting your endpoint from a malicious page. Allow-list your actual origins.
+
+---
+
+## Locking down the proxy
+
+The templates above are deliberately unauthenticated to keep the shape readable. Before pointing public traffic at one, add at least one of:
+
+1. **Same-origin only** — host the proxy under your app's domain (Vercel, Next.js API routes, the Pure Node demo) so the browser only ever calls it from your page. Combined with `SameSite=Strict` cookies and an `Origin` header check, this is enough for most internal-tools use cases.
+
+2. **Session cookie / auth header check** — gate the route on whatever your app already uses for the rest of its API. The proxy is just another API route; treat it accordingly.
+
+3. **Rate limit per session/IP** — the proxy can hit Anthropic for any caller. Cloudflare Workers + Cloudflare's rate-limiting rules, Vercel + Upstash rate-limit, or a simple in-memory token bucket on a long-lived server will keep cost bounded if abuse happens.
+
+4. **Origin allow-listing** — check `request.headers.get("origin")` against an explicit allow-list and reject everything else. Doesn't replace auth (an attacker can spoof Origin from a non-browser client) but raises the bar for casual abuse.
+
+5. **Logging hygiene** — the request body contains the user's natural-language question, which may include PII. Log lengths and timing, not bodies.
+
+For ~100 LOC of "production-shaped" Cloudflare Worker that bundles all of these in, see the [Cloudflare Pages + Functions tutorial](https://developers.cloudflare.com/pages/functions/) or the analogous Vercel docs.
+
+---
+
+## See also
+
+- [`docs/ask.md`](ask.md) — the canonical Ask reference (architecture, all SDKs, defaults, errors, prompt caching, security)
+- [`sdk/wasm/README.md`](../sdk/wasm/README.md) — WASM SDK API reference, including `askPrompt` / `askParse` shapes
+- [`examples/wasm/`](../examples/wasm/) — runnable end-to-end demo: WASM in a browser tab + zero-dep Node proxy

--- a/docs/ask.md
+++ b/docs/ask.md
@@ -1,0 +1,424 @@
+# Ask — natural-language → SQL
+
+`ask` is SQLRite's natural-language query feature: type a question in English, get back generated SQL ready to run against your database. It ships across **every product surface** — the REPL, the desktop app, all four SDKs (Python / Node.js / Go / WASM), and the embedded Rust library — with a single underlying engine and one consistent set of defaults.
+
+This doc is the canonical reference. For the per-language API details, the SDK READMEs go deeper; for the design decisions, see [`docs/phase-7-plan.md`](phase-7-plan.md) §7g.
+
+---
+
+## Table of contents
+
+- [What `ask` does](#what-ask-does)
+- [Architecture](#architecture)
+- [Configuration — `SQLRITE_LLM_*` env vars](#configuration--sqlrite_llm_-env-vars)
+- [Defaults](#defaults)
+- [How to use it from each surface](#how-to-use-it-from-each-surface)
+  - [REPL](#repl)
+  - [Desktop app](#desktop-app)
+  - [Rust library](#rust-library)
+  - [Python SDK](#python-sdk)
+  - [Node.js SDK](#nodejs-sdk)
+  - [Go SDK](#go-sdk)
+  - [WASM SDK](#wasm-sdk-the-different-one)
+- [The shared `AskResponse` shape](#the-shared-askresponse-shape)
+- [Errors and how they surface](#errors-and-how-they-surface)
+- [Prompt caching](#prompt-caching)
+- [Security notes](#security-notes)
+- [Provider support](#provider-support)
+- [Cost considerations](#cost-considerations)
+- [Limitations](#limitations)
+
+---
+
+## What `ask` does
+
+Given a connection to a SQLRite database and a natural-language question, `ask`:
+
+1. Walks the database's schema (your `CREATE TABLE` statements, alphabetically sorted for prompt-cache stability).
+2. Builds a structured prompt — frozen system rules block, then the schema dump wrapped in a cacheable Anthropic prompt-cache breakpoint, then the user's question.
+3. Calls the configured LLM provider (Anthropic by default).
+4. Parses the model's response into `{sql, explanation, usage}` — tolerant to fenced JSON / leading prose because real LLM output drifts even with strict instructions.
+
+`ask` does NOT execute the SQL by default. The convention across every SDK: `ask()` returns the generated SQL for the caller to review (or hand to a confirm-and-run UX); `ask_run()` (or its language-idiomatic equivalent) is the one-shot generate-and-execute convenience.
+
+---
+
+## Architecture
+
+The Rust crate `sqlrite-ask` (published on crates.io) holds the core machinery. Two halves:
+
+| Half | Where it lives | Wasm-safe? |
+|---|---|---|
+| Core (prompt construction, response parsing, types) | `sqlrite-ask` lib root | ✅ yes |
+| HTTP transport (`AnthropicProvider`, ureq + rustls) | `sqlrite-ask::provider::anthropic`, gated behind `http` feature | ❌ no (ureq doesn't compile to wasm32) |
+
+The engine integration (the `Connection::ask` extension trait + the `sqlrite::ask::ask` family of free functions) lives in `sqlrite-engine` itself, gated behind the engine's `ask` feature (default-on for the CLI binary; off for the WASM SDK and any minimal library embedding).
+
+The schema-dump helper (`sqlrite::ask::schema::dump_schema_for_database`) is **always available**, no feature flag needed — it's pure-engine code that the WASM SDK uses to introspect schemas without pulling in the HTTP transport.
+
+---
+
+## Configuration — `SQLRITE_LLM_*` env vars
+
+Every surface (except WASM, which has the split JS-callback shape) reads the same environment variables for zero-config use:
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `SQLRITE_LLM_PROVIDER` | LLM provider | `anthropic` |
+| `SQLRITE_LLM_API_KEY` | Provider API key | *(required for any LLM call)* |
+| `SQLRITE_LLM_MODEL` | Model ID | `claude-sonnet-4-6` |
+| `SQLRITE_LLM_MAX_TOKENS` | Per-call max output tokens | `1024` |
+| `SQLRITE_LLM_CACHE_TTL` | Anthropic prompt-cache TTL on the schema block | `5m` (also `1h` or `off`) |
+
+Set them once in your shell rc and every surface picks them up:
+
+```sh
+export SQLRITE_LLM_API_KEY="sk-ant-…"
+# Optional overrides:
+# export SQLRITE_LLM_MODEL="claude-haiku-4-5"
+# export SQLRITE_LLM_CACHE_TTL="1h"
+```
+
+For per-call / per-connection overrides, each SDK exposes an `AskConfig` struct/object you can pass explicitly — see the SDK sections below.
+
+---
+
+## Defaults
+
+Same across every surface:
+
+| Default | Value | Why |
+|---|---|---|
+| Model | `claude-sonnet-4-6` | Cost/quality sweet spot for NL→SQL. Haiku 4.5 is buggy on joins/aggregates/vectors; Opus 4.7 overkills the task at 5× cost. |
+| `max_tokens` | `1024` | SQL output rarely exceeds 500 tokens. Leaves headroom for a long `explanation`. |
+| Cache TTL | `5m` | Break-even at 2 calls per cached prefix; right for interactive REPL/notebook use. Set `1h` for editor/desktop sessions where the same DB is queried sporadically over an hour. |
+| Provider | `anthropic` | Per Phase 7 plan Q4 — Anthropic-first; OpenAI / Ollama follow-ups planned. |
+
+---
+
+## How to use it from each surface
+
+Every example below assumes `SQLRITE_LLM_API_KEY` is set in the environment. Each section also shows the per-call explicit-config form for non-default keys.
+
+### REPL
+
+```
+$ sqlrite my.sqlrite
+sqlrite> .ask How many users are over 30?
+Generated SQL:
+  SELECT COUNT(*) FROM users WHERE age > 30
+Rationale: Counts users older than thirty.
+Run? [Y/n] y
++-------+
+| count |
++-------+
+| 47    |
++-------+
+```
+
+Confirmation defaults to `y` (just hit enter). `n` skips. Ctrl-C / EOF also skip — paranoid default for LLM-generated SQL. Per Phase 7g.2 retrospective in the roadmap.
+
+### Desktop app
+
+Click the **Ask…** button in the editor toolbar. A composer panel slides in above the editor. Type a question, hit Cmd/Ctrl+Enter (or click "Generate SQL"), and the generated SQL drops into the editor textarea for review. Click **Run** when ready.
+
+The Tauri Rust backend reads `SQLRITE_LLM_API_KEY` from the env Tauri inherited at launch, makes the HTTP call server-side, and returns only `{sql, explanation}` to the webview. **The API key never crosses into the browser-render process.** Same security story as the WASM split, achieved here as a natural side effect of how Tauri's command bridge works.
+
+If `SQLRITE_LLM_API_KEY` is missing, the panel surfaces a clean "missing API key" error in the existing error slot.
+
+### Rust library
+
+```toml
+[dependencies]
+sqlrite-engine = "0.1"
+sqlrite-ask    = "0.1"
+```
+
+```rust
+use sqlrite::{Connection, ConnectionAskExt};
+use sqlrite_ask::AskConfig;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = Connection::open("foo.sqlrite")?;
+
+    // Path 1: env vars (zero config)
+    let cfg = AskConfig::from_env()?;
+    let resp = conn.ask("How many users are over 30?", &cfg)?;
+    println!("{}", resp.sql);
+    println!("{}", resp.explanation);
+
+    // Path 2: explicit config
+    let cfg = AskConfig {
+        api_key: Some("sk-ant-…".to_string()),
+        model: "claude-haiku-4-5".to_string(),
+        ..AskConfig::default()
+    };
+    let resp = conn.ask("count by age", &cfg)?;
+    Ok(())
+}
+```
+
+The `ConnectionAskExt::ask` method is gated behind the engine's `ask` feature (default-on). Equivalent free functions live at `sqlrite::ask::{ask, ask_with_database, ask_with_provider, ask_with_database_and_provider}` — pick whichever shape reads better at the call site.
+
+### Python SDK
+
+```bash
+pip install sqlrite
+```
+
+```python
+import sqlrite
+
+conn = sqlrite.connect("foo.sqlrite")
+
+# Path 1: env vars
+resp = conn.ask("How many users are over 30?")
+print(resp.sql)
+print(resp.explanation)
+
+# Path 2: explicit config
+cfg = sqlrite.AskConfig(
+    api_key="sk-ant-…",
+    model="claude-haiku-4-5",
+    cache_ttl="1h",
+)
+resp = conn.ask("count by age", cfg)
+
+# Path 3: per-connection (set once, reuse)
+conn.set_ask_config(cfg)
+resp = conn.ask("anything")     # uses cfg
+
+# Convenience: generate + execute
+rows = conn.ask_run("list active users").fetchall()
+```
+
+`AskConfig.__repr__` deliberately omits the API key value (shows `<set>` or `None`). See [`sdk/python/README.md`](../sdk/python/README.md) for the full reference.
+
+### Node.js SDK
+
+```bash
+npm install @joaoh82/sqlrite
+```
+
+```js
+import { Database, AskConfig } from '@joaoh82/sqlrite';
+
+const db = new Database('foo.sqlrite');
+
+// Path 1: env vars
+const resp = db.ask('How many users are over 30?');
+
+// Path 2: explicit config (camelCase per JS convention)
+const cfg = new AskConfig({
+  apiKey: 'sk-ant-…',
+  model: 'claude-haiku-4-5',
+  cacheTtl: '1h',
+});
+const resp = db.ask('count by age', cfg);
+
+// Path 3: per-connection
+db.setAskConfig(cfg);
+const resp = db.ask('anything');
+
+// Convenience: generate + execute
+const rows = db.askRun('list active users');
+```
+
+Auto-generated TypeScript types in `index.d.ts`. `AskConfig.toString()` deliberately omits the API key value. See [`sdk/nodejs/README.md`](../sdk/nodejs/README.md) for the full reference.
+
+### Go SDK
+
+```bash
+go get github.com/joaoh82/rust_sqlite/sdk/go
+```
+
+```go
+import (
+    "database/sql"
+    sqlrite "github.com/joaoh82/rust_sqlite/sdk/go"
+)
+
+db, _ := sql.Open("sqlrite", "foo.sqlrite")
+
+// Path 1: env vars (nil cfg)
+resp, err := sqlrite.Ask(db, "How many users are over 30?", nil)
+
+// Path 2: explicit config
+cfg := &sqlrite.AskConfig{
+    APIKey:    "sk-ant-…",
+    Model:     "claude-haiku-4-5",
+    MaxTokens: 512,
+    CacheTTL:  "1h",
+}
+resp, _ := sqlrite.Ask(db, "count by age", cfg)
+
+// Convenience: generate + execute
+rows, _ := sqlrite.AskRun(db, "list active users", nil)
+defer rows.Close()
+
+// Context-aware variants for connection-pool acquisition
+resp, _ = sqlrite.AskContext(ctx, db, "...", cfg)
+rows, _  = sqlrite.AskRunContext(ctx, db, "...", cfg)
+```
+
+`(*AskConfig).String()` deliberately omits the API key value. See [`sdk/go/README.md`](../sdk/go/README.md) for the full reference.
+
+### WASM SDK (the different one)
+
+The WASM SDK is **the only surface that requires a backend you control.** Browsers can't call `api.anthropic.com` directly (CORS) and can't safely hold an API key (anyone with DevTools can read it). So the WASM SDK splits the work: the browser builds the prompt and parses the response, your backend does the HTTP call.
+
+```bash
+npm install @joaoh82/sqlrite-wasm
+```
+
+```js
+import init, { Database } from '@joaoh82/sqlrite-wasm';
+await init();
+
+const db = new Database();
+db.exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)`);
+
+async function ask(question) {
+  // Step 1: build the LLM-API payload locally. No key needed.
+  const payload = db.askPrompt(question);
+
+  // Step 2: send to YOUR backend, which adds the key + forwards.
+  const apiResponse = await fetch('/api/llm/complete', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).then(r => r.text());
+
+  // Step 3: parse the model's reply.
+  return db.askParse(apiResponse);
+}
+
+const result = await ask('How many users are over 30?');
+console.log(result.sql);
+```
+
+The backend proxy is ~10 lines on any modern serverless platform. **See [`docs/ask-backend-examples.md`](ask-backend-examples.md) for ready-to-deploy templates** — Cloudflare Workers, Vercel Edge Functions, Deno Deploy, Firebase Functions, and Node/Express.
+
+A runnable end-to-end demo (browser + zero-dep Node proxy) lives at [`examples/wasm/`](../examples/wasm/) — `make build && make ask-demo`. See [`sdk/wasm/README.md`](../sdk/wasm/README.md) for the full reference.
+
+---
+
+## The shared `AskResponse` shape
+
+Every surface returns the same logical structure (the field names are spelled idiomatically per language):
+
+| Field | Meaning |
+|---|---|
+| `sql` | The generated SQL, ready to execute. Empty string if the model declined to generate SQL for the schema. |
+| `explanation` | One-sentence rationale from the model. May be empty. |
+| `usage.input_tokens` | Tokens billed as input on this call. |
+| `usage.output_tokens` | Tokens billed as output on this call. |
+| `usage.cache_creation_input_tokens` | Tokens written to the prompt cache (charged at ~1.25× normal). Non-zero on the first call against a fresh schema. |
+| `usage.cache_read_input_tokens` | Tokens served from the prompt cache (charged at ~0.1× normal). **Use this to verify caching is working** — see [Prompt caching](#prompt-caching). |
+
+---
+
+## Errors and how they surface
+
+| Failure mode | Where it surfaces | Typical message |
+|---|---|---|
+| Missing API key | `ask()` call returns / throws | `"missing API key (set SQLRITE_LLM_API_KEY ...)"` |
+| HTTP transport error (network) | `ask()` call returns / throws | `"HTTP transport error: <details>"` |
+| LLM API 4xx/5xx | `ask()` call returns / throws | `"API returned status <code>: <Anthropic error type+message>"` |
+| Model declined (empty SQL) | `ask()` returns response with `sql=""`; `ask_run()` raises with the model's explanation | `"model declined to generate SQL: <explanation>"` |
+| Model output unparseable | `ask()` returns / throws | `"model output not valid JSON: <raw>"` |
+
+The parser is tolerant — strict JSON, fenced JSON (`` ```json … ``` ``), and JSON-with-leading-prose all parse — because real LLM output drifts even with strict prompt instructions.
+
+---
+
+## Prompt caching
+
+Anthropic's prompt cache lets the schema dump be served at ~10% of normal input cost on repeat calls. The schema block in `ask`'s prompt carries a `cache_control: ephemeral` marker that's stable across calls (alphabetical column order, byte-identical rules block) so the cache reliably hits.
+
+**Verifying it works:**
+
+```python
+# Python — same shape in every SDK
+resp1 = conn.ask("first question")
+resp2 = conn.ask("second question")
+assert resp2.usage.cache_read_input_tokens > 0     # cache hit on the schema
+```
+
+If `cache_read_input_tokens` stays zero across repeated asks against the same schema, something is invalidating the cache. Common culprits:
+- Timestamps / UUIDs / random IDs leaking into the schema dump (the schema dump is byte-stable, but if you use `ALTER TABLE` between asks, the schema changes).
+- Switching models between calls (cache is model-scoped).
+- Switching the cache TTL (`5m` vs `1h` are separate cache entries).
+
+For long-running editor / desktop sessions where the same DB is queried sporadically over an hour, set `cache_ttl` to `"1h"` — costs 2× write premium instead of 1.25× but stays alive between asks.
+
+---
+
+## Security notes
+
+### Where the API key lives per surface
+
+| Surface | API key location |
+|---|---|
+| REPL | Process env (`SQLRITE_LLM_API_KEY`) — visible to other processes owned by the same user, same as any tool you run from a shell. |
+| Desktop | Tauri Rust backend's process env. Webview (the JS rendering process) never sees the key. |
+| Rust library | Wherever you put it. Read from env, secrets manager, vault, etc. |
+| Python / Node / Go SDKs | Wherever you put it. Same flexibility — env, secrets manager, runtime config. |
+| WASM | **YOUR backend, never the browser tab.** The browser hands the prompt to your backend, the backend adds the key and forwards. See [`docs/ask-backend-examples.md`](ask-backend-examples.md). |
+
+### What `__repr__` / `String()` / `toString()` shows
+
+Every SDK's `AskConfig` representation **deliberately omits the API key value**. Printing the config in logs / debuggers / Jupyter cells / `console.log` won't leak the secret. Each shows a `<set>` / `<unset>` marker so you can tell whether a key is configured:
+
+```
+Python:  AskConfig(provider="anthropic", model="claude-sonnet-4-6", max_tokens=1024, cache_ttl="5m", api_key=<set>)
+Node.js: AskConfig(provider="anthropic", model="claude-sonnet-4-6", maxTokens=1024, cacheTtl="5m", apiKey=<set>)
+Go:      AskConfig(provider="anthropic", model="claude-sonnet-4-6", maxTokens=1024, cacheTtl="5m", apiKey=<set>)
+```
+
+### What `AskResponse` does NOT carry
+
+The `AskResponse` returned to your code carries `{sql, explanation, usage}` — never the API key, never the request body, never the raw API response. Logging an `AskResponse` is safe.
+
+---
+
+## Provider support
+
+Phase 7g.1–7g.7 ships with **Anthropic** as the only built-in provider. Per Phase 7 plan Q4, OpenAI and Ollama follow-ups are planned but not yet implemented. The internal `Provider` trait is open — Rust callers can supply a custom backend via `ask_with_schema_and_provider` (see `sqlrite-ask`'s docs).
+
+**For non-Anthropic providers today, the WASM SDK already offers a clean path**: your backend translates the Anthropic-shaped payload to whatever provider it talks to (the `system` blocks and `messages` array map cleanly to OpenAI's `messages` field, for example). No SDK changes needed; provider variety lives entirely on your backend. Per-SDK native support for OpenAI/Ollama is tracked as a Phase 7g.x follow-up.
+
+---
+
+## Cost considerations
+
+`ask`'s typical cost per call (Anthropic Sonnet 4.6, no cache hit on schema):
+
+- **Input tokens**: ~3,000 — ~500 for the rules block, varies with your schema (a small DB ~500; a 20-table app DB might run 2,000+).
+- **Output tokens**: ~50–150 — generated SQL + one-sentence explanation.
+
+At Sonnet 4.6 pricing ($3/MTok input, $15/MTok output): roughly **$0.01 per first call**, then **~$0.001 per cached follow-up call** within the 5-minute TTL.
+
+For high-volume scenarios:
+- Set `model: "claude-haiku-4-5"` to drop cost ~3× at the price of slightly worse SQL on complex schemas.
+- Set `cache_ttl: "1h"` if your DB is queried sporadically over an hour — costs 2× cache-write but keeps every subsequent call cheap.
+- Inspect `resp.usage.cache_read_input_tokens` after each call to confirm caching is hitting.
+
+---
+
+## Limitations
+
+- **No streaming.** `ask` waits for the full response. Streaming would complicate the confirm-and-run flow + the SDK return-type story for marginal UX gain on a small payload.
+- **No multi-turn.** Stateless — every call is a fresh prompt. Conversational refinement ("now sort by age") is its own UX problem.
+- **No parameter binding in generated SQL.** The model emits literal-inlined SQL, matching the engine's current parameter-binding story (deferred to Phase 5a.2 across the whole stack).
+- **Anthropic only at the SDK layer today.** OpenAI / Ollama require translation on your own backend (clean path on the WASM SDK; Rust crate has the `Provider` trait open).
+
+---
+
+## See also
+
+- [`docs/phase-7-plan.md`](phase-7-plan.md) §7g — design decisions + sub-phase breakdown.
+- [`docs/ask-backend-examples.md`](ask-backend-examples.md) — ready-to-deploy backend proxies for the WASM SDK (Cloudflare Workers / Vercel Edge / Deno Deploy / Firebase / Express).
+- [`sdk/python/README.md`](../sdk/python/README.md), [`sdk/nodejs/README.md`](../sdk/nodejs/README.md), [`sdk/go/README.md`](../sdk/go/README.md), [`sdk/wasm/README.md`](../sdk/wasm/README.md) — per-SDK API references.
+- [`examples/wasm/`](../examples/wasm/) — runnable browser demo with the Ask flow.
+- [`docs/embedding.md`](embedding.md) — Rust library embedding guide that includes `ConnectionAskExt::ask`.

--- a/examples/wasm/Makefile
+++ b/examples/wasm/Makefile
@@ -1,12 +1,18 @@
 # Build + serve the SQLRite WASM browser demo.
 #
 # Targets:
-#   make build    — build the wasm-pack output into ./pkg/
-#   make serve    — serve the demo on http://localhost:8080
-#   make          — build + serve
-#   make clean    — remove the built pkg/
+#   make build       — build the wasm-pack output into ./pkg/
+#   make serve       — serve static demo on http://localhost:8080 (no Ask)
+#   make ask-demo    — serve via node server.mjs (static + Ask proxy)
+#   make             — build + serve (no Ask)
+#   make clean       — remove the built pkg/
+#
+# The plain `serve` target uses Python's stdlib http.server — fine
+# for the SQL console part, but the Ask demo needs a backend that
+# proxies POST /api/llm/complete to Anthropic. Use `make ask-demo`
+# for that flow.
 
-.PHONY: all build serve clean
+.PHONY: all build serve ask-demo clean
 
 PORT ?= 8080
 
@@ -21,10 +27,27 @@ build:
 # Simple static server so the browser can fetch the wasm file via
 # HTTP (file:// loads block WebAssembly for security reasons). Uses
 # Python because it's on every macOS/Linux install; any static
-# server works (miniserve, `npx serve`, etc.).
+# server works (miniserve, `npx serve`, etc.). Note: the Ask
+# section in the demo will report "couldn't reach proxy" because
+# python's http.server doesn't proxy. Use `make ask-demo` for that.
 serve:
 	@echo "Open http://localhost:$(PORT)/ in a browser"
 	python3 -m http.server $(PORT)
+
+# Static-server + Ask proxy in one process. Requires Node 18+
+# (built-in fetch) and ANTHROPIC_API_KEY in the env. Zero npm
+# dependencies — the server is ~70 LOC in server.mjs using only
+# `node:http` and `node:fs`.
+#
+# After `make build`:
+#
+#     export ANTHROPIC_API_KEY=sk-ant-…
+#     make ask-demo
+#
+# Then open http://localhost:8080/ and use the "Ask" section.
+ask-demo:
+	@echo "SQLRite WASM demo + Ask proxy:  http://localhost:$(PORT)/"
+	PORT=$(PORT) node server.mjs
 
 clean:
 	rm -rf pkg

--- a/examples/wasm/index.html
+++ b/examples/wasm/index.html
@@ -15,6 +15,11 @@
       h1 {
         font-size: 1.5rem;
       }
+      h2 {
+        margin-top: 2.5rem;
+        padding-top: 1rem;
+        border-top: 1px solid #e5e5ea;
+      }
       textarea {
         width: 100%;
         font-family: ui-monospace, Menlo, Consolas, monospace;
@@ -24,6 +29,9 @@
         border-radius: 6px;
         min-height: 8rem;
       }
+      textarea.compact {
+        min-height: 3rem;
+      }
       button {
         margin: 0.5rem 0.3rem 0.5rem 0;
         padding: 0.4rem 0.9rem;
@@ -32,6 +40,10 @@
         border: 0;
         border-radius: 6px;
         cursor: pointer;
+      }
+      button:disabled {
+        background: #b0b0b8;
+        cursor: not-allowed;
       }
       button.secondary {
         background: #e5e5ea;
@@ -47,6 +59,24 @@
       .status {
         color: #515154;
         font-size: 0.85rem;
+      }
+      .ask-banner {
+        background: #fffaf0;
+        border: 1px solid #f0d8a8;
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        font-size: 0.9rem;
+        margin-bottom: 1rem;
+      }
+      .ask-banner code {
+        background: #f5e7c4;
+        padding: 0 0.2rem;
+        border-radius: 3px;
+      }
+      .meta {
+        color: #6e6e73;
+        font-size: 0.8rem;
+        font-family: ui-monospace, Menlo, Consolas, monospace;
       }
     </style>
   </head>
@@ -74,6 +104,52 @@ SELECT id, name, age FROM users ORDER BY age DESC;</textarea
     <h3>Result</h3>
     <pre id="out">(run a query to see output)</pre>
 
+    <!-- ============================================================ -->
+    <!-- Phase 7g.7 — natural-language → SQL via askPrompt / askParse -->
+    <!-- ============================================================ -->
+
+    <h2>Ask (natural-language → SQL)</h2>
+
+    <p>
+      The WASM SDK builds the LLM-API request body in this browser tab, but
+      <strong>doesn't make the HTTP call itself</strong>. CORS + API-key
+      exposure rule that out (see <code>docs/ask.md</code> for the full
+      reasoning). Instead, the call goes through a backend proxy you control.
+      The proxy is ~10 lines — see <code>examples/wasm/server.mjs</code> for a
+      zero-dependency Node version that this demo expects on
+      <code>POST /api/llm/complete</code>.
+    </p>
+
+    <div class="ask-banner">
+      <strong>To use this section:</strong>
+      <ol>
+        <li>Set <code>ANTHROPIC_API_KEY</code> in your shell.</li>
+        <li>
+          Run <code>node server.mjs</code> from
+          <code>examples/wasm/</code> (after <code>make build</code>). It serves
+          this page on <code>http://localhost:8080</code> and proxies
+          <code>/api/llm/complete</code> to Anthropic with your key.
+        </li>
+        <li>Type a question below. The generated SQL drops into the SQL console above.</li>
+      </ol>
+      No proxy running? The Ask button will report a clean "couldn't reach
+      proxy" error and the rest of the console keeps working.
+    </div>
+
+    <textarea id="askQuestion" class="compact" placeholder="e.g. How many users are over 30?">How many users are over 30?</textarea>
+    <div>
+      <button id="ask">Ask</button>
+      <span class="status" id="askStatus"></span>
+    </div>
+
+    <h3>Generated SQL</h3>
+    <pre id="askSql">(submit a question to see generated SQL here)</pre>
+
+    <h3>Explanation</h3>
+    <pre id="askExplanation">(model rationale shows here)</pre>
+
+    <p class="meta" id="askUsage"></p>
+
     <script type="module">
       // wasm-pack's `--target web` build is imported directly as a
       // JS module. `init()` fetches the `.wasm` file and wires up
@@ -87,6 +163,10 @@ SELECT id, name, age FROM users ORDER BY age DESC;</textarea
       await init();
       let db = new Database();
       status.textContent = `sqlrite-wasm ready (in-memory)`;
+
+      // ----------------------------------------------------------------
+      // SQL console
+      // ----------------------------------------------------------------
 
       document.getElementById("run").onclick = () => {
         const input = sqlTextarea.value.trim();
@@ -128,6 +208,80 @@ SELECT id, name, age FROM users ORDER BY age DESC;</textarea
         db.free();
         db = new Database();
         out.textContent = "(reset — fresh in-memory DB)";
+      };
+
+      // ----------------------------------------------------------------
+      // Ask flow — the Q9 split: build prompt here, post to backend,
+      // parse response here.
+      // ----------------------------------------------------------------
+
+      const askButton = document.getElementById("ask");
+      const askStatus = document.getElementById("askStatus");
+      const askSqlEl = document.getElementById("askSql");
+      const askExplanationEl = document.getElementById("askExplanation");
+      const askUsageEl = document.getElementById("askUsage");
+      const askQuestionEl = document.getElementById("askQuestion");
+
+      askButton.onclick = async () => {
+        const question = askQuestionEl.value.trim();
+        if (!question) return;
+        askButton.disabled = true;
+        askStatus.textContent = "asking…";
+        askSqlEl.textContent = "(generating…)";
+        askExplanationEl.textContent = "";
+        askUsageEl.textContent = "";
+
+        try {
+          // Step 1: build the LLM-API payload in-browser. No API key
+          // needed here — it's just the prompt body.
+          const payload = db.askPrompt(question);
+
+          // Step 2: POST to the local backend proxy. The proxy adds
+          // x-api-key from its env and forwards to Anthropic.
+          // Set up: see server.mjs alongside this file.
+          const response = await fetch("/api/llm/complete", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+          });
+          if (!response.ok) {
+            const errText = await response.text();
+            throw new Error(`backend ${response.status}: ${errText}`);
+          }
+          const rawApiResponse = await response.text();
+
+          // Step 3: parse the LLM response back into structured form.
+          const result = db.askParse(rawApiResponse);
+
+          if (!result.sql || result.sql.trim().length === 0) {
+            askSqlEl.textContent = "(model declined to generate SQL)";
+            askExplanationEl.textContent = result.explanation || "(no explanation)";
+          } else {
+            askSqlEl.textContent = result.sql;
+            askExplanationEl.textContent = result.explanation || "(no explanation)";
+            // Drop the generated SQL into the SQL console for review +
+            // execution. User clicks Run to actually execute. This
+            // mirrors the REPL's confirm-and-run UX from Phase 7g.2.
+            sqlTextarea.value = result.sql + ";";
+          }
+          const u = result.usage;
+          askUsageEl.textContent =
+            `tokens: input=${u.input_tokens}, output=${u.output_tokens}, ` +
+            `cache_write=${u.cache_creation_input_tokens}, cache_hit=${u.cache_read_input_tokens}`;
+          askStatus.textContent = "done — SQL pasted into console above; click Run to execute.";
+        } catch (err) {
+          // Most common error: proxy isn't running. Give a clear hint
+          // rather than a cryptic "Failed to fetch".
+          const msg = String(err);
+          if (msg.includes("Failed to fetch") || msg.includes("NetworkError")) {
+            askStatus.textContent = "couldn't reach proxy — is `node server.mjs` running?";
+          } else {
+            askStatus.textContent = msg;
+          }
+          askSqlEl.textContent = `Error: ${msg}`;
+        } finally {
+          askButton.disabled = false;
+        }
       };
     </script>
   </body>

--- a/examples/wasm/server.mjs
+++ b/examples/wasm/server.mjs
@@ -1,0 +1,167 @@
+// Tiny zero-dependency Node server for the WASM Ask demo.
+//
+// Two responsibilities:
+//   1. Serve the static files in this directory (so the browser can
+//      load index.html + pkg/*.wasm + pkg/*.js without extra setup).
+//   2. Proxy POST /api/llm/complete to api.anthropic.com, adding the
+//      x-api-key header from the ANTHROPIC_API_KEY env var.
+//
+// **Why this lives in the example, not the SDK:** the WASM SDK
+// deliberately doesn't ship a backend. Q9's whole point is that
+// the API key lives in YOUR backend, so we show what the absolute-
+// minimum "your backend" looks like. ~70 LOC, no dependencies.
+//
+// Usage:
+//
+//     # First-time setup — build the wasm package.
+//     make build
+//
+//     # Then run THIS server (not `python -m http.server`):
+//     export ANTHROPIC_API_KEY=sk-ant-…
+//     node server.mjs
+//
+//     # → open http://localhost:8080/
+//
+// For production patterns on Cloudflare Workers / Vercel Edge /
+// Deno Deploy / Firebase Functions / etc., see the worked examples
+// in `docs/ask-backend-examples.md`. They're all the same shape:
+// receive payload, add x-api-key, forward.
+
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { extname, join, normalize, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PORT = process.env.PORT || 8080;
+const ROOT = resolve(fileURLToPath(import.meta.url), "..");
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+
+if (!ANTHROPIC_API_KEY) {
+  console.warn(
+    "[warn] ANTHROPIC_API_KEY is not set. Static files will serve, but " +
+      "POST /api/llm/complete will return 500 for every request.\n" +
+      "       Set the var and restart: export ANTHROPIC_API_KEY=sk-ant-…",
+  );
+}
+
+// Minimal MIME table — enough for the WASM demo. Anything not
+// listed falls back to application/octet-stream which the browser
+// handles fine for downloads but won't auto-execute as a script.
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+};
+
+const server = createServer(async (req, res) => {
+  // ---------------------------------------------------------------
+  // Route: /api/llm/complete (the Ask proxy)
+  // ---------------------------------------------------------------
+  if (req.method === "POST" && req.url === "/api/llm/complete") {
+    if (!ANTHROPIC_API_KEY) {
+      res.writeHead(500, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "ANTHROPIC_API_KEY not set on the server" }));
+      return;
+    }
+    try {
+      // Read the request body the browser POSTed. Cap the size so a
+      // misbehaving client can't OOM the server with a giant payload —
+      // 256 KiB is generous for an Ask request (system blocks +
+      // schema dump + question; rarely cracks 100 KiB).
+      const chunks = [];
+      let size = 0;
+      const MAX = 256 * 1024;
+      for await (const chunk of req) {
+        size += chunk.length;
+        if (size > MAX) {
+          res.writeHead(413, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "request body too large" }));
+          return;
+        }
+        chunks.push(chunk);
+      }
+      const body = Buffer.concat(chunks).toString("utf-8");
+
+      // Forward to Anthropic with our API key. The browser never
+      // sees this header — that's the whole point of the proxy.
+      const upstream = await fetch("https://api.anthropic.com/v1/messages", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": ANTHROPIC_API_KEY,
+          "anthropic-version": "2023-06-01",
+        },
+        body,
+      });
+
+      // Pipe the response body straight back. We pass through the
+      // upstream status code so the browser sees Anthropic's 4xx /
+      // 5xx as-is — `db.askParse` and the demo's error handling
+      // know how to surface those.
+      res.writeHead(upstream.status, { "content-type": "application/json" });
+      res.end(await upstream.text());
+    } catch (err) {
+      res.writeHead(502, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({ error: `proxy failed to reach upstream: ${String(err)}` }),
+      );
+    }
+    return;
+  }
+
+  // ---------------------------------------------------------------
+  // Static files (everything else)
+  // ---------------------------------------------------------------
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.writeHead(405).end();
+    return;
+  }
+
+  // Map / to /index.html for the demo's root URL.
+  const url = req.url === "/" ? "/index.html" : req.url;
+
+  // Resolve + sandbox: never serve outside ROOT, even if the URL
+  // contains `..`. `normalize` collapses traversals; the
+  // startsWith check confirms the result is still inside ROOT.
+  const safePath = normalize(join(ROOT, url));
+  if (!safePath.startsWith(ROOT)) {
+    res.writeHead(403).end();
+    return;
+  }
+
+  try {
+    const info = await stat(safePath);
+    if (info.isDirectory()) {
+      res.writeHead(403).end();
+      return;
+    }
+    const data = await readFile(safePath);
+    const mime = MIME[extname(safePath).toLowerCase()] || "application/octet-stream";
+    res.writeHead(200, {
+      "content-type": mime,
+      "content-length": data.length,
+      // Tell browsers the WASM module is fine to compile + execute.
+      // Without this the browser's "wasm-strict" mode (Firefox, some
+      // Chrome flags) refuses to instantiate.
+      "cross-origin-resource-policy": "same-origin",
+    });
+    res.end(data);
+  } catch {
+    res.writeHead(404).end("not found");
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`SQLRite WASM demo:   http://localhost:${PORT}/`);
+  console.log(`Ask proxy endpoint:  POST http://localhost:${PORT}/api/llm/complete`);
+  if (ANTHROPIC_API_KEY) {
+    console.log("ANTHROPIC_API_KEY:   detected (proxy will forward to Anthropic)");
+  } else {
+    console.log("ANTHROPIC_API_KEY:   NOT SET — Ask proxy will 500 until you set it");
+  }
+});

--- a/sdk/wasm/README.md
+++ b/sdk/wasm/README.md
@@ -177,6 +177,8 @@ app.listen(3000);
 
 A minimal Cloudflare Worker / Vercel Edge function is essentially identical — read JSON in, forward with the key header, pass the response body through. **The API key stays on the server**; the browser never sees it.
 
+**Ready-to-deploy templates** for Cloudflare Workers, Vercel Edge Functions, Deno Deploy, Firebase Functions, AWS Lambda, and Express live in [`docs/ask-backend-examples.md`](../../docs/ask-backend-examples.md). For the broader Ask-feature reference (every SDK, env vars, defaults, prompt caching, security model), see [`docs/ask.md`](../../docs/ask.md). A runnable end-to-end demo (browser + zero-dep Node proxy) lives at [`examples/wasm/`](../../examples/wasm/) — `make build && make ask-demo`.
+
 #### `askPrompt` options
 
 ```js


### PR DESCRIPTION
## Summary

Adds a single canonical reference for the **Ask feature** across every product surface, plus copy-paste backend proxy templates for the WASM SDK's split design, and an end-to-end WASM Ask demo developers can run locally.

- **`docs/ask.md`** — canonical reference covering REPL, desktop, Rust library, and Python / Node / Go / WASM SDKs. Sections: architecture, env-var configuration, defaults, per-surface usage with working code, the shared `AskResponse` shape, error taxonomy, prompt-caching guidance with a verification snippet, security notes, provider support, cost considerations, limitations.
- **`docs/ask-backend-examples.md`** — ready-to-deploy backend proxy templates the WASM SDK needs: Cloudflare Workers, Vercel Edge Functions, Deno Deploy, Firebase Cloud Functions (v2), AWS Lambda Function URLs, Express, and the zero-dep pure-Node template that ships with `examples/wasm/`. Includes CORS guidance and a "locking down the proxy" section.
- **`examples/wasm/`** — adds an Ask panel to the existing WASM demo (question textarea + button + SQL/explanation/usage display, with generated SQL dropped into the console for review). New `server.mjs` is a zero-dep Node 18+ proxy that serves the static demo and forwards `/api/llm/complete` to Anthropic. New `make ask-demo` target wires it up.
- **Cross-references** — links to the new docs from `README.md`, `docs/_index.md`, and `sdk/wasm/README.md`.

No code changes to engine, SDKs, or release pipeline. Pure docs + example.

## Test plan

- [ ] `docs/ask.md` and `docs/ask-backend-examples.md` render cleanly on GitHub
- [ ] Code samples in `docs/ask-backend-examples.md` are syntactically valid for each platform (visual review)
- [ ] `cd examples/wasm && make build && ANTHROPIC_API_KEY=sk-ant-… make ask-demo` serves the demo and the Ask panel returns SQL for "How many users are over 30?" on the seeded schema
- [ ] All cross-reference links resolve (no 404s when navigating from `README.md` → `docs/ask.md` → `docs/ask-backend-examples.md` → `examples/wasm/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)