### PR TITLE
feat(fts): 8b — SQL surface for full-text search

### DIFF
--- a/src/sql/db/table.rs
+++ b/src/sql/db/table.rs
@@ -1,5 +1,6 @@
 use crate::error::{Result, SQLRiteError};
 use crate::sql::db::secondary_index::{IndexOrigin, SecondaryIndex};
+use crate::sql::fts::PostingList;
 use crate::sql::hnsw::HnswIndex;
 use crate::sql::parser::create::CreateQuery;
 use std::collections::{BTreeMap, HashMap};
@@ -137,6 +138,12 @@ pub struct Table {
     /// persisted CREATE INDEX SQL. The graph itself is NOT yet persisted —
     /// see Phase 7d.3 for cell-encoded graph storage.
     pub hnsw_indexes: Vec<HnswIndexEntry>,
+    /// FTS inverted indexes on TEXT columns (Phase 8b). Maintained in
+    /// lockstep with row storage on INSERT (incremental); DELETE / UPDATE
+    /// flag `needs_rebuild` and the next save rebuilds from current rows.
+    /// The posting lists themselves are NOT yet persisted — Phase 8c
+    /// wires the cell-encoded `KIND_FTS_POSTING` storage.
+    pub fts_indexes: Vec<FtsIndexEntry>,
     /// ROWID of most recent insert.
     pub last_rowid: i64,
     /// PRIMARY KEY column name, or "-1" if the table has no PRIMARY KEY.
@@ -160,6 +167,29 @@ pub struct HnswIndexEntry {
     /// invalidated the graph since the last rebuild. INSERT maintains
     /// the graph incrementally and leaves this false. The next save
     /// rebuilds dirty indexes from current rows before serializing.
+    pub needs_rebuild: bool,
+}
+
+/// One FTS index attached to a table (Phase 8b). The inverted index
+/// itself is a [`PostingList`]; metadata (name, column, dirty flag)
+/// lives here. Mirrors [`HnswIndexEntry`] field-for-field so the
+/// rebuild-on-save and DELETE/UPDATE invalidation paths can use one
+/// pattern across both index families.
+#[derive(Debug, Clone)]
+pub struct FtsIndexEntry {
+    /// User-supplied name from `CREATE INDEX <name> … USING fts(<col>)`.
+    /// Unique across `secondary_indexes`, `hnsw_indexes`, and
+    /// `fts_indexes` on a given table.
+    pub name: String,
+    /// The TEXT column this index covers.
+    pub column_name: String,
+    /// The inverted index + per-doc length cache.
+    pub index: PostingList,
+    /// True iff a DELETE or UPDATE-on-text-col has invalidated the
+    /// posting lists since the last rebuild. INSERT maintains the
+    /// index incrementally and leaves this false. The next save
+    /// rebuilds dirty indexes from current rows before serializing
+    /// (mirrors HNSW's Q7 strategy).
     pub needs_rebuild: bool,
 }
 
@@ -244,6 +274,9 @@ impl Table {
             // time, because there's no UNIQUE-style constraint that
             // implies a vector index.
             hnsw_indexes: Vec::new(),
+            // Same story for FTS indexes — explicit `CREATE INDEX … USING
+            // fts(<col>)` only (Phase 8b).
+            fts_indexes: Vec::new(),
             last_rowid: 0,
             primary_key,
         }
@@ -271,6 +304,8 @@ impl Table {
             // graph copy. Phase 4f's snapshot-rollback semantics require
             // the snapshot to be fully decoupled from live state.
             hnsw_indexes: self.hnsw_indexes.clone(),
+            // Same fully-decoupled clone for FTS indexes (Phase 8b).
+            fts_indexes: self.fts_indexes.clone(),
             last_rowid: self.last_rowid,
             primary_key: self.primary_key.clone(),
         }
@@ -908,8 +943,16 @@ impl Table {
             // wiring up neighbor edges, so build a get_vec closure that
             // pulls from the table's row storage (which we *just* updated
             // with the new value).
-            if let Some(Value::Vector(new_vec)) = typed_value {
-                self.maintain_hnsw_on_insert(key, next_rowid, &new_vec);
+            if let Some(Value::Vector(new_vec)) = &typed_value {
+                self.maintain_hnsw_on_insert(key, next_rowid, new_vec);
+            }
+
+            // Step 4 (Phase 8b): maintain any FTS indexes on this column.
+            // Cheap incremental update — PostingList::insert tokenizes
+            // the value and adds postings under the new rowid. DELETE
+            // and UPDATE take the rebuild-on-save path instead (Q7).
+            if let Some(Value::Text(text)) = &typed_value {
+                self.maintain_fts_on_insert(key, next_rowid, text);
             }
         }
         self.last_rowid = next_rowid;
@@ -944,6 +987,20 @@ impl Table {
                 entry.index.insert(rowid, new_vec, |id| {
                     vec_snapshot.get(&id).cloned().unwrap_or_default()
                 });
+            }
+        }
+    }
+
+    /// After a row insert, push the new (rowid, text) into every FTS
+    /// index whose column matches `column`. Phase 8b.
+    ///
+    /// Mirrors [`Self::maintain_hnsw_on_insert`] but the FTS index is
+    /// self-contained — `PostingList::insert` only needs the new doc's
+    /// text, not the rest of the corpus, so there's no snapshot dance.
+    fn maintain_fts_on_insert(&mut self, column: &str, rowid: i64, text: &str) {
+        for entry in &mut self.fts_indexes {
+            if entry.column_name == column {
+                entry.index.insert(rowid, text);
             }
         }
     }

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -7,13 +7,16 @@ use prettytable::{Cell as PrintCell, Row as PrintRow, Table as PrintTable};
 use sqlparser::ast::{
     AssignmentTarget, BinaryOperator, CreateIndex, Delete, Expr, FromTable, FunctionArg,
     FunctionArgExpr, FunctionArguments, IndexType, ObjectNamePart, Statement, TableFactor,
-    TableWithJoins, UnaryOperator, Update,
+    TableWithJoins, UnaryOperator, Update, Value as AstValue,
 };
 
 use crate::error::{Result, SQLRiteError};
 use crate::sql::db::database::Database;
 use crate::sql::db::secondary_index::{IndexOrigin, SecondaryIndex};
