### PR TITLE
docs: pre-release sweep — surface Phase 7 completion + MCP discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ A cross-platform Tauri 2.0 + Svelte 5 desktop GUI ships alongside the REPL (see 
 
 **From source** — `cd desktop && npm install && npm run tauri dev`. The header's New… / Open… / Save As… buttons cover the file lifecycle; the query editor has a live line-number gutter, `⌘/` (Ctrl+/) SQL comment toggle, and selection-aware Run (highlight a statement to run just that one).
 
+### MCP server (drive SQLRite from an LLM agent)
+
+`sqlrite-mcp` exposes a SQLRite database as a [Model Context Protocol](https://modelcontextprotocol.io/) stdio server. Spawn it from any MCP client (Claude Code, Cursor, `mcp-inspector`, …) and the agent gets seven tools — `list_tables`, `describe_table`, `query`, `execute`, `schema_dump`, `vector_search`, plus `ask` for natural-language → SQL — without any custom integration code.
+
+```sh
+cargo install sqlrite-mcp
+```
+
+Or grab a per-platform pre-built binary from the [latest release](https://github.com/joaoh82/rust_sqlite/releases/latest) (Linux x86_64/aarch64, macOS aarch64, Windows x86_64).
+
+Wire it into Claude Code (`~/.claude.json`):
+
+```json
+{
+  "mcpServers": {
+    "sqlrite": {
+      "command": "sqlrite-mcp",
+      "args": ["/absolute/path/to/your.sqlrite"],
+      "env": { "SQLRITE_LLM_API_KEY": "sk-ant-…" }
+    }
+  }
+}
+```
+
+`--read-only` opens the DB with a shared lock and hides the `execute` tool. Full docs + the other six tools' references in [`docs/mcp.md`](docs/mcp.md).
+
 ### Developer guide
 
 In-depth documentation lives under [`docs/`](docs/). Start at [`docs/_index.md`](docs/_index.md) — it navigates to:
@@ -100,10 +126,10 @@ Build and launch the REPL:
 cargo run
 ```
 
-You'll drop into a REPL connected to a transient in-memory database. On-disk persistence (`.open`, `.save`) is coming in Phase 2.
+You'll drop into a REPL connected to a transient in-memory database. Use `.open <path>` to switch to a file-backed database (auto-saves on every statement; see Meta commands).
 
 ```
-SQLRite - 0.1.0
+SQLRite
 Enter .exit to quit.
 Enter .help for usage hints.
 Connected to a transient in-memory database.
@@ -183,7 +209,7 @@ println!("Why: {}",          resp.explanation);
 
 **Defaults:** `claude-sonnet-4-6`, `max_tokens: 1024`, schema dump cached for 5 minutes via Anthropic prompt caching (configurable to 1h or off via `AskConfig::cache_ttl`). Bring your own API key — set `SQLRITE_LLM_API_KEY` or pass it on `AskConfig`.
 
-In the REPL: `.ask <question>`. From an open `Connection` (this section). Per-product wrappers — desktop "Ask" button, `conn.ask()` in the Python / Node / Go SDKs, MCP `ask` tool, WASM with a JS-callback shape so the API key never enters the browser — ship in **7g.3-7g.8** as follow-up sub-phases. See [`docs/phase-7-plan.md`](docs/phase-7-plan.md) §7g for the full surface plan.
+In the REPL: `.ask <question>`. From an open `Connection` (this section). Per-product wrappers shipped across **7g.3 – 7g.8**: the desktop "Ask…" composer, `conn.ask()` / `db.ask()` in the Python / Node / Go SDKs, the WASM SDK's split `db.askPrompt()` / `db.askParse()` shape (so the API key never enters the browser), and the MCP `ask` tool exposed by [`sqlrite-mcp`](docs/mcp.md) (so any LLM agent over MCP can call `ask` against your database directly). See [`docs/phase-7-plan.md`](docs/phase-7-plan.md) §7g for the full surface plan.
 
 For the canonical Ask reference covering every surface (REPL, desktop, Rust library, Python / Node / Go / WASM), env vars, defaults, prompt caching, and the security model — read [`docs/ask.md`](docs/ask.md). For copy-paste backend proxy templates the WASM SDK needs (Cloudflare Workers, Vercel Edge, Deno Deploy, Firebase, AWS Lambda, Express), see [`docs/ask-backend-examples.md`](docs/ask-backend-examples.md).
 
@@ -230,7 +256,7 @@ The project is staged in phases, each independently shippable. A finished phase 
 - [x] **Tauri 2.0 backend**: four commands (`open_database`, `list_tables`, `table_rows`, `execute_sql`) wrap the engine; results are tagged enums shipped to the UI via the JSON IPC bridge.
 - [x] **Svelte 5 frontend**: dark-themed three-pane layout — header with "Open…" file picker, sidebar with table list + schema, query editor with Cmd/Ctrl+Enter to run, result grid with sticky header.
 
-**Phase 4 — Durability and concurrency** *(in progress)*
+**Phase 4 — Durability and concurrency** *(done)*
 - [x] **4a — Exclusive file lock**: `Pager::open` / `::create` takes an OS advisory lock (`fs2::try_lock_exclusive`); a second process on the same file gets a clean "already in use" error. Lock releases automatically when the Pager drops.
 - [x] **4b — Write-Ahead Log (`<db>.sqlrite-wal`) file format + frame codec**: 32-byte WAL header (magic / version / page size / salt / checkpoint seq), 4112-byte frames carrying `(page_num, commit_page_count, salt, checksum, body)`. Rolling-sum checksum. Torn-write recovery: corrupt or partial trailing frames are silently truncated at the boundary. Standalone module; not wired yet.
 - [x] **4c — WAL-aware Pager**: `Pager::open` / `::create` now own both the main file and its `-wal` sidecar. Reads resolve `staged → wal_cache → on_disk` with a page-count bounds check; commits append a WAL frame per dirty page plus a final commit frame carrying the new page 0 (encoded header). The main file stays frozen between checkpoints — reopening replays the WAL and the decoded page-0 frame overrides the (stale) main-file header.
@@ -246,7 +272,7 @@ The project is staged in phases, each independently shippable. A finished phase 
 - [x] **5e — Go SDK**: new `sdk/go/` module at `github.com/joaoh82/rust_sqlite/sdk/go`; cgo-wired against `libsqlrite_c` from Phase 5b. Implements the full `database/sql/driver` surface so users get the standard-library experience (`sql.Open("sqlrite", path)`, `db.Query/Exec/Begin`, `rows.Scan(&id, &name)`). 9-test `go test` integration suite. `examples/go/hello.go` runs after `cargo build --release -p sqlrite-ffi`. Module publish landed in Phase 6i — `go get github.com/joaoh82/rust_sqlite/sdk/go@vX.Y.Z` resolves directly via VCS tag.
 - [ ] **5f — Rust crate polish** *(deferred — Phase 6c companion)*: crate metadata, docs.rs config, prep for `cargo publish`. Deferred to land alongside the actual publish workflow.
 - [x] **5g — WASM** build: new `sdk/wasm/` crate via `wasm-bindgen`; engine runs entirely in a browser tab. Feature-gated root crate (`cli` + `file-locks` optional, both default-on) so WASM disables fs2 / rustyline / clap / env_logger cleanly. `Database` class with `exec/query/columns/inTransaction`; rows as plain JS objects in projection order. ~1.8 MB wasm / ~500 KB gzipped. Three `wasm-pack` targets (web/bundler/nodejs). `examples/wasm/` ships a self-contained HTML SQL console.
-- [ ] Code examples for every language under `examples/{rust,python,nodejs,go,wasm}/`
+- [x] Code examples for every language under `examples/{rust,python,nodejs,go,wasm,c}/`
 
 **Phase 6 — Release engineering + CI/CD**
 Lockstep versioning — one dispatch bumps every product to the same `vX.Y.Z`. Two-workflow design: `release-pr.yml` opens a Release PR with the version bumps (human reviews + merges), then `release.yml` fires on merge to tag + publish everything. Trusted-publishing via OIDC for PyPI + npm (no long-lived tokens). Full plan: [`docs/release-plan.md`](docs/release-plan.md).
@@ -265,7 +291,7 @@ Lockstep versioning — one dispatch bumps every product to the same `vX.Y.Z`. T
 - [ ] macOS Apple Developer ID cert → `codesign` + `notarytool` in `tauri-action`
 - [ ] Windows code-signing cert → `signtool` in `tauri-action`
 
-**Phase 7 — AI-era extensions** *(in progress — full plan in [`docs/phase-7-plan.md`](docs/phase-7-plan.md))*
+**Phase 7 — AI-era extensions** *(7a–7h shipped; FTS deferred to Phase 8 — full plan in [`docs/phase-7-plan.md`](docs/phase-7-plan.md))*
 - [x] **7a — `VECTOR(N)` column type** *(v0.1.10)*: dense f32 vectors with bracket-array literal syntax (`[0.1, 0.2, ...]`); file format bumped to v4
 - [x] **7b — Distance functions** *(v0.1.11)*: `vec_distance_l2/cosine/dot` + `ORDER BY <expr> LIMIT k` so KNN queries work end-to-end
 - [x] **7c — Bounded-heap top-k optimization** *(v0.1.12)*

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -36,28 +36,29 @@ These documents go into the implementation of each subsystem.
 
 ## Project state
 
-As of April 2026, SQLRite has:
+As of May 2026, SQLRite has:
 
 - A working SQL engine (in-memory + on-disk with a real B-Tree per table + secondary indexes, Phases 0 – 3 complete)
 - WAL-backed persistence with crash-safe checkpointing, shared/exclusive lock modes, and real `BEGIN` / `COMMIT` / `ROLLBACK` transactions (Phase 4 complete)
 - A stable public Rust embedding API plus C FFI shim and SDKs for Python, Node.js, Go, and WASM (Phase 5 complete except the optional 5f crate-polish task)
 - A Tauri 2.0 + Svelte desktop app (Phase 2.5 complete)
-- A fully-automated release pipeline that ships every product to its registry on every release with one human action — Rust crate to crates.io (`sqlrite-engine`), Python wheels to PyPI (`sqlrite`), Node.js + WASM to npm (`@joaoh82/sqlrite` + `@joaoh82/sqlrite-wasm`), Go module via `sdk/go/v*` git tag, plus C FFI tarballs and unsigned desktop installers as GitHub Release assets (Phase 6 complete)
+- AI-era extensions across the product surface (Phase 7 complete except FTS): VECTOR columns + HNSW indexes (7a-7d), JSON columns (7e), the `ask()` natural-language → SQL family across the REPL / desktop / Rust / Python / Node / Go / WASM (7g.1-7g.7), and the [`sqlrite-mcp`](mcp.md) Model Context Protocol server with seven tools including `ask` (7h + 7g.8)
+- A fully-automated release pipeline that ships every product to its registry on every release with one human action — Rust engine + `sqlrite-ask` + `sqlrite-mcp` to crates.io, Python wheels to PyPI (`sqlrite`), Node.js + WASM to npm (`@joaoh82/sqlrite` + `@joaoh82/sqlrite-wasm`), Go module via `sdk/go/v*` git tag, plus C FFI tarballs, MCP binary tarballs, and unsigned desktop installers as GitHub Release assets (Phase 6 complete)
 
-The active frontier is **Phase 7 — AI-era extensions**.
+The active frontier is **Phase 8 — Full-text search + hybrid retrieval** (the deferred 7f scope).
 
 See the [Roadmap](roadmap.md) for the full phase plan.
 
 ## Release engineering
 
-- [Release plan](release-plan.md) — Phase 6 design doc: lockstep versioning, PR-based release flow, OIDC trusted publishing, the ten-file version-bump surface
+- [Release plan](release-plan.md) — Phase 6 design doc: lockstep versioning, PR-based release flow, OIDC trusted publishing, the version-bump surface
 - [Release secrets runbook](release-secrets.md) — one-time web-UI setup for crates.io, PyPI, npm, GitHub `release` environment, and `main` branch protection
 - [`scripts/`](../scripts/) — runnable tooling used by release workflows + reproducible locally (start with `scripts/bump-version.sh`)
 
 ## Future work
 
-- [Phase 7 plan](phase-7-plan.md) — AI-era extensions (vector column type + HNSW, JSON, NL→SQL `ask()` API across REPL/library/SDKs/desktop/MCP, MCP server). **Approved 2026-04-26**, implementation starts at sub-phase 7a.
-- Phase 8 — Full-text search (FTS5-style BM25) + hybrid retrieval, deferred from Phase 7 per the plan-doc's Q1.
+- [Phase 7 plan](phase-7-plan.md) — AI-era extensions (vector column type + HNSW, JSON, NL→SQL `ask()` API across REPL/library/SDKs/desktop/MCP, MCP server). **Implementation complete except 7f, which deferred to Phase 8.**
+- Phase 8 — Full-text search (FTS5-style BM25) + hybrid retrieval, deferred from Phase 7 per the plan-doc's Q1. **Active frontier as of May 2026.**
 
 ## Conventions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,20 +66,43 @@ A bird's-eye view of the system, with pointers into the code.
                      └───────────────────────────┘
 ```
 
-## Module map
+## Workspace layout
+
+The repo is a Cargo workspace. The engine is the root crate; everything else lives in a sibling directory.
+
+| Crate / directory | Role |
+|---|---|
+| Root (`./`) — `sqlrite-engine` on crates.io, `use sqlrite::…` in code | The engine. Library + the REPL `[[bin]]`. Library surface: `Connection`, `Statement`, `Rows`, `Value`, `Database`. |
+| [`sqlrite-ffi/`](../sqlrite-ffi/) | C FFI shim. Builds `libsqlrite_c.{so,dylib,dll}` + cbindgen-generated `sqlrite.h`. Used by the Go SDK + by anyone wanting to dlopen SQLRite from another language. Phase 5b. |
+| [`sqlrite-ask/`](../sqlrite-ask/) | Pure-Rust LLM transport adapter (Anthropic-first; OpenAI / Ollama follow-ups pending). Takes a `&str` schema dump + `&str` question, returns generated SQL. No engine dep — the engine integration lives in `sqlrite-engine`'s `ask` feature. Phase 7g.1 + the 7g.2 dep-direction flip. |
+| [`sqlrite-mcp/`](../sqlrite-mcp/) | Model Context Protocol server binary. Hand-rolled JSON-RPC 2.0 over stdio. Seven tools (`list_tables`, `describe_table`, `query`, `execute`, `schema_dump`, `vector_search`, `ask`). Phase 7h + 7g.8. See [`mcp.md`](mcp.md). |
+| [`sdk/python/`](../sdk/python/) | PyO3 bindings — `sqlrite` on PyPI. Phase 5c. |
+| [`sdk/nodejs/`](../sdk/nodejs/) | napi-rs bindings — `@joaoh82/sqlrite` on npm. Phase 5d. |
+| [`sdk/go/`](../sdk/go/) | cgo wrapper over `sqlrite-ffi`. `database/sql` driver. Phase 5e. |
+| [`sdk/wasm/`](../sdk/wasm/) | wasm-bindgen build — `@joaoh82/sqlrite-wasm` on npm. Phase 5g. *(Not a workspace member — wasm32 target only.)* |
+| [`desktop/src-tauri/`](../desktop/src-tauri/) | Tauri 2.0 + Svelte 5 desktop app. Embeds the engine directly. Phase 2.5. |
+
+The engine never depends on the SDK crates; the SDK crates each depend on the engine via path-dep. `sqlrite-mcp` depends on the engine (default-features = false) plus its own optional `ask` feature that re-enables the engine's `ask` feature, which pulls `sqlrite-ask` transitively. The whole graph is acyclic — see the 7g.2 dep-direction flip retrospective in [roadmap.md](roadmap.md) for the work that made it so.
+
+## Module map (engine)
 
 | Module | What it owns |
 |---|---|
 | [`src/main.rs`](../src/main.rs) | Binary entry: init env_logger, build rustyline editor, run the REPL loop, route input to either the meta or SQL dispatcher |
+| [`src/lib.rs`](../src/lib.rs) | Library entry: re-exports `Connection`, `Statement`, `Rows`, `Value`, `Database`, `process_command`, the `ask` module (when feature on), etc. — the stable public surface every SDK binds against |
+| [`src/connection.rs`](../src/connection.rs) | `Connection` / `Statement` / `Rows` / `Row` / `OwnedRow` / `FromValue` — the Phase 5a public API |
+| [`src/ask/`](../src/ask/) | Engine integration with `sqlrite-ask`: `ConnectionAskExt`, `ask_with_database`, the `schema::dump_schema_for_database` helper. The `schema` submodule is always available; the rest is gated behind the `ask` feature. Phase 7g.2. |
 | [`src/repl/`](../src/repl/) | `REPLHelper` (implements rustyline's `Helper` trait: completer, hinter, highlighter, validator). Also `get_config` and `get_command_type` |
-| [`src/meta_command/`](../src/meta_command/) | `MetaCommand` enum, parsing (`.open FOO.db` → `Open(PathBuf)`), and dispatch to persistence helpers |
+| [`src/meta_command/`](../src/meta_command/) | `MetaCommand` enum, parsing (`.open FOO.db` → `Open(PathBuf)`, `.ask <Q>` → `Ask(String)`), and dispatch to persistence + ask helpers |
 | [`src/error.rs`](../src/error.rs) | `SQLRiteError` (thiserror-derived), `Result<T>` alias, hand-rolled `PartialEq` that handles `io::Error` |
 | [`src/sql/mod.rs`](../src/sql/mod.rs) | `SQLCommand` classifier, `process_command` — the top-level entry that parses a SQL string and routes to the right executor. Also triggers auto-save. |
 | [`src/sql/parser/`](../src/sql/parser/) | Takes a `sqlparser::ast::Statement` and produces internal query structs (`CreateQuery`, `InsertQuery`, `SelectQuery`) with only the fields we actually use |
-| [`src/sql/executor.rs`](../src/sql/executor.rs) | `execute_select`, `execute_delete`, `execute_update`, plus the shared expression evaluator `eval_expr` / `eval_predicate` |
-| [`src/sql/db/database.rs`](../src/sql/db/database.rs) | `Database`: table map + optional `source_path` + optional long-lived `Pager` |
-| [`src/sql/db/table.rs`](../src/sql/db/table.rs) | `Table`, `Column`, `Row`, `Index` (in-memory storage); helpers for row iteration (`rowids`, `get_value`, `set_value`, `delete_row`, `insert_row`) |
-| [`src/sql/pager/`](../src/sql/pager/) | On-disk file format and I/O — see [file-format.md](file-format.md) and [pager.md](pager.md) for details |
+| [`src/sql/executor.rs`](../src/sql/executor.rs) | `execute_select`, `execute_delete`, `execute_update`, plus the shared expression evaluator `eval_expr` / `eval_predicate`. Also the bounded-heap top-k optimization (Phase 7c) and the HNSW probe shortcut (Phase 7d.2). |
+| [`src/sql/db/database.rs`](../src/sql/db/database.rs) | `Database`: table map + optional `source_path` + optional long-lived `Pager` + transaction-snapshot state |
+| [`src/sql/db/table.rs`](../src/sql/db/table.rs) | `Table`, `Column`, `Row`, `Value` (in-memory storage incl. VECTOR + JSON columns); helpers for row iteration (`rowids`, `get_value`, `set_value`, `delete_row`, `insert_row`) |
+| [`src/sql/hnsw.rs`](../src/sql/hnsw.rs) | Standalone HNSW algorithm — insert / search / layer assignment / beam search. Phase 7d.1. |
+| [`src/sql/json.rs`](../src/sql/json.rs) | JSON column type + path-extraction functions (`json_extract`, `json_type`, `json_array_length`, `json_object_keys`). Phase 7e. |
+| [`src/sql/pager/`](../src/sql/pager/) | On-disk file format and I/O — see [file-format.md](file-format.md) and [pager.md](pager.md) for details. WAL + checkpointer + shared/exclusive lock modes (Phase 4a-4e) live here. |
 
 ## Flow of a SQL statement
 
@@ -104,16 +127,18 @@ Steps 1–7 are purely in-memory; step 8 is the only disk contact, and after the
 - **Planning**: intentionally not a thing yet. Execution is direct — a query plan is implicit in the executor code path.
 - **Execution**: `src/sql/executor.rs` walks the internal structs, drives reads against `Table`, and writes via `Table::set_value` / `insert_row` / `delete_row`.
 - **Storage (in memory)**: `src/sql/db/table.rs` — column-oriented `BTreeMap<rowid, value>` per column; indexes as separate `BTreeMap`s on UNIQUE/PK columns.
-- **Storage (on disk)**: `src/sql/pager/` — 4 KiB pages. Currently every table serializes to a `bincode` blob laid across chained pages; a real B-Tree replaces this in Phase 3d.
-- **Persistence policy**: `src/sql/mod.rs::process_command` for when to auto-save; `src/sql/pager/mod.rs::save_database` for how.
+- **Storage (on disk)**: `src/sql/pager/` — 4 KiB pages, real B-Tree per table (Phase 3d), secondary indexes (3e), HNSW indexes as their own page tree (7d.3), WAL + crash-safe checkpointer (4c-4d), shared/exclusive lock modes (4e).
+- **Persistence policy**: `src/sql/mod.rs::process_command` for when to auto-save; `src/sql/pager/mod.rs::save_database` for how. Inside a `BEGIN`/`COMMIT` block, auto-save is suppressed and changes accumulate against an in-memory snapshot — `COMMIT` flushes the whole batch in one WAL frame; `ROLLBACK` restores the snapshot.
 - **Error handling**: `src/error.rs` defines a single `SQLRiteError` enum used throughout, with `#[from]` conversions from `ParserError` and `io::Error`.
 
 ## What's deliberately missing
 
-- No network layer — SQLRite is embedded only. Phase 5 will split into a `lib` crate with a Connection API.
-- No transactions — every statement implicitly commits. `BEGIN`/`COMMIT` are parsed by `sqlparser` but rejected by the executor.
-- No query optimizer — simple table scans.
-- No server process — no daemon, no wire protocol.
-- No concurrent access — single process, single thread. WAL + file locking is Phase 4.
+The roadmap has shipped far enough that the original "deliberately missing" list mostly turned into shipped features. What's still left:
 
-Most of these are on the [Roadmap](roadmap.md).
+- **No query optimizer** beyond the bounded-heap top-k pass for KNN (Phase 7c) and the HNSW probe shortcut (7d.2). Equality-on-PK probes are direct; everything else is a table scan.
+- **No joins.** `INNER` / `LEFT OUTER` / `CROSS` are parsed but rejected by the executor. On the "possible extras" list in [roadmap.md](roadmap.md).
+- **No aggregates.** `COUNT(*)` / `SUM` / `AVG` / `GROUP BY` aren't implemented yet — the parser accepts them but the executor errors. Phase 8 candidate alongside FTS.
+- **No network layer.** SQLRite is embedded-only. The closest thing is the [`sqlrite-mcp`](mcp.md) server, which is stdio (not network). A real wire protocol isn't on the roadmap.
+- **No streaming row cursor.** `Rows` is currently backed by an eager `Vec` (Phase 5a). The `Rows::next` API is shaped to support a real cursor — the swap is deferred to **5a.2**.
+
+Everything else from the original "deliberately missing" list (transactions, file locking, concurrency, embedding API, FFI, language SDKs, WASM, AI extensions) has shipped. See [roadmap.md](roadmap.md) for the full ledger.

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -186,7 +186,7 @@ No external store — just `$state` runes inside the component. For a single-win
 - **App icon** — a placeholder PNG; replace before bundling for distribution
 - **Error recovery after panic** — the Tauri app is a thin shell, so if the engine panics the whole window dies. The engine isn't supposed to panic on user input (Phase 1 made that a requirement), but a panic in the Tauri layer itself would take the app down.
 
-Most of the above are straightforward frontend additions. The bigger shift is the cursor API — see [Roadmap](roadmap.md) Phase 5.
+Most of the above are straightforward frontend additions. The bigger shift is the cursor API — see [Roadmap](roadmap.md) Phase 5a.2 (deferred — currently `Rows` materializes eagerly into a `Vec`).
 
 ## Multi-process behavior
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,11 +1,14 @@
 # Embedding the SQLRite engine
 
-SQLRite ships as a library that other programs can embed — the REPL and desktop app are just thin UIs over the same core. Phase 5 builds out the embedding surface:
+SQLRite ships as a library that other programs can embed — the REPL and desktop app are just thin UIs over the same core. Phase 5 built out the embedding surface across every reasonable runtime; Phase 7g/7h layered the natural-language `ask()` family + an MCP server on top.
 
-- **Phase 5a** — a stable public Rust API (`Connection` / `Statement` / `Rows` / `Row` / `Value`) plus structured row return. ✅ **Landed.**
-- **Phase 5b** — a C FFI shim (`libsqlrite.{so,dylib,dll}` + generated `sqlrite.h`) that every non-Rust SDK binds against.
-- **Phase 5c – 5f** — Python, Node.js, Go, Rust SDKs published to their respective registries.
-- **Phase 5g** — WASM build so the engine runs entirely in a browser tab.
+- ✅ **Phase 5a** — stable public Rust API (`Connection` / `Statement` / `Rows` / `Row` / `Value`) plus structured row return. Parameter binding + a streaming cursor abstraction are deferred to **5a.2**.
+- ✅ **Phase 5b** — C FFI shim (`libsqlrite_c.{so,dylib,dll}` + cbindgen-generated `sqlrite.h`) that every non-Rust SDK binds against.
+- ✅ **Phase 5c – 5e** — Python (PyO3 → PyPI), Node.js (napi-rs → npm), Go (cgo against the FFI shim → git tag) SDKs published to their respective registries.
+- ⏳ **Phase 5f** — Rust crate polish (deferred — Phase 6c shipped the actual crates.io publish; 5f's polish work folded into ongoing maintenance).
+- ✅ **Phase 5g** — WASM build (`@joaoh82/sqlrite-wasm` on npm) so the engine runs entirely in a browser tab.
+- ✅ **Phase 7g** — `ask()` natural-language → SQL family across every embedding surface — see [`ask.md`](ask.md).
+- ✅ **Phase 7h** — [`sqlrite-mcp`](mcp.md), a Model Context Protocol stdio server that wraps a database for LLM agents (Claude Code, Cursor, `mcp-inspector`, …) without any custom integration code on the LLM side. Sibling product to the SDKs, not a replacement — use the SDKs when *your* code drives the database, use the MCP server when an *LLM agent* drives it.
 
 See [roadmap.md](roadmap.md) for the detailed Phase 5 breakdown.
 
@@ -120,7 +123,7 @@ let _ = conn.execute(&resp.sql)?;
 
 **REPL surface** *(7g.2)*: type `.ask <question>` at the prompt. Prints generated SQL + rationale, asks `Run? [Y/n]`, executes through the same `process_command` pipeline as a typed statement on confirm. Requires `SQLRITE_LLM_API_KEY`.
 
-**Per-product wrappers ship in 7g.3-7g.8** — desktop "Ask" button, Python/Node/Go SDKs `conn.ask()`, WASM SDK with a JS-callback shape (so the API key stays out of the browser tab), and the MCP `ask` tool.
+**Per-product wrappers shipped across 7g.3 – 7g.8** — desktop "Ask…" composer, Python/Node/Go SDKs' `conn.ask()` / `db.ask()`, WASM SDK with the split JS-callback shape (so the API key stays out of the browser tab; see [`ask-backend-examples.md`](ask-backend-examples.md) for backend templates), and the MCP `ask` tool exposed by [`sqlrite-mcp`](mcp.md). [`ask.md`](ask.md) is the canonical reference covering all of them.
 
 ## The C FFI (Phase 5b)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ cargo run
 You'll land in an in-memory REPL:
 
 ```
-SQLRite - 0.1.0
+SQLRite
 Enter .exit to quit.
 Enter .help for usage hints.
 Connected to a transient in-memory database.
@@ -89,22 +89,35 @@ rust_sqlite/
 ├── rust-toolchain.toml     Pinned stable Rust + rustfmt + clippy
 ├── README.md               Project overview (what/why/how)
 ├── docs/                   Developer guide (you are here)
-├── src/
+├── src/                    Engine library + REPL binary
 │   ├── lib.rs              Library root — the public engine API
 │   ├── main.rs             Binary entry point, REPL loop
+│   ├── connection.rs       Phase 5a public API (Connection, Statement, Rows)
+│   ├── ask/                Engine integration with sqlrite-ask (Phase 7g.2)
 │   ├── error.rs            SQLRiteError enum
 │   ├── repl/               rustyline integration, input validation
-│   ├── meta_command/       Parsing + execution of .exit, .open, .save, .tables
+│   ├── meta_command/       Parsing + execution of .exit, .open, .save, .tables, .ask
 │   └── sql/
 │       ├── mod.rs          Top-level process_command dispatcher
 │       ├── parser/         sqlparser → internal SelectQuery / CreateQuery / InsertQuery
 │       ├── executor.rs     SELECT / UPDATE / DELETE / CREATE INDEX execution
-│       ├── db/             In-memory data model (Database, Table, Column, Row,
-│       │                   SecondaryIndex)
-│       └── pager/          On-disk paged file format + Pager cache
+│       ├── hnsw.rs         HNSW ANN algorithm (Phase 7d.1)
+│       ├── json.rs         JSON column type + path functions (Phase 7e)
+│       ├── db/             In-memory data model (Database, Table, Column, Row, Value)
+│       └── pager/          On-disk paged file format + Pager cache + WAL + checkpointer
+├── sqlrite-ffi/            C FFI shim — libsqlrite_c.{so,dylib,dll} + sqlrite.h
+├── sqlrite-ask/            Pure-Rust LLM transport adapter (Phase 7g.1)
+├── sqlrite-mcp/            Model Context Protocol server binary (Phase 7h)
+├── sdk/
+│   ├── python/             PyO3 bindings → `sqlrite` on PyPI
+│   ├── nodejs/             napi-rs bindings → `@joaoh82/sqlrite` on npm
+│   ├── go/                 cgo wrapper over sqlrite-ffi
+│   └── wasm/               wasm-bindgen build → `@joaoh82/sqlrite-wasm` on npm
 ├── desktop/                Tauri 2.0 desktop app (see docs/desktop.md)
 │   ├── src/                Svelte 5 UI
 │   └── src-tauri/          Tauri backend; pulls in the engine by path
+├── examples/               Runnable examples for every SDK + the WASM browser demo
+├── scripts/                Release tooling (start with bump-version.sh)
 └── samples/                Example SQL and reference ASTs
 ```
 

--- a/docs/phase-7-plan.md
+++ b/docs/phase-7-plan.md
@@ -1,6 +1,6 @@
 # Phase 7 — AI-era extensions: proposal + plan
 
-**Status:** *approved 2026-04-26 — implementation pending.* The 10 design questions (Q1–Q10) have been resolved by the project owner; see the **Decisions** section below for the canonical answers. Each per-sub-phase section reflects the chosen design. Implementation has not yet started — sub-phase 7a is the next branch to cut.
+**Status:** *approved 2026-04-26 — implementation complete except 7f (FTS5/BM25), which deferred to Phase 8 per Q1.* All ten design questions (Q1–Q10) were resolved by the project owner; see the **Decisions** section below for the canonical answers. The per-sub-phase narratives below are now retrospectives — each marked ✅ and dated to the version that shipped it. Phase 7 closed out the v0.1.x cycle with seven new product surfaces (`sqlrite-ask` crate, `sqlrite-mcp` server binary, the `ask()` family across REPL / desktop / Rust / Python / Node / Go / WASM, the MCP tools).
 
 **Audience:** primarily the project owner deciding what Phase 7 should be; secondarily future-self / contributors trying to understand the rationale once the decisions are made and code lands.
 
@@ -514,7 +514,11 @@ For clarity:
 
 1. ~~Project owner answers Q1–Q10.~~ ✅ done 2026-04-26.
 2. ~~Update this document with the chosen answers.~~ ✅ done in the same commit that records this status.
-3. Cut a branch for sub-phase **7a** (`feat/vector-column-type`).
-4. Implementation begins.
+3. ~~Cut a branch for sub-phase **7a** (`feat/vector-column-type`).~~ ✅ shipped in v0.1.10.
+4. ~~Implementation begins.~~ ✅ Phase 7 implementation ran from v0.1.10 (7a) through v0.1.25 (7h + 7g.8). Each sub-phase shipped as its own PR + release wave.
+5. **Phase 8** — return to the FTS5/BM25 work deferred per Q1, plus hybrid retrieval (vector + BM25 score fusion).
 
-If any of the sub-phases turn out scope-misjudged in the doing — too small, too large, missing a hidden complication — re-scope in this document and link a "scope correction" note. The plan is allowed to evolve; that's why it's written down.
+The "scope correction" provision of this doc was used twice:
+
+- **7d's HNSW ANN index** broke into three follow-up sub-phases (7d.1 algorithm, 7d.2 SQL integration, 7d.3 persistence) instead of one — the persistence layer was 2× the original LOC estimate, see the 7d retrospective in `docs/roadmap.md`.
+- **7g.2's REPL `.ask`** triggered the dep-direction flip retrospective documented in `docs/roadmap.md`. `sqlrite-ask` shed its engine dep entirely; the `Connection`/`Database` integration moved into `sqlrite-engine` itself behind a new `ask` feature. Public API surface unchanged for end users; the structural cleanup unblocked 7g.7's WASM build (no HTTP transport needed there) and made 7h's MCP server simpler.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,8 @@
 
 The project is staged in phases. Each phase is shippable on its own, ends with a working build + full test suite + a commit on `main`, and can be paused between. The README's roadmap section is a summary of this doc.
 
+> **Active frontier (May 2026):** Phase 8 — Full-text search (FTS5-style BM25) + hybrid retrieval. The deferred 7f scope. Phases 0 – 7 are shipped (Phase 7 except for the deferred FTS slice).
+
 ## ✅ Phase 0 — Modernization
 
 *Done (commit `ce3ddd4`).*
@@ -40,7 +42,7 @@ The engine could parse SQL but only execute CREATE and INSERT. Phase 1 finished 
 
 See [File format](file-format.md).
 
-## Phase 3 — On-disk B-Tree + auto-save pager *(in progress)*
+## ✅ Phase 3 — On-disk B-Tree + auto-save pager
 
 Split into sub-phases for manageable commits.
 
@@ -101,7 +103,7 @@ Real B-Tree per table, keyed by ROWID. Leaves stay in the Phase 3c cell format; 
 
 Build / run: `cd desktop && npm install && npm run tauri dev`. See [docs/desktop.md](../docs/desktop.md) for details.
 
-## Phase 4 — Durability + concurrency *(in progress)*
+## ✅ Phase 4 — Durability + concurrency
 
 ### ✅ Phase 4a — Exclusive file lock
 

--- a/docs/smoke-test.md
+++ b/docs/smoke-test.md
@@ -13,7 +13,7 @@ Before starting:
   cargo build --workspace
   cargo test --workspace
   ```
-  Current expected: 123 tests pass across lib + bin + doctests.
+  All tests should pass. (The exact count grows each phase — don't pin to a number.)
 
 - For the desktop section: Node 18+, a functional webview (macOS has it built in; Linux needs `webkit2gtk-4.1`; Windows needs Edge WebView2), and the Tauri prerequisites per [docs/desktop.md](desktop.md).
 
@@ -34,13 +34,15 @@ cargo run --quiet --bin sqlrite
 You should see:
 
 ```
-sqlrite - 0.1.0
+sqlrite
 Enter .exit to quit.
 Enter .help for usage hints.
 Connected to a transient in-memory database.
 Use '.open FILENAME' to reopen on a persistent database.
 sqlrite>
 ```
+
+(The version line in the banner tracks the current build — `cargo run` always shows the live value, so don't be surprised if it's later than what's printed here.)
 
 Also verify the help text is detailed:
 
@@ -557,7 +559,8 @@ In the terminal running `tauri dev`, press Ctrl+C.
 When you want a fast before/after comparison for a change, run this condensed checklist instead of the full walkthrough:
 
 - [ ] `cargo build --workspace` → clean, zero warnings
-- [ ] `cargo test --workspace` → 123 tests pass (123 was the count as of Phase 2.5; update when new tests land)
+- [ ] `cargo test --workspace` → all tests pass (don't pin to a specific count — it grows each phase)
+- [ ] `cargo run --bin sqlrite-mcp -- --help` prints the MCP server CLI without crashing — quick check that the stdio_redirect dance still works
 - [ ] `cargo run -- --help` prints the full description + meta-command table + SQL surface (not just `-h` / `-V`)
 - [ ] `cargo run -- somefile.sqlrite` on a non-existent path creates the file and enters the REPL with auto-save on
 - [ ] REPL launches, `.help` shows 5 commands
@@ -594,7 +597,7 @@ Mark the ones you haven't covered for the current change; revisit if any fail.
 
 **`.open` fails with `not a SQLRite database (bad magic bytes)`** on a file you just wrote. Likely cause: the file was written by an older format version (pre-Phase-3e). Delete and recreate.
 
-**`.open` fails with `unsupported SQLRite format version N`**. The current code expects format version `3` (Phase 3e). Older / newer files produce this error. If you hit it on a file from *this* build, the format constant and the file's bytes have desynced — rerun `cargo build` and `.open` again.
+**`.open` fails with `unsupported SQLRite format version N`**. The current code expects format version `4` (bumped in Phase 7a for VECTOR support). Older / newer files produce this error. If you hit it on a file from *this* build, the format constant and the file's bytes have desynced — rerun `cargo build` and `.open` again.
 
 **`cargo run --bin sqlrite` fails to find the binary.** Since Phase 2.5.1 the binary name is `sqlrite`, not `SQLRite`. Passing `--bin sqlrite` is only necessary in the workspace context; `cargo run` alone also defaults to the REPL.
 

--- a/docs/supported-sql.md
+++ b/docs/supported-sql.md
@@ -81,6 +81,19 @@ sqlrite_autoindex_<table>_<column>
 
 These are full-citizen indexes — they're visible via `.tables`-adjacent catalog queries (once those land), persist across saves, and accelerate equality probes. You don't need to `CREATE INDEX` them yourself.
 
+### HNSW indexes (Phase 7d)
+
+```sql
+CREATE INDEX <name> ON <table> USING hnsw (<vector_column>);
+```
+
+Builds an [HNSW](https://arxiv.org/abs/1603.09320) approximate-nearest-neighbor index over a `VECTOR(N)` column. The query optimizer recognizes `ORDER BY vec_distance_l2(col, literal) LIMIT k` (or the cosine / dot variants) on an HNSW-indexed column and probes the graph instead of full-scanning.
+
+- Recall@10 ≥ 0.95 at default parameters (`M=16`, `ef_construction=200`, `ef_search=50`). Parameters aren't tunable from SQL yet — see Q2 of [`docs/phase-7-plan.md`](phase-7-plan.md).
+- The index is built incrementally on `INSERT`. `DELETE` / `UPDATE` mark the index `needs_rebuild`; the next save rebuilds from current rows.
+- Persisted as a `KIND_HNSW` cell tree alongside the regular page hierarchy — open path loads the graph bit-for-bit, no algorithm runs.
+- Without an HNSW index, the same `ORDER BY vec_distance_… LIMIT k` query still works — it just brute-force-scans every row (Phase 7c's bounded-heap top-k optimization keeps the memory footprint to O(k)).
+
 ---
 
 ## `INSERT INTO`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,4 +69,4 @@ while let Some(row) = rows.next()? {
 }
 ```
 
-See [Embedding the SQLRite engine](embedding.md) for the full API reference, and [`examples/`](../examples/) for runnable samples (`cargo run --example quickstart` walks through the basics end-to-end). Language SDKs for Python, Node.js, Go, and WASM land in Phases 5b – 5g.
+See [Embedding the SQLRite engine](embedding.md) for the full API reference, and [`examples/`](../examples/) for runnable samples (`cargo run --example quickstart` walks through the basics end-to-end). Language SDKs shipped across Phases 5b – 5g — Python (PyPI: `sqlrite`), Node.js (npm: `@joaoh82/sqlrite`), Go (`github.com/joaoh82/rust_sqlite/sdk/go`), WASM (npm: `@joaoh82/sqlrite-wasm`). For LLM-agent-driven access, the [`sqlrite-mcp`](mcp.md) MCP server (Phase 7h) wraps the same engine over stdio.

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ Phase 5 lands these incrementally — each sub-phase fills in one language. The 
 | Node.js  | ✅ Phase 5d       | npm as `@joaoh82/sqlrite` (Phase 6g) | [`nodejs/`](nodejs/) |
 | Go       | ✅ Phase 5e       | Go modules (Phase 6i) | [`go/`](go/)         |
 | WASM     | ✅ Phase 5g       | npm as `@joaoh82/sqlrite-wasm` (Phase 6h) | [`wasm/`](wasm/)     |
+| MCP      | ✅ Phase 7h       | crates.io as `sqlrite-mcp` + per-platform binary tarballs | *(no `examples/` subdir — see [`docs/mcp.md`](../docs/mcp.md) for the full quickstart with Claude Code / Cursor / `mcp-inspector` wiring snippets)* |
 
 See [docs/roadmap.md](../docs/roadmap.md) for what each sub-phase delivers.
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -239,6 +239,10 @@ cargo build --release -p sqlrite-ffi   # one-time
 cd sdk/go && go test -v ./...
 ```
 
+## Sibling products
+
+This SDK is for when *your code* drives the database. If you want an *LLM agent* to drive a SQLRite database directly, install the [`sqlrite-mcp`](../../docs/mcp.md) Model Context Protocol server (`cargo install sqlrite-mcp`) and wire it into Claude Code / Cursor / `mcp-inspector` / any MCP-aware client. Same engine underneath.
+
 ## Status
 
 Phase 5e MVP: ✅ — CRUD, transactions, file-backed + read-only, `QueryRow`/`Scan` round-trip, `database/sql`'s context-aware interfaces, error surfacing through the driver layer. Parameter binding, prepared-plan caching, and `LastInsertId`/`RowsAffected` tracking land with the engine-level 5a.2 cursor work.

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -230,6 +230,10 @@ npm run build
 npm test                # uses node --test (Node 18+'s built-in runner)
 ```
 
+## Sibling products
+
+This SDK is for when *your code* drives the database. If you want an *LLM agent* to drive a SQLRite database directly, install the [`sqlrite-mcp`](../../docs/mcp.md) Model Context Protocol server (`cargo install sqlrite-mcp`) and wire it into Claude Code / Cursor / `mcp-inspector` / any MCP-aware client. Same engine underneath.
+
 ## Status
 
 Phase 5d MVP: ✅ — CRUD, transactions, read-only mode, error handling, statement preparation, `columns()` introspection, typed columns back as JS primitives / objects. Parameter binding, prepared-plan caching, `changes`/`lastInsertRowid` tracking, and a real lazy iterator are natural follow-ups once the engine's cursor abstraction lands (5a.2).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -218,6 +218,10 @@ python -m pytest tests/
 - maturin as the build backend, emitting standard `.whl` files that pip can install directly.
 - Phase 6f's CI publishes abi3-py38 wheels to PyPI for manylinux x86_64/aarch64, macOS aarch64, and Windows x86_64 (plus an sdist) on every release. OIDC trusted publishing — no long-lived PyPI token in the repo.
 
+## Sibling products
+
+This SDK is for when *your code* drives the database. If you want an *LLM agent* to drive a SQLRite database directly, install the [`sqlrite-mcp`](../../docs/mcp.md) Model Context Protocol server (`cargo install sqlrite-mcp`) and wire it into Claude Code / Cursor / `mcp-inspector` / any MCP-aware client. Same engine underneath.
+
 ## Status
 
 Phase 5c MVP: ✅ — basic CRUD, transactions, context managers, read-only mode, iteration. Parameter binding, CursorRow namedtuples, and type converters (datetime, Decimal) are natural follow-ups.

--- a/sdk/wasm/README.md
+++ b/sdk/wasm/README.md
@@ -240,6 +240,10 @@ The wasm gzips to ~500 KB; browsers serve it compressed.
 - Release profile uses `opt-level = "z"` + LTO + `codegen-units = 1` + symbol stripping — wasm binary size is the main cost center on the wire.
 - Rows are marshalled to JS via `serde_wasm_bindgen` with `serialize_maps_as_objects(true)` (so each row is a plain JS `Object`, not a `Map`) and `serde_json`'s `preserve_order` feature (so column keys come across in projection order, not alphabetical).
 
+## Sibling products
+
+The WASM SDK is browser-only. For LLM-agent-driven *server-side* access to SQLRite, install the [`sqlrite-mcp`](../../docs/mcp.md) Model Context Protocol server (`cargo install sqlrite-mcp`) and wire it into Claude Code / Cursor / `mcp-inspector` / any MCP-aware client. Same engine underneath.
+
 ## Status
 
 Phase 5g MVP: ✅ — in-memory CRUD, transactions, columns(), panic hook, serialization behavior matches the Node.js SDK. OPFS-backed persistence, prepared-statement objects, and parameter binding are natural follow-ups.

--- a/sqlrite-ask/Cargo.toml
+++ b/sqlrite-ask/Cargo.toml
@@ -17,6 +17,9 @@ rust-version = "1.85"
 description = "Natural-language → SQL adapter for sqlrite-engine. Anthropic-first; OpenAI / Ollama follow-ups."
 repository = "https://github.com/joaoh82/rust_sqlite"
 license = "MIT"
+readme = "README.md"
+keywords = ["sqlrite", "llm", "anthropic", "ai", "sql"]
+categories = ["database", "api-bindings"]
 
 [lib]
 name = "sqlrite_ask"

--- a/sqlrite-ask/README.md
+++ b/sqlrite-ask/README.md
@@ -1,0 +1,88 @@
+# `sqlrite-ask`
+
+Natural-language → SQL adapter for [SQLRite](https://github.com/joaoh82/rust_sqlite). Pure-Rust LLM transport (Anthropic-first; OpenAI / Ollama bindings on the roadmap), no async runtime, no third-party LLM SDK — built directly on `ureq` + `serde_json`. Phase 7g.1 of the project.
+
+## What it does
+
+Given a `&str` schema dump (a sequence of `CREATE TABLE` statements) plus a `&str` question, returns the generated SQL plus a one-sentence explanation:
+
+```rust
+use sqlrite_ask::{ask_with_schema, AskConfig};
+
+let schema = "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);";
+let cfg = AskConfig::from_env()?;        // reads SQLRITE_LLM_API_KEY etc.
+let resp = ask_with_schema(schema, "How many users are over 30?", &cfg)?;
+
+println!("SQL:         {}", resp.sql);
+println!("Explanation: {}", resp.explanation);
+println!("Cache hit:   {} input tokens", resp.usage.cache_read_input_tokens);
+```
+
+The crate is **pure** — it doesn't know about `Connection`, `Database`, or any engine type. The schema-dump-aware integration with the engine lives in the `sqlrite-engine` crate's `ask` feature instead. See the **Most users want** section below for which entry point to reach for.
+
+## Most users want…
+
+This crate is the LLM transport layer. **Most callers don't need to use it directly** — the engine's `ask` feature wraps it in an ergonomic `Connection::ask` extension trait that introspects the schema for you:
+
+```toml
+[dependencies]
+sqlrite-engine = "0.1"
+# `sqlrite-engine`'s `ask` feature is on by default, which pulls
+# `sqlrite-ask` transitively. You don't usually need to depend on
+# this crate directly.
+```
+
+```rust
+use sqlrite::{Connection, ConnectionAskExt};
+use sqlrite::ask::AskConfig;
+
+let conn = Connection::open("foo.sqlrite")?;
+let cfg  = AskConfig::from_env()?;
+let resp = conn.ask("How many users are over 30?", &cfg)?;
+```
+
+Reach for `sqlrite-ask` directly only if:
+
+- You want to build the schema dump yourself (custom introspection, schema generation, schema fragments) and call `ask_with_schema` over a `&str`.
+- You're targeting a runtime where `sqlrite-engine` won't compile (e.g. wasm32, where the WASM SDK uses `sqlrite-ask` with `default-features = false` to skip the `ureq` HTTP transport).
+- You want to plug a custom `Provider` impl in via `ask_with_schema_and_provider` for testing / proxying / non-Anthropic backends.
+
+## Configuration
+
+Three layers of precedence: per-call argument > `AskConfig::from_env()` > defaults. Env vars:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SQLRITE_LLM_PROVIDER` | `anthropic` | Provider |
+| `SQLRITE_LLM_API_KEY` | *(none)* | Provider API key (required for any LLM call) |
+| `SQLRITE_LLM_MODEL` | `claude-sonnet-4-6` | Model ID |
+| `SQLRITE_LLM_MAX_TOKENS` | `1024` | Per-call max output tokens |
+| `SQLRITE_LLM_CACHE_TTL` | `5m` | Anthropic prompt-cache TTL on the schema dump (`5m`, `1h`, `off`) |
+
+`AskConfig`'s `Debug` impl deliberately omits the API key value — printing the config in logs / debuggers won't leak the secret.
+
+Full reference for the env vars + the per-surface usage notes lives in the project's [`docs/ask.md`](https://github.com/joaoh82/rust_sqlite/blob/main/docs/ask.md).
+
+## Features
+
+- `default = ["http"]` — pulls `ureq` + `rustls` for the HTTP transport.
+- `http` — the Anthropic provider that POSTs to `api.anthropic.com/v1/messages`.
+
+For wasm32 builds, depend on this crate with `default-features = false` to keep just the prompt-construction + response-parsing helpers (`AskConfig`, `AskResponse`, `parse_response`, `ask_with_schema_and_provider<P: Provider>`) without dragging in the HTTP transport. The WASM SDK does this — see the [WASM SDK README](https://github.com/joaoh82/rust_sqlite/blob/main/sdk/wasm/README.md#natural-language--sql-phase-7g7) for the JS-callback shape it uses instead.
+
+## Architecture notes
+
+- **Hand-rolled JSON request/response shapes** in `serde_json` — there is no official Anthropic Rust SDK and rolling our own matches the project's "build it ourselves" theme. ~120 LOC of types vs ~400 LOC + a tokio runtime via a third-party SDK.
+- **Sync `ureq` over async `reqwest`** — per `ask()` call we make exactly one POST. The sync surface is the right fit and avoids pulling tokio into every embedder. (rejected `reqwest::blocking` because it pulls tokio in even on the blocking path.)
+- **Schema dump is byte-stable** — alphabetically sorted, deterministic column ordering — so the prompt's `cache_control: ephemeral` block reliably hits Anthropic's prompt cache on repeat asks.
+- **Tolerant response parsing** — accepts strict JSON, fenced JSON (` ```json … ``` `), and JSON-with-leading-prose. Real LLM output drifts even with strict instructions; the parser is forgiving so the caller doesn't have to be.
+- **No engine dep** — `sqlrite-ask` 0.1.18 had a `sqlrite-engine` path-dep that created a cargo cycle (`sqlrite-engine[bin] → sqlrite-ask → sqlrite-engine[lib]`). Dropped in 0.1.19; the engine integration moved into `sqlrite-engine`'s new `ask` feature. See the **v0.1.19 dep-direction flip retrospective** in [`docs/roadmap.md`](https://github.com/joaoh82/rust_sqlite/blob/main/docs/roadmap.md).
+
+## Sibling products
+
+- The [`sqlrite-mcp`](https://github.com/joaoh82/rust_sqlite/blob/main/docs/mcp.md) Model Context Protocol server exposes `ask` as a tool any MCP client (Claude Code, Cursor, `mcp-inspector`) can call. Phase 7g.8.
+- Per-language SDKs (`sqlrite` on PyPI, `@joaoh82/sqlrite` on npm, `github.com/joaoh82/rust_sqlite/sdk/go`, `@joaoh82/sqlrite-wasm` on npm) all expose the `ask()` family in idiomatic shapes — see [`docs/ask.md`](https://github.com/joaoh82/rust_sqlite/blob/main/docs/ask.md) for the per-SDK reference.
+
+## License
+
+MIT. Same as the rest of the project.


### PR DESCRIPTION
## Summary

Pre-release documentation audit ahead of v0.1.25 (which ships `sqlrite-mcp` to crates.io for the first time). Two themes:

1. **Phase 7 status drift.** Phase 7 is now feature-complete except for the deferred FTS slice — but a lot of docs still said "in progress" / "implementation pending" / "ships in 7g.X-7g.Y". Flipped them all to past tense.
2. **MCP discoverability.** `sqlrite-mcp` was only mentioned in its own README + the new `docs/mcp.md`. Anyone landing on the root README, an SDK README, or `docs/embedding.md` had no idea it existed. Added a one-line "Sibling products" cross-ref everywhere with the framing *"use SDKs when YOUR code drives the DB; use MCP when an LLM AGENT drives it."*

## What changed

- **Root `README.md`** — flipped Phase 4 / Phase 7 status markers; added a full "MCP server" install section with `cargo install sqlrite-mcp` + a Claude Code config snippet; rewrote the "Per-product wrappers ship in 7g.3-7g.8" claim into past tense including the MCP `ask` tool; flipped the "examples for every language" checkbox; dropped the stale `0.1.0` REPL banner literal.
- **`docs/_index.md`** — refreshed Project state with Phase 7 achievements; flipped active frontier to Phase 8; bumped May 2026.
- **`docs/roadmap.md`** — added an "Active frontier (May 2026)" callout up top; dropped "(in progress)" from Phase 3 and Phase 4 headings.
- **`docs/phase-7-plan.md`** — flipped status to "complete except 7f"; rewrote "Next steps" as a retrospective.
- **`docs/embedding.md`** — Phase 5b-5g rewritten in past tense; added 7g + 7h bullets.
- **`docs/architecture.md`** — added a Workspace layout table covering every crate (engine, ffi, ask, mcp, four SDKs, desktop); refreshed the engine module map (`connection.rs`, `ask/`, `hnsw.rs`, `json.rs`); rewrote the stale "What's deliberately missing" section.
- **`docs/supported-sql.md`** — added an HNSW indexes subsection under CREATE INDEX with the `USING hnsw` syntax + recall@10 default.
- **`docs/smoke-test.md`** — dropped stale "123 tests pass" pin; added a `cargo run --bin sqlrite-mcp -- --help` smoke step (catches stdio_redirect regressions); updated format-version note (3 → 4).
- **`docs/getting-started.md`** — refreshed repo-tree map to include all current workspace dirs + new engine modules; dropped `0.1.0` literal.
- **`docs/usage.md`** + **`docs/desktop.md`** — small tense fixes; MCP cross-ref.
- **`sdk/{python,nodejs,go,wasm}/README.md`** — added "Sibling products" cross-refs to `sqlrite-mcp`.
- **`sqlrite-ask/README.md`** — NEW. The crate had no README; crates.io would render only the Cargo.toml description. Now has install snippet, "most users want the engine's `ask` feature instead", env-var config table, features, architecture notes, sibling products. `Cargo.toml` gets `readme` + `keywords` + `categories` fields for crates.io discoverability.
- **`examples/README.md`** — added an MCP row pointing at `docs/mcp.md`.

No code changes. No new tests.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-desktop` — all green (~340 tests across engine + sqlrite-mcp + sqlrite-ask + sqlrite-ffi)
- [ ] **Visual review on GitHub** that the new "MCP server" section in the root README renders cleanly above the "Developer guide" section
- [ ] **Visual review** that `sqlrite-ask/README.md` will render as expected once published to crates.io (no broken inline links)

## Out of scope (intentional)

The audit also flagged some deeper rewrites that I left for follow-up PRs because they're architectural rather than just stale-text:

- `docs/storage-model.md` — the upper sections still describe the pre-Phase-3e per-Column `Index` shape. Needs a real rewrite, not a touch-up.
- `docs/pager.md` — the "Staging writes" code sample uses the pre-3c bincode-blob path. Same.
- `docs/sql-engine.md` — dispatcher table doesn't include transaction statements; no mention of CreateIndex, JSON funcs, or vec funcs.
- `docs/design-decisions.md` — stops at Phase 6; doesn't capture the Phase 7 architectural choices (sqlrite-ask split + dep-direction flip; MCP stdio fd-redirect trick).

These would be a separate "internals doc refresh" PR — not blocking the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)