### PR TITLE
feat(fts): 8a — standalone algorithms (tokenizer + BM25 + posting list)

### DIFF
--- a/src/sql/fts/bm25.rs
+++ b/src/sql/fts/bm25.rs
@@ -1,0 +1,302 @@
+//! BM25 relevance scoring — the standard ranking function for keyword
+//! retrieval. Pure math; no SQL coupling.
+//!
+//! Resolves Phase 8 plan Q4 + Q5: no stemming and no stop-list. The
+//! caller is responsible for tokenizing both the query and the document
+//! (see [`super::tokenizer::tokenize`]); this module just consumes term
+//! frequencies + corpus stats and produces a score.
+//!
+//! ## Formula (Robertson/Spärck Jones BM25)
+//!
+//! For a document `d` and query `q`:
+//!
+//! ```text
+//! score(d, q) = Σ_{t ∈ q} idf(t) · (tf(t,d) · (k1 + 1)) /
+//!                                  (tf(t,d) + k1 · (1 - b + b · |d| / avgdl))
+//!
+//! idf(t) = ln(1 + (N - n(t) + 0.5) / (n(t) + 0.5))
+//! ```
+//!
+//! - `N`        = total documents in corpus
+//! - `n(t)`     = number of documents containing term `t`
+//! - `tf(t,d)`  = frequency of `t` in `d`
+//! - `|d|`      = length of `d` in tokens
+//! - `avgdl`    = average document length across the corpus
+//! - `k1`, `b`  = tuning constants (Q4 — fixed at SQLite FTS5 defaults)
+//!
+//! The `+ 1` inside the IDF log keeps the term non-negative even when
+//! `n(t) > N/2`, which would otherwise give the classic BM25 negative
+//! IDF and require clipping. This is the "BM25+" / Lucene variant.
+
+use std::collections::HashMap;
+
+/// Tuning parameters for BM25. Per Phase 8 Q4 the public surface still
+/// exposes these as a struct so we can grow per-call overrides later
+/// without breaking signatures, but the [`Bm25Params::default()`] values
+/// (`k1 = 1.5`, `b = 0.75`) are fixed for the MVP and match SQLite FTS5.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Bm25Params {
+    /// Term-frequency saturation. Higher → less aggressive saturation
+    /// (each additional occurrence keeps adding to the score). Typical
+    /// range is `[1.2, 2.0]`; SQLite FTS5 ships `1.5`.
+    pub k1: f64,
+    /// Length-normalization weight. `0.0` → no length normalization,
+    /// `1.0` → fully proportional. SQLite FTS5 ships `0.75`.
+    pub b: f64,
+}
+
+impl Default for Bm25Params {
+    fn default() -> Self {
+        Self { k1: 1.5, b: 0.75 }
+    }
+}
+
+/// Compute the BM25 score for a single (document, query) pair.
+///
+/// - `query_terms` is the pre-tokenized query. Duplicate tokens are
+///   summed naturally — if the user typed `"rust rust db"`, the `rust`
+///   contribution gets counted twice, matching the standard formulation.
+/// - `term_freq` maps each *unique* term in the document to its
+///   frequency within that document. The caller can build this from
+///   [`super::tokenizer::tokenize`] output.
+/// - `n_docs_with` is the corpus statistic — for each term, how many
+///   distinct documents contain it. Only entries for query terms are
+///   read; extra entries are ignored.
+/// - Returns `0.0` for the empty query, the empty corpus
+///   (`total_docs == 0`), or a document whose terms don't intersect the
+///   query.
+pub fn score(
+    query_terms: &[String],
+    term_freq: &HashMap<String, u32>,
+    doc_len: u32,
+    avg_doc_len: f64,
+    n_docs_with: &HashMap<String, u32>,
+    total_docs: u32,
+    params: &Bm25Params,
+) -> f64 {
+    if query_terms.is_empty() || total_docs == 0 {
+        return 0.0;
+    }
+
+    let n = total_docs as f64;
+    let dl = doc_len as f64;
+    // avgdl == 0 only if every doc is empty; guard the division.
+    let length_norm = if avg_doc_len > 0.0 {
+        params.b * (dl / avg_doc_len)
+    } else {
+        0.0
+    };
+    let denom_base = params.k1 * (1.0 - params.b + length_norm);
+
+    let mut total = 0.0;
+    for term in query_terms {
+        let tf = term_freq.get(term).copied().unwrap_or(0) as f64;
+        if tf == 0.0 {
+            continue;
+        }
+        let n_t = n_docs_with.get(term).copied().unwrap_or(0) as f64;
+        // BM25+ IDF: ln(1 + (N - n_t + 0.5) / (n_t + 0.5))
+        let idf = (1.0 + (n - n_t + 0.5) / (n_t + 0.5)).ln();
+        let numerator = tf * (params.k1 + 1.0);
+        let denominator = tf + denom_base;
+        total += idf * (numerator / denominator);
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p() -> Bm25Params {
+        Bm25Params::default()
+    }
+
+    fn tf(pairs: &[(&str, u32)]) -> HashMap<String, u32> {
+        pairs.iter().map(|(k, v)| ((*k).to_string(), *v)).collect()
+    }
+
+    #[test]
+    fn empty_query_or_corpus_returns_zero() {
+        assert_eq!(score(&[], &tf(&[]), 0, 0.0, &tf(&[]), 0, &p()), 0.0);
+        let q = vec!["rust".to_string()];
+        assert_eq!(
+            score(
+                &q,
+                &tf(&[("rust", 3)]),
+                10,
+                10.0,
+                &tf(&[("rust", 1)]),
+                0,
+                &p()
+            ),
+            0.0
+        );
+    }
+
+    #[test]
+    fn zero_term_freq_yields_zero_score() {
+        let q = vec!["rust".to_string()];
+        let s = score(
+            &q,
+            &tf(&[("python", 5)]),
+            10,
+            10.0,
+            &tf(&[("rust", 1), ("python", 1)]),
+            5,
+            &p(),
+        );
+        assert_eq!(s, 0.0);
+    }
+
+    #[test]
+    fn higher_tf_strictly_higher_score_at_fixed_length() {
+        let q = vec!["rust".to_string()];
+        let n_docs_with = tf(&[("rust", 2)]);
+        let s_low = score(&q, &tf(&[("rust", 1)]), 10, 10.0, &n_docs_with, 100, &p());
+        let s_hi = score(&q, &tf(&[("rust", 5)]), 10, 10.0, &n_docs_with, 100, &p());
+        assert!(s_hi > s_low, "tf=5 ({}) should beat tf=1 ({})", s_hi, s_low);
+    }
+
+    #[test]
+    fn longer_doc_scores_lower_at_same_tf() {
+        // Same term-frequency, longer document → length normalization
+        // (b > 0) drags the score down.
+        let q = vec!["rust".to_string()];
+        let n_docs_with = tf(&[("rust", 2)]);
+        let s_short = score(&q, &tf(&[("rust", 3)]), 10, 50.0, &n_docs_with, 100, &p());
+        let s_long = score(&q, &tf(&[("rust", 3)]), 200, 50.0, &n_docs_with, 100, &p());
+        assert!(
+            s_short > s_long,
+            "short ({}) should beat long ({}) at same tf",
+            s_short,
+            s_long
+        );
+    }
+
+    #[test]
+    fn rare_term_dominates_common_term() {
+        // "the" appears in every doc (n_t == N) → IDF ≈ 0.4 (positive but
+        // small, BM25+ doesn't go negative). "quasar" appears in 1 doc →
+        // IDF much larger. Same TF + length, the rare term wins.
+        let q_common = vec!["the".to_string()];
+        let q_rare = vec!["quasar".to_string()];
+        let n_docs_with = tf(&[("the", 1000), ("quasar", 1)]);
+        let s_common = score(
+            &q_common,
+            &tf(&[("the", 2)]),
+            20,
+            20.0,
+            &n_docs_with,
+            1000,
+            &p(),
+        );
+        let s_rare = score(
+            &q_rare,
+            &tf(&[("quasar", 2)]),
+            20,
+            20.0,
+            &n_docs_with,
+            1000,
+            &p(),
+        );
+        assert!(
+            s_rare > s_common * 5.0,
+            "rare term ({}) should dominate common term ({})",
+            s_rare,
+            s_common
+        );
+    }
+
+    #[test]
+    fn hand_computed_reference_three_doc_corpus() {
+        // 3-doc corpus, query = ["rust"]:
+        //   doc1: "rust rust db"      tf=2, len=3
+        //   doc2: "rust db lang"      tf=1, len=3
+        //   doc3: "python db tool"    tf=0, len=3
+        // n("rust") = 2, N = 3, avgdl = 3.0, k1=1.5, b=0.75
+        //
+        //   length_norm  = 0.75 * (3 / 3) = 0.75
+        //   denom_base   = 1.5 * (1 - 0.75 + 0.75) = 1.5
+        //   idf("rust")  = ln(1 + (3 - 2 + 0.5) / (2 + 0.5))
+        //                = ln(1 + 1.5/2.5) = ln(1.6) = 0.47000362924...
+        //
+        //   doc1: 0.47000362924... * (2 * 2.5) / (2 + 1.5)
+        //       = 0.47000362924... * 5 / 3.5
+        //       = 0.67143375606...
+        //   doc2: 0.47000362924... * (1 * 2.5) / (1 + 1.5)
+        //       = 0.47000362924... * 2.5 / 2.5
+        //       = 0.47000362924...
+        //   doc3: 0.0 (no rust)
+        let q = vec!["rust".to_string()];
+        let n_docs_with = tf(&[
+            ("rust", 2),
+            ("db", 3),
+            ("lang", 1),
+            ("python", 1),
+            ("tool", 1),
+        ]);
+        let avgdl = 3.0;
+        let s1 = score(
+            &q,
+            &tf(&[("rust", 2), ("db", 1)]),
+            3,
+            avgdl,
+            &n_docs_with,
+            3,
+            &p(),
+        );
+        let s2 = score(
+            &q,
+            &tf(&[("rust", 1), ("db", 1), ("lang", 1)]),
+            3,
+            avgdl,
+            &n_docs_with,
+            3,
+            &p(),
+        );
+        let s3 = score(
+            &q,
+            &tf(&[("python", 1), ("db", 1), ("tool", 1)]),
+            3,
+            avgdl,
+            &n_docs_with,
+            3,
+            &p(),
+        );
+
+        let idf = (1.0_f64 + (3.0 - 2.0 + 0.5) / (2.0 + 0.5)).ln();
+        let expected_s1 = idf * (2.0 * (1.5 + 1.0)) / (2.0 + 1.5);
+        let expected_s2 = idf * (1.0 * (1.5 + 1.0)) / (1.0 + 1.5);
+        let tol = f64::EPSILON * 16.0;
+        assert!(
+            (s1 - expected_s1).abs() < tol,
+            "doc1 score {} vs expected {}",
+            s1,
+            expected_s1
+        );
+        assert!(
+            (s2 - expected_s2).abs() < tol,
+            "doc2 score {} vs expected {}",
+            s2,
+            expected_s2
+        );
+        assert_eq!(s3, 0.0);
+        assert!(s1 > s2, "doc1 (tf=2) should outrank doc2 (tf=1)");
+    }
+
+    #[test]
+    fn duplicate_query_tokens_compound() {
+        let q_one = vec!["rust".to_string()];
+        let q_two = vec!["rust".to_string(), "rust".to_string()];
+        let n_docs_with = tf(&[("rust", 2)]);
+        let s1 = score(&q_one, &tf(&[("rust", 1)]), 5, 5.0, &n_docs_with, 10, &p());
+        let s2 = score(&q_two, &tf(&[("rust", 1)]), 5, 5.0, &n_docs_with, 10, &p());
+        assert!(
+            (s2 - 2.0 * s1).abs() < f64::EPSILON * 8.0,
+            "duplicated query token should double the score: 2*s1={}, s2={}",
+            2.0 * s1,
+            s2
+        );
+    }
+}

--- a/src/sql/fts/mod.rs
+++ b/src/sql/fts/mod.rs
@@ -1,0 +1,26 @@
+//! Full-text search (FTS) — inverted-index keyword retrieval with BM25
+//! ranking. Pure algorithms; no SQL integration in this module.
+//!
+//! Phase 8 of the SQLRite roadmap; see [`docs/phase-8-plan.md`]. This is
+//! sub-phase 8a, the standalone trio that the SQL surface (8b) and
+//! persistence layer (8c) build on top of:
+//!
+//! - [`tokenizer`] — split text into terms (ASCII MVP per Q3).
+//! - [`bm25`] — BM25 relevance scoring (`k1 = 1.5`, `b = 0.75`, fixed per
+//!   Q4 + Q5; no stemming, no stop list).
+//! - [`posting_list`] — in-memory inverted index keyed by term, holding
+//!   per-document term frequencies + lengths. Insert / remove / query.
+//!
+//! Mirrors the shape of [`crate::sql::hnsw`] (Phase 7d.1's standalone
+//! algorithm module): infallible public API, no project-error coupling,
+//! zero crate deps beyond `std`. The integration concerns — `IndexMethod`
+//! arms, `fts_match` / `bm25_score` scalar fns, the `try_fts_probe`
+//! optimizer hook, `KIND_FTS_POSTING` cell encoding — all land in 8b/8c.
+
+pub mod bm25;
+pub mod posting_list;
+pub mod tokenizer;
+
+pub use bm25::{Bm25Params, score as bm25_score};
+pub use posting_list::PostingList;
+pub use tokenizer::tokenize;

--- a/src/sql/fts/posting_list.rs
+++ b/src/sql/fts/posting_list.rs
@@ -1,0 +1,449 @@
+//! In-memory inverted index for FTS — `term -> { rowid -> term_freq }`,
+//! plus per-document length cache. Wraps the [`super::tokenizer`] +
+//! [`super::bm25`] primitives into a usable index. Pure data structure;
+//! no SQL coupling.
+//!
+//! Mirrors the role of [`crate::sql::hnsw::HnswIndex`] in 7d.1: this is
+//! the in-memory state that 8b will hang off `Table` (via a future
+//! `fts_indexes: Vec<FtsIndex>` field) and that 8c will serialize into
+//! `KIND_FTS_POSTING` cells.
+//!
+//! ## Identity choices
+//!
+//! - Rowids are `i64` (matches HNSW's `node_id` and SQLRite's row-id
+//!   convention; see [`crate::sql::hnsw::HnswIndex::insert`]).
+//! - The map structure is `BTreeMap<String, BTreeMap<i64, u32>>` rather
+//!   than `HashMap` so that (1) persistence (8c) gets a deterministic
+//!   on-disk byte order for free — postings are emitted in lexicographic
+//!   term order, each posting list in ascending rowid order — and (2)
+//!   tests get stable ordering without sorting. `HashMap` is faster on a
+//!   per-op basis but the lookups in the FTS hot path are bounded by
+//!   query-term count (single digits in practice), so the BTreeMap log-N
+//!   factor is negligible.
+//!
+//! ## What it does NOT do (yet)
+//!
+//! - **No persistence.** State lives entirely in memory. 8c wires it
+//!   into the page format under cell-kind `0x06`.
+//! - **No transaction integration.** 8b is responsible for batching
+//!   updates inside a `BEGIN; ... COMMIT;` block.
+//! - **No phrase / boolean queries.** Single-token any-term match only
+//!   for the MVP per the plan's "Out of scope" section. Multi-token
+//!   queries OR the per-term hits — no AND, NOT, or positional info.
+
+use std::collections::{BTreeMap, HashMap};
+
+use super::bm25::{Bm25Params, score as bm25_score};
+use super::tokenizer::tokenize;
+
+/// In-memory inverted index. See module-level doc.
+#[derive(Debug, Default, Clone)]
+pub struct PostingList {
+    /// Term -> { rowid -> term frequency in that doc }.
+    postings: BTreeMap<String, BTreeMap<i64, u32>>,
+    /// Rowid -> document length (in tokens, post-tokenization).
+    /// Acts as the canonical "set of indexed rowids" — `len()` and
+    /// `is_empty()` derive from this.
+    doc_lengths: BTreeMap<i64, u32>,
+    /// Sum of all `doc_lengths` values; tracked incrementally to make
+    /// [`avg_doc_len`] O(1) regardless of corpus size.
+    total_tokens: u64,
+}
+
+impl PostingList {
+    /// Empty index with no postings and no documents.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of indexed documents.
+    pub fn len(&self) -> usize {
+        self.doc_lengths.len()
+    }
+
+    /// True iff no document has been inserted (or all have been removed).
+    pub fn is_empty(&self) -> bool {
+        self.doc_lengths.is_empty()
+    }
+
+    /// Average document length in tokens. Returns `0.0` when the index
+    /// is empty so BM25 can guard cleanly without a div-by-zero.
+    pub fn avg_doc_len(&self) -> f64 {
+        if self.doc_lengths.is_empty() {
+            0.0
+        } else {
+            self.total_tokens as f64 / self.doc_lengths.len() as f64
+        }
+    }
+
+    /// Tokenize `text` and add its postings under `rowid`. If `rowid` is
+    /// already indexed, its previous postings are removed first — i.e.
+    /// `insert` is idempotent for re-indexing the same row.
+    ///
+    /// A row whose tokenization yields zero tokens is still recorded
+    /// (with `doc_len = 0` and no posting entries). This keeps `len()`
+    /// honest for "indexed but empty" rows; BM25 returns 0.0 for them.
+    pub fn insert(&mut self, rowid: i64, text: &str) {
+        if self.doc_lengths.contains_key(&rowid) {
+            self.remove(rowid);
+        }
+
+        let tokens = tokenize(text);
+        let doc_len = tokens.len() as u32;
+        self.total_tokens += doc_len as u64;
+        self.doc_lengths.insert(rowid, doc_len);
+
+        // Aggregate per-term frequency for this doc, then push into the
+        // global postings map. This avoids bumping the same posting
+        // entry repeatedly for a doc with many occurrences of one term.
+        let mut tf: HashMap<&str, u32> = HashMap::new();
+        for tok in &tokens {
+            *tf.entry(tok.as_str()).or_insert(0) += 1;
+        }
+        for (term, freq) in tf {
+            self.postings
+                .entry(term.to_string())
+                .or_default()
+                .insert(rowid, freq);
+        }
+    }
+
+    /// Remove all postings for `rowid`. No-op if `rowid` was never
+    /// inserted. Empty per-term posting lists left behind by the last
+    /// referencing row are pruned to keep the BTreeMap tight.
+    pub fn remove(&mut self, rowid: i64) {
+        let Some(doc_len) = self.doc_lengths.remove(&rowid) else {
+            return;
+        };
+        self.total_tokens -= doc_len as u64;
+
+        // Walk every term — fine because term count grows with vocab,
+        // not corpus size, and remove is rare. 8b's incremental DELETE
+        // path uses the rebuild-at-save strategy (Q7) anyway.
+        let mut empty_terms = Vec::new();
+        for (term, postings) in self.postings.iter_mut() {
+            if postings.remove(&rowid).is_some() && postings.is_empty() {
+                empty_terms.push(term.clone());
+            }
+        }
+        for term in empty_terms {
+            self.postings.remove(&term);
+        }
+    }
+
+    /// True iff `rowid` is indexed and at least one of its terms is in
+    /// the (tokenized) `query`. Powers `fts_match(col, 'q')` in 8b
+    /// without going through scoring.
+    pub fn matches(&self, rowid: i64, query: &str) -> bool {
+        if !self.doc_lengths.contains_key(&rowid) {
+            return false;
+        }
+        for term in tokenize(query) {
+            if let Some(postings) = self.postings.get(&term) {
+                if postings.contains_key(&rowid) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// BM25 score for a single (rowid, query) pair. Returns `0.0` if
+    /// `rowid` is unknown or no query terms hit.
+    pub fn score(&self, rowid: i64, query: &str, params: &Bm25Params) -> f64 {
+        let Some(&doc_len) = self.doc_lengths.get(&rowid) else {
+            return 0.0;
+        };
+        let query_terms = tokenize(query);
+        if query_terms.is_empty() {
+            return 0.0;
+        }
+
+        let term_freq = self.term_freq_for_doc(rowid, &query_terms);
+        let n_docs_with = self.n_docs_with_for_terms(&query_terms);
+        bm25_score(
+            &query_terms,
+            &term_freq,
+            doc_len,
+            self.avg_doc_len(),
+            &n_docs_with,
+            self.doc_lengths.len() as u32,
+            params,
+        )
+    }
+
+    /// Score every doc that contains at least one query term and return
+    /// `(rowid, score)` sorted by score descending, ties broken by
+    /// rowid ascending. Powers the bulk path used by 8b's
+    /// `try_fts_probe` optimizer hook.
+    ///
+    /// Empty query → empty result. Empty index → empty result. Rows
+    /// that don't match any query term are not scored at all (they
+    /// would score 0.0 — including them just bloats the result).
+    pub fn query(&self, query: &str, params: &Bm25Params) -> Vec<(i64, f64)> {
+        let query_terms = tokenize(query);
+        if query_terms.is_empty() || self.doc_lengths.is_empty() {
+            return Vec::new();
+        }
+
+        // Collect candidate rowids: every doc that has at least one
+        // query term in its postings. BTreeMap iteration is sorted, so
+        // the candidate set comes out in ascending rowid order — handy
+        // for the tie-break below.
+        let mut candidates: BTreeMap<i64, u32> = BTreeMap::new();
+        for term in &query_terms {
+            if let Some(postings) = self.postings.get(term) {
+                for &rowid in postings.keys() {
+                    candidates.entry(rowid).or_insert(0);
+                }
+            }
+        }
+        if candidates.is_empty() {
+            return Vec::new();
+        }
+
+        let n_docs_with = self.n_docs_with_for_terms(&query_terms);
+        let avg = self.avg_doc_len();
+        let total_docs = self.doc_lengths.len() as u32;
+
+        let mut scored: Vec<(i64, f64)> = candidates
+            .into_keys()
+            .map(|rowid| {
+                let doc_len = self.doc_lengths[&rowid];
+                let tf = self.term_freq_for_doc(rowid, &query_terms);
+                let s = bm25_score(
+                    &query_terms,
+                    &tf,
+                    doc_len,
+                    avg,
+                    &n_docs_with,
+                    total_docs,
+                    params,
+                );
+                (rowid, s)
+            })
+            .collect();
+
+        // Score desc, then rowid asc on ties. f64::partial_cmp + the
+        // candidate set already being sorted ascending means we only
+        // need a stable sort_by on score.
+        scored.sort_by(|a, b| {
+            b.1.partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.cmp(&b.0))
+        });
+        scored
+    }
+
+    fn term_freq_for_doc(&self, rowid: i64, query_terms: &[String]) -> HashMap<String, u32> {
+        let mut tf = HashMap::with_capacity(query_terms.len());
+        for term in query_terms {
+            if tf.contains_key(term) {
+                continue;
+            }
+            let freq = self
+                .postings
+                .get(term)
+                .and_then(|p| p.get(&rowid).copied())
+                .unwrap_or(0);
+            tf.insert(term.clone(), freq);
+        }
+        tf
+    }
+
+    fn n_docs_with_for_terms(&self, query_terms: &[String]) -> HashMap<String, u32> {
+        let mut n = HashMap::with_capacity(query_terms.len());
+        for term in query_terms {
+            if n.contains_key(term) {
+                continue;
+            }
+            let count = self.postings.get(term).map(|p| p.len() as u32).unwrap_or(0);
+            n.insert(term.clone(), count);
+        }
+        n
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_list_is_empty() {
+        let pl = PostingList::new();
+        assert!(pl.is_empty());
+        assert_eq!(pl.len(), 0);
+        assert_eq!(pl.avg_doc_len(), 0.0);
+        assert!(pl.query("anything", &Bm25Params::default()).is_empty());
+        assert_eq!(pl.score(1, "anything", &Bm25Params::default()), 0.0);
+        assert!(!pl.matches(1, "anything"));
+    }
+
+    #[test]
+    fn empty_query_returns_empty_results() {
+        let mut pl = PostingList::new();
+        pl.insert(1, "rust embedded database");
+        assert!(pl.query("", &Bm25Params::default()).is_empty());
+        assert!(pl.query("!!!", &Bm25Params::default()).is_empty());
+        assert_eq!(pl.score(1, "", &Bm25Params::default()), 0.0);
+    }
+
+    #[test]
+    fn insert_and_query_two_docs_ranks_correctly() {
+        let mut pl = PostingList::new();
+        pl.insert(1, "rust rust embedded database");
+        pl.insert(2, "rust language");
+        let res = pl.query("rust", &Bm25Params::default());
+        assert_eq!(res.len(), 2);
+        // doc1 has tf=2 in a longer doc; doc2 has tf=1 in a shorter doc.
+        // Length normalization makes the call non-obvious — just check
+        // that the result set contains both rows in some order, with
+        // both scores positive.
+        let (id_a, s_a) = res[0];
+        let (id_b, s_b) = res[1];
+        assert!(s_a > 0.0 && s_b > 0.0);
+        assert!(s_a >= s_b);
+        assert!(
+            (id_a == 1 || id_a == 2) && (id_b == 1 || id_b == 2) && id_a != id_b,
+            "result rowids should be {{1,2}}, got ({}, {})",
+            id_a,
+            id_b
+        );
+
+        // matches() agrees on which rows hit.
+        assert!(pl.matches(1, "rust"));
+        assert!(pl.matches(2, "rust"));
+        assert!(!pl.matches(1, "python"));
+    }
+
+    #[test]
+    fn score_method_matches_bulk_query() {
+        let mut pl = PostingList::new();
+        pl.insert(10, "rust embedded database");
+        pl.insert(20, "go embedded database");
+        pl.insert(30, "python web framework");
+
+        let params = Bm25Params::default();
+        let bulk = pl.query("embedded", &params);
+        for (rowid, score) in &bulk {
+            let direct = pl.score(*rowid, "embedded", &params);
+            assert!(
+                (direct - score).abs() < f64::EPSILON * 16.0,
+                "score({}, ...) = {} vs query() reported {}",
+                rowid,
+                direct,
+                score
+            );
+        }
+        assert_eq!(pl.score(30, "embedded", &params), 0.0);
+    }
+
+    #[test]
+    fn remove_clears_doc_and_prunes_empty_terms() {
+        let mut pl = PostingList::new();
+        pl.insert(1, "rust");
+        pl.insert(2, "rust embedded");
+        assert_eq!(pl.len(), 2);
+        assert_eq!(pl.total_tokens, 3);
+        assert!(pl.postings.contains_key("rust"));
+        assert!(pl.postings.contains_key("embedded"));
+
+        pl.remove(2);
+        assert_eq!(pl.len(), 1);
+        assert_eq!(pl.total_tokens, 1);
+        // "embedded" only existed in doc 2; should be gone now.
+        assert!(!pl.postings.contains_key("embedded"));
+        assert!(pl.postings.contains_key("rust"));
+
+        pl.remove(1);
+        assert!(pl.is_empty());
+        assert!(pl.postings.is_empty());
+        assert_eq!(pl.total_tokens, 0);
+
+        // Idempotent remove.
+        pl.remove(1);
+        pl.remove(99);
+        assert!(pl.is_empty());
+    }
+
+    #[test]
+    fn reinsert_replaces_prior_postings() {
+        let mut pl = PostingList::new();
+        pl.insert(1, "rust rust rust");
+        assert_eq!(pl.postings["rust"][&1], 3);
+        assert_eq!(pl.total_tokens, 3);
+
+        pl.insert(1, "go");
+        assert_eq!(pl.len(), 1);
+        assert_eq!(pl.total_tokens, 1);
+        assert!(!pl.postings.contains_key("rust"));
+        assert_eq!(pl.postings["go"][&1], 1);
+    }
+
+    #[test]
+    fn tie_break_orders_by_rowid_ascending() {
+        // Two identical docs → identical scores → rowid ASC.
+        let mut pl = PostingList::new();
+        pl.insert(7, "alpha beta");
+        pl.insert(3, "alpha beta");
+        pl.insert(5, "alpha beta");
+        let res = pl.query("alpha", &Bm25Params::default());
+        let ids: Vec<i64> = res.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![3, 5, 7]);
+        // All three scores should be exactly equal.
+        let s = res[0].1;
+        for (_, score) in &res {
+            assert_eq!(*score, s);
+        }
+    }
+
+    #[test]
+    fn multi_term_query_unions_candidates_any_term() {
+        let mut pl = PostingList::new();
+        pl.insert(1, "rust embedded");
+        pl.insert(2, "rust web");
+        pl.insert(3, "go embedded");
+        pl.insert(4, "python web");
+        let res = pl.query("rust embedded", &Bm25Params::default());
+        let ids: std::collections::BTreeSet<i64> = res.iter().map(|(id, _)| *id).collect();
+        // Per the MVP "any-term" semantic — rowid 4 is the only one with
+        // neither term, so it must NOT appear; the other three must.
+        assert_eq!(ids, [1, 2, 3].iter().copied().collect());
+        // Doc 1 has both terms → should outrank singletons.
+        assert_eq!(res[0].0, 1);
+    }
+
+    #[test]
+    fn synthetic_thousand_doc_corpus_top_ten_is_stable() {
+        // 1000 deterministic docs. Most are noise; only 5 contain the
+        // rare "quasar" term. Top-10 query must surface those 5 (the
+        // remaining slots score 0.0 and aren't returned at all because
+        // we filter to candidates with at least one matching term).
+        let mut pl = PostingList::new();
+        let rare_rows: [i64; 5] = [137, 248, 391, 642, 873];
+        for i in 0..1000_i64 {
+            // Pseudo-random body deterministic in `i`.
+            let words = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"];
+            let pick_a = words[((i as usize) * 7) % words.len()];
+            let pick_b = words[((i as usize) * 13 + 1) % words.len()];
+            let body = if rare_rows.contains(&i) {
+                format!("quasar {} {}", pick_a, pick_b)
+            } else {
+                format!("{} {}", pick_a, pick_b)
+            };
+            pl.insert(i, &body);
+        }
+        assert_eq!(pl.len(), 1000);
+
+        let res = pl.query("quasar", &Bm25Params::default());
+        assert_eq!(res.len(), 5, "exactly five docs should contain 'quasar'");
+        let returned: std::collections::BTreeSet<i64> = res.iter().map(|(id, _)| *id).collect();
+        let expected: std::collections::BTreeSet<i64> = rare_rows.iter().copied().collect();
+        assert_eq!(returned, expected);
+
+        // Stability: re-running the query yields identical output (no
+        // hidden HashMap order leaking through).
+        let res2 = pl.query("quasar", &Bm25Params::default());
+        assert_eq!(res, res2);
+    }
+}

--- a/src/sql/fts/tokenizer.rs
+++ b/src/sql/fts/tokenizer.rs
@@ -1,0 +1,101 @@
+//! ASCII tokenizer for FTS — splits on `[^A-Za-z0-9]+` and lowercases.
+//!
+//! Resolves Phase 8 plan Q3 (ASCII MVP). Unicode-aware tokenization is
+//! deferred to Phase 8.1 behind a `unicode` cargo feature; the limitation
+//! here is intentional. Non-ASCII bytes are treated as separators, which
+//! means accented Latin (`café`), CJK, and other non-ASCII scripts won't
+//! be searchable until that follow-up lands.
+//!
+//! No stemming and no stop-word removal (Q4 + Q5). BM25's IDF naturally
+//! downweights common terms, and modern RAG pipelines rely on exact
+//! lexical matches for technical retrieval.
+
+/// Split `text` on runs of non-ASCII-alphanumeric bytes and lowercase
+/// each resulting term. Empty input or input made entirely of separators
+/// returns an empty `Vec`.
+///
+/// Tokens are `String` rather than `&str` because the posting-list owns
+/// its term strings (see [`super::posting_list::PostingList`]); returning
+/// owned strings keeps the call site shape consistent with how the index
+/// stores them and avoids a second allocation downstream.
+pub fn tokenize(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    for b in text.bytes() {
+        if b.is_ascii_alphanumeric() {
+            current.push(b.to_ascii_lowercase() as char);
+        } else if !current.is_empty() {
+            tokens.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_empty_vec() {
+        assert!(tokenize("").is_empty());
+        assert!(tokenize("   ").is_empty());
+        assert!(tokenize("!!!---???").is_empty());
+    }
+
+    #[test]
+    fn splits_on_punctuation_and_whitespace() {
+        assert_eq!(
+            tokenize("hello, world!"),
+            vec!["hello".to_string(), "world".to_string()]
+        );
+        assert_eq!(
+            tokenize("a\tb\nc d"),
+            vec![
+                "a".to_string(),
+                "b".to_string(),
+                "c".to_string(),
+                "d".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn lowercases_ascii_letters() {
+        assert_eq!(
+            tokenize("FooBar BAZ"),
+            vec!["foobar".to_string(), "baz".to_string()]
+        );
+    }
+
+    #[test]
+    fn alphanumeric_runs_stay_together() {
+        // "rust2026" is a single token; digits are alphanumeric.
+        assert_eq!(tokenize("rust2026"), vec!["rust2026".to_string()]);
+        // "co-op" splits on the hyphen.
+        assert_eq!(tokenize("co-op"), vec!["co".to_string(), "op".to_string()]);
+    }
+
+    #[test]
+    fn non_ascii_bytes_act_as_separators_without_panicking() {
+        // ASCII MVP per Q3 — non-ASCII bytes (é = 0xC3 0xA9 in UTF-8) are
+        // treated as separators. "café" -> ["caf"]. Documented limitation.
+        let toks = tokenize("café");
+        assert_eq!(toks, vec!["caf".to_string()]);
+        // CJK input: every byte is non-ASCII, so we get an empty result.
+        assert!(tokenize("日本語").is_empty());
+    }
+
+    #[test]
+    fn smoke_module_path_reaches_through_lib() {
+        // Confirms `sqlrite::sql::fts::tokenize` is reachable via the
+        // public `sql` module path from the crate root. If 8b ever moves
+        // the module behind a feature gate, this test will fail loudly.
+        assert_eq!(
+            crate::sql::fts::tokenize("Hello, world!"),
+            vec!["hello".to_string(), "world".to_string()]
+        );
+    }
+}

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,5 +1,6 @@
 pub mod db;
 pub mod executor;
+pub mod fts;
 pub mod hnsw;
 pub mod pager;
 pub mod parser;


### PR DESCRIPTION
## Summary

First sub-phase of [Phase 8](docs/phase-8-plan.md) — full-text search. **8a ships the standalone algorithms only**, no SQL integration yet. Mirrors the shape of Phase 7d.1's `src/sql/hnsw.rs`: pure algorithm, infallible API, zero project deps.

- New module `src/sql/fts/` with three files
  - `tokenizer.rs` — ASCII split + lowercase (Q3: ASCII MVP)
  - `bm25.rs` — BM25+ scoring (`k1=1.5`, `b=0.75` fixed; Q4 + Q5: no stemming, no stop list)
  - `posting_list.rs` — in-memory `BTreeMap<term, BTreeMap<rowid, freq>>` index with `insert` / `remove` / `query` / `matches` / `score`
- Single-line wire-up in `src/sql/mod.rs` (`pub mod fts;`)
- 22 inline unit tests (~370 LOC); whole module is ~510 LOC of code

The public surface is shaped to be **directly callable from 8b** without rework: `PostingList::matches` / `score` back the per-row `fts_match` / `bm25_score` scalar fns, and `PostingList::query` powers the bulk `try_fts_probe` optimizer hook.

## Out of scope (later sub-phases)

| Concern | Lands in |
|---|---|
| `IndexMethod::Fts` enum arm + executor dispatch | 8b |
| `fts_match` / `bm25_score` scalar fn dispatch | 8b |
| `try_fts_probe` optimizer hook | 8b |
| `fts_indexes: Vec<FtsIndex>` on `Table` + INSERT/DELETE wiring | 8b |
| `KIND_FTS_POSTING` cell encoding + v4→v5 file-format bump | 8c |
| `fts` cargo feature gate | 8e (where it gates the MCP `bm25_search` tool) |
| Hybrid retrieval worked example | 8d |
| Docs sweep (`docs/fts.md`, `supported-sql.md`, etc.) | 8f |

## Test plan

- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — clean
- [x] `cargo test sql::fts` — **22 / 22 passing**
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` — full suite green
- [x] `cargo fmt --all -- --check` — no diff
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — no new warnings on FTS code
- [x] `cargo doc --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --no-deps` — module docs build

## Notable test coverage

- **BM25 numeric reproducibility** — hand-computed reference on a 3-doc corpus, asserted within `f64::EPSILON * 16`. Catches any future formula drift.
- **Length normalization sanity** — same TF in a longer doc strictly scores lower (`b > 0` working).
- **IDF behavior** — rare term (1 of 1000 docs) outscores common term (1000 of 1000) by ≥5×.
- **1k-doc deterministic synthetic corpus** — top-10 query for a rare term surfaces exactly the 5 inserted matches, in stable order across re-runs.
- **Tie-break** — equal-score docs come back in ascending rowid order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)