-use crate::sql::db::table::{DataType, HnswIndexEntry, Table, Value, parse_vector_literal};
+use crate::sql::db::table::{
+    DataType, FtsIndexEntry, HnswIndexEntry, Table, Value, parse_vector_literal,
+};
+use crate::sql::fts::{Bm25Params, PostingList};
 use crate::sql::hnsw::{DistanceMetric, HnswIndex};
 use crate::sql::parser::select::{OrderByClause, Projection, SelectQuery};
 
@@ -99,12 +102,18 @@ pub fn execute_select_rows(query: SelectQuery, db: &Database) -> Result<SelectRe
     //
     // We branch in cases:
     //   1. ORDER BY + LIMIT k matches the HNSW probe pattern  → graph probe.
-    //   2. ORDER BY + LIMIT k where k < |matching|            → bounded heap (7c).
-    //   3. ORDER BY without LIMIT, or LIMIT >= |matching|     → full sort.
-    //   4. LIMIT without ORDER BY                              → just truncate.
+    //   2. ORDER BY + LIMIT k matches the FTS probe pattern   → posting probe.
+    //   3. ORDER BY + LIMIT k where k < |matching|            → bounded heap (7c).
+    //   4. ORDER BY without LIMIT, or LIMIT >= |matching|     → full sort.
+    //   5. LIMIT without ORDER BY                              → just truncate.
     match (&query.order_by, query.limit) {
         (Some(order), Some(k)) if try_hnsw_probe(table, &order.expr, k).is_some() => {
             matching = try_hnsw_probe(table, &order.expr, k).unwrap();
+        }
+        (Some(order), Some(k))
+            if try_fts_probe(table, &order.expr, order.ascending, k).is_some() =>
+        {
+            matching = try_fts_probe(table, &order.expr, order.ascending, k).unwrap();
         }
         (Some(order), Some(k)) if k < matching.len() => {
             matching = select_topk(&matching, table, order, k)?;
@@ -208,8 +217,15 @@ pub fn execute_delete(stmt: &Statement, db: &mut Database) -> Result<usize> {
     // table (the deleted node could still appear in other nodes'
     // neighbor lists, breaking subsequent searches). Mark dirty so
     // the next save rebuilds from current rows before serializing.
+    //
+    // Phase 8b — same posture for FTS indexes (Q7 — rebuild-on-save
+    // mirrors HNSW). The deleted rowid still appears in posting
+    // lists; leaving it would surface zombie hits in future queries.
     if !matching.is_empty() {
         for entry in &mut table.hnsw_indexes {
+            entry.needs_rebuild = true;
+        }
+        for entry in &mut table.fts_indexes {
             entry.needs_rebuild = true;
         }
     }
@@ -314,12 +330,19 @@ pub fn execute_update(stmt: &Statement, db: &mut Database) -> Result<usize> {
     // non-vector columns also mark dirty, which is over-conservative
     // but harmless — the rebuild walks rows anyway, and the cost is
     // only paid on save.)
+    //
+    // Phase 8b — same shape for FTS indexes covering updated TEXT cols.
     if !work.is_empty() {
         let updated_columns: std::collections::HashSet<&str> = work
             .iter()
             .flat_map(|(_, values)| values.iter().map(|(c, _)| c.as_str()))
             .collect();
         for entry in &mut tbl.hnsw_indexes {
+            if updated_columns.contains(entry.column_name.as_str()) {
+                entry.needs_rebuild = true;
+            }
+        }
+        for entry in &mut tbl.fts_indexes {
             if updated_columns.contains(entry.column_name.as_str()) {
                 entry.needs_rebuild = true;
             }
@@ -384,12 +407,16 @@ pub fn execute_create_index(stmt: &Statement, db: &mut Database) -> Result<Strin
         Some(IndexType::Custom(ident)) if ident.value.eq_ignore_ascii_case("hnsw") => {
             IndexMethod::Hnsw
         }
+        Some(IndexType::Custom(ident)) if ident.value.eq_ignore_ascii_case("fts") => {
+            IndexMethod::Fts
+        }
         Some(IndexType::Custom(ident)) if ident.value.eq_ignore_ascii_case("btree") => {
             IndexMethod::Btree
         }
         Some(other) => {
             return Err(SQLRiteError::NotImplemented(format!(
-                "CREATE INDEX … USING {other:?} is not supported (try `hnsw` or no USING clause)"
+                "CREATE INDEX … USING {other:?} is not supported \
+                 (try `hnsw`, `fts`, or no USING clause)"
             )));
         }
         None => IndexMethod::Btree,
@@ -430,10 +457,11 @@ pub fn execute_create_index(stmt: &Statement, db: &mut Database) -> Result<Strin
             .find(|c| c.column_name == column_name)
             .expect("we just verified the column exists");
 
-        // Name uniqueness check spans BOTH index kinds — a btree and an
-        // hnsw can't share a name.
+        // Name uniqueness check spans ALL index kinds — btree, hnsw, and
+        // fts share one namespace per table.
         if table.index_by_name(&index_name).is_some()
             || table.hnsw_indexes.iter().any(|i| i.name == index_name)
+            || table.fts_indexes.iter().any(|i| i.name == index_name)
         {
             if *if_not_exists {
                 return Ok(index_name);
@@ -472,6 +500,15 @@ pub fn execute_create_index(stmt: &Statement, db: &mut Database) -> Result<Strin
             *unique,
             &existing_rowids_and_values,
         ),
+        IndexMethod::Fts => create_fts_index(
+            db,
+            &table_name_str,
+            &index_name,
+            &column_name,
+            &datatype,
+            *unique,
+            &existing_rowids_and_values,
+        ),
     }
 }
 
@@ -482,6 +519,8 @@ pub fn execute_create_index(stmt: &Statement, db: &mut Database) -> Result<Strin
 enum IndexMethod {
     Btree,
     Hnsw,
+    /// Phase 8b — full-text inverted index over a TEXT column.
+    Fts,
 }
 
 /// Builds a Phase 3e B-Tree secondary index and attaches it to the table.
@@ -598,6 +637,57 @@ fn create_hnsw_index(
         column_name: column_name.to_string(),
         index: idx,
         // Freshly built — no DELETE/UPDATE has invalidated it yet.
+        needs_rebuild: false,
+    });
+    Ok(index_name.to_string())
+}
+
+/// Builds a Phase 8b FTS inverted index and attaches it to the table.
+/// Mirrors [`create_hnsw_index`] in shape: validate column type,
+/// tokenize each existing row's text into the in-memory posting list,
+/// push an `FtsIndexEntry`.
+fn create_fts_index(
+    db: &mut Database,
+    table_name: &str,
+    index_name: &str,
+    column_name: &str,
+    datatype: &DataType,
+    unique: bool,
+    existing: &[(i64, Value)],
+) -> Result<String> {
+    // FTS is a TEXT-only feature for the MVP. JSON columns share the
+    // Row::Text storage but their content is structured — full-text
+    // indexing JSON keys + values would need a different design (and
+    // is out of scope per the Phase 8 plan's "Out of scope" section).
+    match datatype {
+        DataType::Text => {}
+        other => {
+            return Err(SQLRiteError::General(format!(
+                "USING fts requires a TEXT column; '{column_name}' is {other}"
+            )));
+        }
+    }
+
+    if unique {
+        return Err(SQLRiteError::General(
+            "UNIQUE has no meaning for FTS indexes".to_string(),
+        ));
+    }
+
+    let mut idx = PostingList::new();
+    for (rowid, v) in existing {
+        if let Value::Text(text) = v {
+            idx.insert(*rowid, text);
+        }
+        // Non-text values (Null, type coercion bugs) get skipped — same
+        // posture as create_hnsw_index for non-vector values.
+    }
+
+    let table_mut = db.get_table_mut(table_name.to_string())?;
+    table_mut.fts_indexes.push(FtsIndexEntry {
+        name: index_name.to_string(),
+        column_name: column_name.to_string(),
+        index: idx,
         needs_rebuild: false,
     });
     Ok(index_name.to_string())
@@ -837,6 +927,89 @@ fn try_hnsw_probe(table: &Table, order_expr: &Expr, k: usize) -> Option<Vec<i64>
         }
     });
     Some(result)
+}
+
+/// Phase 8b — FTS optimizer hook.
+///
+/// Recognizes `ORDER BY bm25_score(<col>, '<query>') DESC LIMIT <k>`
+/// and serves it from the FTS index instead of full-scanning. Returns
+/// `Some(rowids)` already sorted by descending BM25 (with rowid
+/// ascending as tie-break), or `None` to fall through to scalar eval.
+///
+/// **Known limitation (mirrors `try_hnsw_probe`).** This shortcut
+/// ignores any `WHERE` clause. The canonical FTS query has a
+/// `WHERE fts_match(<col>, '<q>')` predicate, which is implicitly
+/// satisfied by the probe results — so dropping it is harmless.
+/// Anything *else* in the WHERE (`AND status = 'published'`) gets
+/// silently skipped on the optimizer path. Per Phase 8 plan Q6 we
+/// match HNSW's posture here; a correctness-preserving multi-index
+/// composer is deferred.
+fn try_fts_probe(table: &Table, order_expr: &Expr, ascending: bool, k: usize) -> Option<Vec<i64>> {
+    if k == 0 || ascending {
+        // BM25 is "higher = better"; ASC ranking is almost certainly a
+        // user mistake. Fall through so the caller gets either an
+        // explicit error from scalar eval or the slow correct path.
+        return None;
+    }
+
+    let func = match order_expr {
+        Expr::Function(f) => f,
+        _ => return None,
+    };
+    let fname = match func.name.0.as_slice() {
+        [ObjectNamePart::Identifier(ident)] => ident.value.to_lowercase(),
+        _ => return None,
+    };
+    if fname != "bm25_score" {
+        return None;
+    }
+
+    let arg_list = match &func.args {
+        FunctionArguments::List(l) => &l.args,
+        _ => return None,
+    };
+    if arg_list.len() != 2 {
+        return None;
+    }
+    let exprs: Vec<&Expr> = arg_list
+        .iter()
+        .filter_map(|a| match a {
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(e)) => Some(e),
+            _ => None,
+        })
+        .collect();
+    if exprs.len() != 2 {
+        return None;
+    }
+
+    // Arg 0 must be a bare column identifier.
+    let col_name = match exprs[0] {
+        Expr::Identifier(ident) if ident.quote_style.is_none() => ident.value.clone(),
+        _ => return None,
+    };
+
+    // Arg 1 must be a single-quoted string literal. Anything else
+    // (column reference, function call) requires per-row evaluation —
+    // we'd lose the whole point of the probe.
+    let query = match exprs[1] {
+        Expr::Value(v) => match &v.value {
+            AstValue::SingleQuotedString(s) => s.clone(),
+            _ => return None,
+        },
+        _ => return None,
+    };
+
+    let entry = table
+        .fts_indexes
+        .iter()
+        .find(|e| e.column_name == col_name)?;
+
+    let scored = entry.index.query(&query, &Bm25Params::default());
+    let mut out: Vec<i64> = scored.into_iter().map(|(id, _)| id).collect();
+    if out.len() > k {
+        out.truncate(k);
+    }
+    Some(out)
 }
 
 /// Helper for `try_hnsw_probe`: given two function args, identify which
@@ -1210,10 +1383,105 @@ fn eval_function(func: &sqlparser::ast::Function, table: &Table, rowid: i64) -> 
         "json_type" => json_fn_type(&name, &func.args, table, rowid),
         "json_array_length" => json_fn_array_length(&name, &func.args, table, rowid),
         "json_object_keys" => json_fn_object_keys(&name, &func.args, table, rowid),
+        // Phase 8b — FTS scalars. Both consult an FTS index attached to
+        // the named column; both error if no index exists (the index is
+        // a hard prerequisite, mirroring SQLite FTS5's MATCH).
+        "fts_match" => {
+            let (entry, query) = resolve_fts_args(&name, &func.args, table, rowid)?;
+            Ok(Value::Bool(entry.index.matches(rowid, &query)))
+        }
+        "bm25_score" => {
+            let (entry, query) = resolve_fts_args(&name, &func.args, table, rowid)?;
+            let s = entry.index.score(rowid, &query, &Bm25Params::default());
+            Ok(Value::Real(s))
+        }
         other => Err(SQLRiteError::NotImplemented(format!(
             "unknown function: {other}(...)"
         ))),
     }
+}
+
+/// Helper for `fts_match` / `bm25_score`: pull the column reference out
+/// of arg 0 (a bare identifier — we need the *name*, not the per-row
+/// value), evaluate arg 1 as a Text query string, and look up the FTS
+/// index attached to that column. Errors if any step fails.
+fn resolve_fts_args<'t>(
+    fn_name: &str,
+    args: &FunctionArguments,
+    table: &'t Table,
+    rowid: i64,
+) -> Result<(&'t FtsIndexEntry, String)> {
+    let arg_list = match args {
+        FunctionArguments::List(l) => &l.args,
+        _ => {
+            return Err(SQLRiteError::General(format!(
+                "{fn_name}() expects exactly two arguments: (column, query_text)"
+            )));
+        }
+    };
+    if arg_list.len() != 2 {
+        return Err(SQLRiteError::General(format!(
+            "{fn_name}() expects exactly 2 arguments, got {}",
+            arg_list.len()
+        )));
+    }
+
+    // Arg 0: bare column identifier. Must resolve syntactically to a
+    // column name (we can't accept arbitrary expressions because we
+    // need the column to look up the index, not the column's value).
+    let col_expr = match &arg_list[0] {
+        FunctionArg::Unnamed(FunctionArgExpr::Expr(e)) => e,
+        other => {
+            return Err(SQLRiteError::NotImplemented(format!(
+                "{fn_name}() argument 0 must be a column name, got {other:?}"
+            )));
+        }
+    };
+    let col_name = match col_expr {
+        Expr::Identifier(ident) => ident.value.clone(),
+        Expr::CompoundIdentifier(parts) => parts
+            .last()
+            .map(|p| p.value.clone())
+            .ok_or_else(|| SQLRiteError::Internal("empty compound identifier".to_string()))?,
+        other => {
+            return Err(SQLRiteError::General(format!(
+                "{fn_name}() argument 0 must be a column reference, got {other:?}"
+            )));
+        }
+    };
+
+    // Arg 1: query string. Evaluated through the normal expression
+    // pipeline so callers can pass a literal `'rust db'` or an
+    // expression that yields TEXT.
+    let q_expr = match &arg_list[1] {
+        FunctionArg::Unnamed(FunctionArgExpr::Expr(e)) => e,
+        other => {
+            return Err(SQLRiteError::NotImplemented(format!(
+                "{fn_name}() argument 1 must be a text expression, got {other:?}"
+            )));
+        }
+    };
+    let query = match eval_expr(q_expr, table, rowid)? {
+        Value::Text(s) => s,
+        other => {
+            return Err(SQLRiteError::General(format!(
+                "{fn_name}() argument 1 must be TEXT, got {}",
+                other.to_display_string()
+            )));
+        }
+    };
+
+    let entry = table
+        .fts_indexes
+        .iter()
+        .find(|e| e.column_name == col_name)
+        .ok_or_else(|| {
+            SQLRiteError::General(format!(
+                "{fn_name}({col_name}, ...): no FTS index on column '{col_name}' \
+                 (run CREATE INDEX <name> ON <table> USING fts({col_name}) first)"
+            ))
+        })?;
+    Ok((entry, query))
 }
 
 // -----------------------------------------------------------------

--- a/src/sql/fts/mod.rs
+++ b/src/sql/fts/mod.rs
@@ -1,9 +1,7 @@
 //! Full-text search (FTS) — inverted-index keyword retrieval with BM25
 //! ranking. Pure algorithms; no SQL integration in this module.
 //!
-//! Phase 8 of the SQLRite roadmap; see [`docs/phase-8-plan.md`]. This is
-//! sub-phase 8a, the standalone trio that the SQL surface (8b) and
-//! persistence layer (8c) build on top of:
+//! Phase 8 of the SQLRite roadmap; see `docs/phase-8-plan.md`.
 //!
 //! - [`tokenizer`] — split text into terms (ASCII MVP per Q3).
 //! - [`bm25`] — BM25 relevance scoring (`k1 = 1.5`, `b = 0.75`, fixed per
@@ -11,11 +9,11 @@
 //! - [`posting_list`] — in-memory inverted index keyed by term, holding
 //!   per-document term frequencies + lengths. Insert / remove / query.
 //!
-//! Mirrors the shape of [`crate::sql::hnsw`] (Phase 7d.1's standalone
-//! algorithm module): infallible public API, no project-error coupling,
-//! zero crate deps beyond `std`. The integration concerns — `IndexMethod`
-//! arms, `fts_match` / `bm25_score` scalar fns, the `try_fts_probe`
-//! optimizer hook, `KIND_FTS_POSTING` cell encoding — all land in 8b/8c.
+//! Phase 8a shipped these standalone algorithms; Phase 8b wires them
+//! into the SQL surface (`CREATE INDEX … USING fts(<col>)`,
+//! `fts_match`, `bm25_score`, the `try_fts_probe` optimizer hook).
+//! Persistence of the posting lists themselves arrives with Phase 8c
+//! (`KIND_FTS_POSTING` cell encoding).
 
 pub mod bm25;
 pub mod posting_list;

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1510,6 +1510,237 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
+    // Phase 8b — CREATE INDEX … USING fts end-to-end
+    // -----------------------------------------------------------------
+
+    /// 5-row docs(id INTEGER PK, body TEXT) populated with overlapping
+    /// vocabulary so BM25 ranking has interesting structure.
+    fn seed_fts_table() -> Database {
+        let mut db = Database::new("tempdb".to_string());
+        process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        for body in &[
+            "rust embedded database",        // id=1 — both 'rust' and 'embedded'
+            "rust web framework",            // id=2 — 'rust' only
+            "go embedded systems",           // id=3 — 'embedded' only
+            "python web framework",          // id=4 — neither
+            "rust rust rust embedded power", // id=5 — heavy on 'rust'
+        ] {
+            process_command(
+                &format!("INSERT INTO docs (body) VALUES ('{body}');"),
+                &mut db,
+            )
+            .unwrap();
+        }
+        db
+    }
+
+    #[test]
+    fn create_index_using_fts_succeeds_and_indexes_existing_rows() {
+        let mut db = seed_fts_table();
+        let resp =
+            process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        assert!(resp.to_lowercase().contains("create index"), "got {resp}");
+        let table = db.get_table("docs".to_string()).unwrap();
+        assert_eq!(table.fts_indexes.len(), 1);
+        assert_eq!(table.fts_indexes[0].name, "ix_body");
+        assert_eq!(table.fts_indexes[0].column_name, "body");
+        // All five rows should be in the in-memory PostingList.
+        assert_eq!(table.fts_indexes[0].index.len(), 5);
+    }
+
+    #[test]
+    fn create_index_using_fts_rejects_non_text_column() {
+        let mut db = Database::new("tempdb".to_string());
+        process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER);",
+            &mut db,
+        )
+        .unwrap();
+        let err = process_command("CREATE INDEX ix_n ON t USING fts (n);", &mut db).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("text"),
+            "expected error mentioning TEXT; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn fts_match_returns_expected_rows() {
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        // Rows that contain 'rust': ids 1, 2, 5.
+        let resp = process_command(
+            "SELECT id FROM docs WHERE fts_match(body, 'rust');",
+            &mut db,
+        )
+        .unwrap();
+        assert!(resp.contains("3 rows returned"), "got: {resp}");
+    }
+
+    #[test]
+    fn fts_match_without_index_errors_clearly() {
+        let mut db = seed_fts_table();
+        // No CREATE INDEX — fts_match must surface a useful error.
+        let err = process_command(
+            "SELECT id FROM docs WHERE fts_match(body, 'rust');",
+            &mut db,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("no FTS index"),
+            "expected no-index error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn bm25_score_orders_descending_by_relevance() {
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        // ORDER BY bm25_score DESC LIMIT 1: id=5 has 'rust' three times in
+        // a 5-token doc — highest tf, modest length penalty → top score.
+        let out = process_command_with_render(
+            "SELECT id FROM docs WHERE fts_match(body, 'rust') \
+             ORDER BY bm25_score(body, 'rust') DESC LIMIT 1;",
+            &mut db,
+        )
+        .unwrap();
+        assert!(out.status.contains("1 row returned"), "got: {}", out.status);
+        let rendered = out.rendered.expect("SELECT should produce rendered output");
+        // The rendered prettytable contains the integer 5 in a cell.
+        assert!(
+            rendered.contains(" 5 "),
+            "expected id=5 to be top-ranked; rendered:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn bm25_score_without_index_errors_clearly() {
+        let mut db = seed_fts_table();
+        let err = process_command(
+            "SELECT id FROM docs ORDER BY bm25_score(body, 'rust') DESC LIMIT 1;",
+            &mut db,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("no FTS index"),
+            "expected no-index error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn fts_post_create_inserts_are_indexed_incrementally() {
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        process_command(
+            "INSERT INTO docs (body) VALUES ('rust embedded analytics');",
+            &mut db,
+        )
+        .unwrap();
+        let table = db.get_table("docs".to_string()).unwrap();
+        // PostingList::len() reports doc count; should be 6 now.
+        assert_eq!(table.fts_indexes[0].index.len(), 6);
+        // 'analytics' appears only in the new row → query returns 1 hit.
+        let resp = process_command(
+            "SELECT id FROM docs WHERE fts_match(body, 'analytics');",
+            &mut db,
+        )
+        .unwrap();
+        assert!(resp.contains("1 row returned"), "got: {resp}");
+    }
+
+    #[test]
+    fn delete_on_fts_indexed_table_marks_dirty() {
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        let resp = process_command("DELETE FROM docs WHERE id = 1;", &mut db).unwrap();
+        assert!(resp.contains("1 row"), "got: {resp}");
+        let docs = db.get_table("docs".to_string()).unwrap();
+        let entry = docs
+            .fts_indexes
+            .iter()
+            .find(|e| e.name == "ix_body")
+            .unwrap();
+        assert!(
+            entry.needs_rebuild,
+            "DELETE should have flagged the FTS index dirty"
+        );
+    }
+
+    #[test]
+    fn update_on_fts_indexed_text_col_marks_dirty() {
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        let resp = process_command(
+            "UPDATE docs SET body = 'java spring framework' WHERE id = 1;",
+            &mut db,
+        )
+        .unwrap();
+        assert!(resp.contains("1 row"), "got: {resp}");
+        let docs = db.get_table("docs".to_string()).unwrap();
+        let entry = docs
+            .fts_indexes
+            .iter()
+            .find(|e| e.name == "ix_body")
+            .unwrap();
+        assert!(
+            entry.needs_rebuild,
+            "UPDATE on the indexed TEXT column should have flagged dirty"
+        );
+    }
+
+    #[test]
+    fn fts_index_name_collides_with_btree_and_hnsw_namespaces() {
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        let err = process_command("CREATE INDEX ix_body ON docs (body);", &mut db).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("already exists"),
+            "expected duplicate-index error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn fts_index_rejects_unique() {
+        let mut db = seed_fts_table();
+        let err = process_command(
+            "CREATE UNIQUE INDEX ix_body ON docs USING fts (body);",
+            &mut db,
+        )
+        .unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("unique"),
+            "expected UNIQUE-rejection error; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_fts_probe_falls_through_on_ascending() {
+        // BM25 is "higher = better"; ASC is rejected so the slow path
+        // applies. We verify by running the query and checking the
+        // result is still correct (the slow path goes through scalar
+        // bm25_score on every row).
+        let mut db = seed_fts_table();
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+        // Same query as bm25_score_orders_descending but ASC → should
+        // still succeed (slow path), and id=5 should now be LAST.
+        let resp = process_command(
+            "SELECT id FROM docs WHERE fts_match(body, 'rust') \
+             ORDER BY bm25_score(body, 'rust') ASC LIMIT 3;",
+            &mut db,
+        )
+        .unwrap();
+        assert!(resp.contains("3 rows returned"), "got: {resp}");
+    }
+
+    // -----------------------------------------------------------------
     // Phase 7b — vector distance functions through process_command
     // -----------------------------------------------------------------
 

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -158,9 +158,15 @@ pub fn open_database_with_mode(path: &Path, db_name: String, mode: AccessMode) -
     // form is just the CREATE INDEX SQL — the graph itself isn't
     // persisted yet (Phase 7d.3). Detect HNSW via the SQL's USING clause
     // and route to a graph-rebuild instead of the B-Tree-cell load.
+    //
+    // Phase 8b — same shape for FTS indexes. The posting lists aren't
+    // persisted yet (Phase 8c), so we replay the CREATE INDEX SQL on
+    // open and let `execute_create_index` walk current rows.
     for row in index_rows {
         if create_index_sql_uses_hnsw(&row.sql) {
             rebuild_hnsw_index(&mut db, &pager, &row)?;
+        } else if create_index_sql_uses_fts(&row.sql) {
+            rebuild_fts_index(&mut db, &row)?;
         } else {
             attach_index(&mut db, &pager, row)?;
         }
@@ -187,6 +193,8 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
     // already hold, before the immutable iteration loops below need
     // their own borrow.
     rebuild_dirty_hnsw_indexes(db);
+    // Phase 8b — same drill for FTS indexes flagged by DELETE / UPDATE.
+    rebuild_dirty_fts_indexes(db);
 
     let same_path = db.source_path.as_deref() == Some(path);
     let mut pager = if same_path {
@@ -279,6 +287,31 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
                 entry.name, table.tb_name, entry.column_name
             ),
             rootpage,
+            last_rowid: 0,
+        });
+    }
+
+    // 2c. Phase 8b — persist a sqlrite_master entry for each FTS index
+    //     so it's replayed on open. The posting list itself isn't on
+    //     disk yet (Phase 8c) — `rootpage = 0` signals replay-from-rows
+    //     to `rebuild_fts_index`. Mirrors HNSW's pre-7d.3 shape.
+    let mut fts_entries: Vec<(&Table, &crate::sql::db::table::FtsIndexEntry)> = Vec::new();
+    for table in db.tables.values() {
+        for entry in &table.fts_indexes {
+            fts_entries.push((table, entry));
+        }
+    }
+    fts_entries
+        .sort_by(|(ta, ea), (tb, eb)| ta.tb_name.cmp(&tb.tb_name).then(ea.name.cmp(&eb.name)));
+    for (table, entry) in fts_entries {
+        master_rows.push(CatalogEntry {
+            kind: "index".into(),
+            name: entry.name.clone(),
+            sql: format!(
+                "CREATE INDEX {} ON {} USING fts ({})",
+                entry.name, table.tb_name, entry.column_name
+            ),
+            rootpage: 0,
             last_rowid: 0,
         });
     }
@@ -478,6 +511,11 @@ fn build_empty_table(name: &str, columns: Vec<Column>, last_rowid: i64) -> Table
         // graph from current row data. Persistence of the graph itself
         // (avoiding the on-open rebuild cost) is Phase 7d.3.
         hnsw_indexes: Vec::new(),
+        // FTS indexes (Phase 8b) follow the same pattern — the
+        // CREATE INDEX … USING fts SQL is the source of truth on open
+        // and the in-memory posting list gets rebuilt from current
+        // rows. Cell-encoded persistence of the postings is Phase 8c.
+        fts_indexes: Vec::new(),
         last_rowid,
         primary_key,
     }
@@ -652,6 +690,41 @@ fn create_index_sql_uses_hnsw(sql: &str) -> bool {
         return false;
     };
     matches!(using, Some(IndexType::Custom(ident)) if ident.value.eq_ignore_ascii_case("hnsw"))
+}
+
+/// Phase 8b — peeks at a CREATE INDEX SQL to detect `USING fts(...)`.
+/// Mirrors [`create_index_sql_uses_hnsw`].
+fn create_index_sql_uses_fts(sql: &str) -> bool {
+    use sqlparser::ast::{CreateIndex, IndexType, Statement};
+
+    let dialect = SQLiteDialect {};
+    let Ok(mut ast) = Parser::parse_sql(&dialect, sql) else {
+        return false;
+    };
+    let Some(Statement::CreateIndex(CreateIndex { using, .. })) = ast.pop() else {
+        return false;
+    };
+    matches!(using, Some(IndexType::Custom(ident)) if ident.value.eq_ignore_ascii_case("fts"))
+}
+
+/// Phase 8b — replays a `CREATE INDEX … USING fts(...)` statement on
+/// database open to rebuild its in-memory `PostingList` from current
+/// rows. Mirrors the `rootpage == 0` arm of [`rebuild_hnsw_index`].
+/// Persistence of the posting lists themselves is Phase 8c.
+fn rebuild_fts_index(db: &mut Database, row: &IndexCatalogRow) -> Result<()> {
+    use crate::sql::executor::execute_create_index;
+    use sqlparser::ast::Statement;
+
+    let dialect = SQLiteDialect {};
+    let mut ast = Parser::parse_sql(&dialect, &row.sql).map_err(SQLRiteError::from)?;
+    let Some(stmt @ Statement::CreateIndex(_)) = ast.pop() else {
+        return Err(SQLRiteError::Internal(format!(
+            "sqlrite_master FTS row's SQL isn't a CREATE INDEX: {}",
+            row.sql
+        )));
+    };
+    execute_create_index(&stmt, db)?;
+    Ok(())
 }
 
 /// Loads (or rebuilds) an HNSW index on database open. Two paths:
@@ -837,6 +910,62 @@ fn rebuild_dirty_hnsw_indexes(db: &mut Database) {
 
             // Replace the entry's index + clear the dirty flag.
             if let Some(entry) = table.hnsw_indexes.iter_mut().find(|e| e.name == idx_name) {
+                entry.index = new_idx;
+                entry.needs_rebuild = false;
+            }
+        }
+    }
+}
+
+/// Phase 8b — rebuild every FTS index a DELETE / UPDATE-on-text-col
+/// marked dirty. Mirrors [`rebuild_dirty_hnsw_indexes`]; runs at save
+/// time under `&mut Database`. Cheap on a clean DB (the `dirty` snapshot
+/// is empty so the per-table loop short-circuits).
+fn rebuild_dirty_fts_indexes(db: &mut Database) {
+    use crate::sql::fts::PostingList;
+
+    for table in db.tables.values_mut() {
+        let dirty: Vec<(String, String)> = table
+            .fts_indexes
+            .iter()
+            .filter(|e| e.needs_rebuild)
+            .map(|e| (e.name.clone(), e.column_name.clone()))
+            .collect();
+        if dirty.is_empty() {
+            continue;
+        }
+
+        for (idx_name, col_name) in dirty {
+            // Snapshot every (rowid, text) pair for this column under
+            // the row mutex, then drop the lock before re-tokenizing.
+            let mut docs: Vec<(i64, String)> = Vec::new();
+            {
+                let row_data = table.rows.lock().expect("rows mutex poisoned");
+                if let Some(Row::Text(map)) = row_data.get(&col_name) {
+                    for (id, v) in map.iter() {
+                        // "Null" sentinel is the parser's
+                        // null-marker for TEXT cells; skip those —
+                        // they'd round-trip as the literal string
+                        // "Null" otherwise. Aligns with insert_row's
+                        // typed_value gate.
+                        if v != "Null" {
+                            docs.push((*id, v.clone()));
+                        }
+                    }
+                }
+            }
+
+            let mut new_idx = PostingList::new();
+            // Sort by id so the rebuild is deterministic across runs
+            // (the BTreeMap inside PostingList is order-stable, but
+            // doc-length aggregation order doesn't matter — sorting
+            // here is purely for reproducibility on inspection).
+            docs.sort_by_key(|(id, _)| *id);
+            for (id, text) in &docs {
+                new_idx.insert(*id, text);
+            }
+
+            if let Some(entry) = table.fts_indexes.iter_mut().find(|e| e.name == idx_name) {
                 entry.index = new_idx;
                 entry.needs_rebuild = false;
             }
@@ -1498,6 +1627,110 @@ mod tests {
         )
         .unwrap();
         assert!(resp.contains("3 rows returned"), "got: {resp}");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn round_trip_rebuilds_fts_index_from_create_sql() {
+        // Phase 8b — FTS indexes don't yet persist their posting lists
+        // (Phase 8c does that). On open, sqlrite_master records the
+        // CREATE INDEX SQL and `rebuild_fts_index` replays it through
+        // `execute_create_index`, walking current rows.
+        let path = tmp_path("fts_roundtrip");
+
+        {
+            let mut db = Database::new("test".to_string());
+            process_command(
+                "CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT);",
+                &mut db,
+            )
+            .unwrap();
+            for body in &[
+                "rust embedded database",
+                "rust web framework",
+                "go embedded systems",
+                "python web framework",
+                "rust rust embedded power",
+            ] {
+                process_command(
+                    &format!("INSERT INTO docs (body) VALUES ('{body}');"),
+                    &mut db,
+                )
+                .unwrap();
+            }
+            process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+            save_database(&mut db, &path).expect("save");
+        } // db drops → exclusive lock releases.
+
+        let mut loaded = open_database(&path, "test".to_string()).expect("open");
+        {
+            let table = loaded.get_table("docs".to_string()).expect("docs");
+            assert_eq!(table.fts_indexes.len(), 1, "FTS index should reattach");
+            let entry = &table.fts_indexes[0];
+            assert_eq!(entry.name, "ix_body");
+            assert_eq!(entry.column_name, "body");
+            assert_eq!(
+                entry.index.len(),
+                5,
+                "rebuilt posting list should hold all 5 rows"
+            );
+            assert!(!entry.needs_rebuild);
+        }
+
+        // Functional smoke: an FTS query through the reloaded index
+        // returns the expected hit count.
+        let resp = process_command(
+            "SELECT id FROM docs WHERE fts_match(body, 'rust');",
+            &mut loaded,
+        )
+        .unwrap();
+        assert!(resp.contains("3 rows returned"), "got: {resp}");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn delete_then_save_then_reopen_excludes_deleted_node_from_fts() {
+        // Phase 8b — DELETE marks the FTS index dirty; save rebuilds it
+        // from current rows; reopen replays the CREATE INDEX SQL against
+        // the post-delete row set. The deleted rowid must not surface
+        // in `fts_match` results post-reopen.
+        let path = tmp_path("fts_delete_rebuild");
+        let mut db = Database::new("test".to_string());
+        process_command(
+            "CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        for body in &[
+            "rust embedded",
+            "rust framework",
+            "go embedded",
+            "python web",
+        ] {
+            process_command(
+                &format!("INSERT INTO docs (body) VALUES ('{body}');"),
+                &mut db,
+            )
+            .unwrap();
+        }
+        process_command("CREATE INDEX ix_body ON docs USING fts (body);", &mut db).unwrap();
+
+        // Delete row 1 ('rust embedded'); save (rebuild fires); reopen.
+        process_command("DELETE FROM docs WHERE id = 1;", &mut db).unwrap();
+        save_database(&mut db, &path).expect("save");
+        drop(db);
+
+        let mut loaded = open_database(&path, "test".to_string()).expect("open");
+        let resp = process_command(
+            "SELECT id FROM docs WHERE fts_match(body, 'rust');",
+            &mut loaded,
+        )
+        .unwrap();
+        // Pre-delete: 2 rows ('rust embedded', 'rust framework') had
+        // 'rust'. Post-delete: only id=2 remains.
+        assert!(resp.contains("1 row returned"), "got: {resp}");
 
         cleanup(&path);
     }


### PR DESCRIPTION
## Summary

Second sub-phase of [Phase 8](docs/phase-8-plan.md). Wires the standalone FTS algorithms shipped in [#78](https://github.com/joaoh82/rust_sqlite/pull/78) into the SQL executor end-to-end. Mirrors the Phase 7d.2 HNSW integration shape across every touchpoint.

User-visible:

\`\`\`sql
CREATE INDEX ix ON docs USING fts (body);

-- predicate: row contains any query term?
SELECT id FROM docs WHERE fts_match(body, 'rust embedded');

-- BM25 ranking, top-k (uses the optimizer probe):
SELECT id FROM docs
 WHERE fts_match(body, 'rust embedded')
 ORDER BY bm25_score(body, 'rust embedded') DESC
 LIMIT 10;
\`\`\`

## Engine plumbing

- **\`Table\` struct** ([src/sql/db/table.rs](src/sql/db/table.rs)) — new \`FtsIndexEntry { name, column_name, index: PostingList, needs_rebuild }\` mirroring \`HnswIndexEntry\` field-for-field; \`Table::fts_indexes\` alongside \`hnsw_indexes\`; \`maintain_fts_on_insert\` hook in \`insert_row\` after the HNSW step.
- **Executor** ([src/sql/executor.rs](src/sql/executor.rs)):
  - \`IndexMethod::Fts\` arm + \`\"fts\"\` string-match in the \`CREATE INDEX … USING\` dispatch
  - \`create_fts_index\` validates TEXT (rejects VECTOR/JSON/INTEGER with a clear error), seeds the \`PostingList\` from existing rows, pushes \`FtsIndexEntry\`
  - \`fts_match\` / \`bm25_score\` scalar fns in \`eval_function\` — bare column ident in arg 0, TEXT expression in arg 1; both error if no FTS index covers the column
  - \`try_fts_probe\` optimizer hook recognizes \`ORDER BY bm25_score(col, 'q') DESC LIMIT k\` and serves it from \`PostingList::query\` (top-k lookup). ASC falls through to scalar eval. WHERE-drop posture mirrors \`try_hnsw_probe\` per [Phase 8 Q6](docs/phase-8-plan.md#q6-filtered-fts).
  - DELETE / UPDATE flag \`fts_indexes[i].needs_rebuild = true\`, same shape as HNSW
  - Name uniqueness check now spans btree + hnsw + fts namespaces
- **Pager** ([src/sql/pager/mod.rs](src/sql/pager/mod.rs)):
  - \`rebuild_dirty_fts_indexes\` runs at \`save_database\` start, replaces the \`PostingList\` from current rows
  - \`rebuild_fts_index\` replays \`CREATE INDEX … USING fts\` SQL on open (rootpage=0; cell-encoded posting persistence lands in 8c)
  - Each FTS index gets a \`sqlrite_master\` row so it survives save/reopen

## Test plan

- [x] 12 new integration tests in [src/sql/mod.rs](src/sql/mod.rs) — CREATE INDEX, \`fts_match\` WHERE, \`bm25_score\` ORDER BY, incremental INSERT, DELETE/UPDATE dirty-flagging, name collisions, UNIQUE rejection, ASC fall-through
- [x] 2 persistence round-trip tests in [src/sql/pager/mod.rs](src/sql/pager/mod.rs) — re-open + query, and delete + save + reopen excludes the deleted row from FTS hits
- [x] \`cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets\` — clean
- [x] \`cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs\` — 287 / 287 engine + 73 across other crates green
- [x] \`cargo fmt --all -- --check\` — no diff
- [x] \`cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets\` — no new FTS warnings (engine total dropped from 22 → 19)
- [x] \`cargo doc --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --no-deps\` — no FTS doc warnings

## Out of scope (later sub-phases)

| Concern | Lands in |
|---|---|
| \`KIND_FTS_POSTING\` cell encoding + v4→v5 file-format bump | 8c |
| Hybrid retrieval worked example | 8d |
| MCP \`bm25_search\` tool | 8e |
| Docs sweep (\`docs/fts.md\`, \`supported-sql.md\`, etc.) | 8f |

## Known limitations (documented per Phase 8 plan)

- \`try_fts_probe\` ignores the WHERE clause when it fires, mirroring \`try_hnsw_probe\`. Canonical \`WHERE fts_match(...)\` is implicitly satisfied; additional WHERE conditions on the optimizer fast path are silently dropped (Q6).
- DELETE / UPDATE flag \`needs_rebuild = true\` and rebuild at save (Q7); incremental delete is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)