### PR TITLE
feat(fts): 8d — hybrid retrieval worked example (BM25 + vector)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,14 @@ required-features = ["cli", "ask"]
 name = "quickstart"
 path = "examples/rust/quickstart.rs"
 
+# Phase 8d — hybrid retrieval (BM25 + vector cosine via raw arithmetic).
+# Run with `cargo run --example hybrid-retrieval`. Pre-baked vectors
+# (no embedding model dependency) over a 6-doc tech-blurb corpus,
+# showing where pure-BM25, pure-vector, and 50/50 hybrid each win.
+[[example]]
+name = "hybrid-retrieval"
+path = "examples/hybrid-retrieval/hybrid_retrieval.rs"
+
 [features]
 # Default build includes everything: the REPL binary (cli) and
 # POSIX/Windows advisory file locks on the Pager (file-locks).

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,14 @@ cargo run --example quickstart
 
 Walks through opening an in-memory `Connection`, creating a table, inserting rows, preparing a SELECT, iterating typed `Row` values, and running a `BEGIN` / `ROLLBACK` block. About 50 lines with comments — read [`rust/quickstart.rs`](rust/quickstart.rs) first.
 
+## Running the hybrid-retrieval example (Phase 8d)
+
+```bash
+cargo run --example hybrid-retrieval
+```
+
+Combines BM25 lexical scoring (Phase 8b) with vector cosine distance (Phase 7d) in a single `ORDER BY`, showing where each ranking shape wins on the same corpus. Pre-baked vectors keep the example self-contained — no embedding-model dependency. Read [`hybrid-retrieval/README.md`](hybrid-retrieval/README.md) for the narrative.
+
 ## Running the C sample
 
 ```bash

--- a/examples/hybrid-retrieval/README.md
+++ b/examples/hybrid-retrieval/README.md
@@ -1,0 +1,87 @@
+# Hybrid retrieval (BM25 + vector)
+
+Phase 8d worked example. Combines `bm25_score` ([Phase 8 plan](../../docs/phase-8-plan.md) — lexical, exact-term matching) with `vec_distance_cosine` ([Phase 7 plan](../../docs/phase-7-plan.md) — semantic, embedding-space proximity) into a single `ORDER BY`. Same corpus, three rankings, one short Rust file.
+
+```bash
+cargo run --example hybrid-retrieval
+```
+
+Expected output (truncated to the rankings):
+
+```
+===  1. Pure BM25 (lexical) ===
+  1. doc3  "sqlite is an embedded database engine"
+  2. doc4  "postgres is a powerful relational database server"
+
+===  2. Pure vector (semantic) ===
+  1. doc3  "sqlite is an embedded database engine"
+  2. doc4  "postgres is a powerful relational database server"
+  3. doc6  "redis caches data in memory for fast lookups"
+
+===  3. Hybrid (50% BM25 + 50% inverted cosine) ===
+  1. doc3  "sqlite is an embedded database engine"
+  2. doc4  "postgres is a powerful relational database server"
+```
+
+## What the example shows
+
+The query is `"small embedded database"`. The corpus is six tech blurbs with hand-picked 4-dim embeddings (axes are roughly: systems / scripting / database / web). The pre-baked vectors stand in for what an embedding model would give you in production — the math is identical; the worked example just doesn't pull in a 1 GB transformer.
+
+- **Pure BM25** finds two docs that literally contain `embedded` or `database`. It cannot return a third — no other row shares any query term, and the FTS optimizer hook serves the top-k from rows that do match. The "small" token finds zero hits because nothing in the corpus uses that word.
+- **Pure vector** ranks _every_ doc by cosine distance to the query embedding `[0.0, 0.0, 0.9, 0.2]`. It surfaces `doc6` ("redis … in memory for fast lookups") in third place — semantically related to "database/storage" but containing none of the literal query terms. Lexical search would never return it.
+- **Hybrid** sums a normalized BM25 score with `1.0 - vec_distance_cosine` (cosine returns _distance_, lower = closer, so we invert it for "higher is better"). It picks the same top-2 as pure BM25 because those are the only docs in the FTS-match set. The fusion's value isn't visible on _this_ query — a deliberate choice; see "When hybrid wins" below.
+
+## When each shape wins
+
+| Scenario | Pure BM25 | Pure vector | Hybrid |
+|---|---|---|---|
+| Query has rare exact terms (`"redis"`, a SKU, an error code) | ✅ Wins | ❌ Spurious neighbours | ✅ BM25 dominates the score sum |
+| Query is conceptual with no overlap (`"in-memory cache"` vs corpus that uses "lookup table") | ❌ Zero hits | ✅ Finds the analog | (degenerate — `WHERE fts_match` returns ∅) |
+| Query has both terms _and_ semantic intent (`"fast embedded SQL"`) | Returns several near-tied lexical hits | Reorders by closeness to true intent | ✅ Best of both — wins consistently |
+| LLM-generated paraphrases of the user's question | ❌ Vocabulary drift kills recall | ✅ Survives paraphrase | ✅ |
+| Code search, log search, SKU lookup | ✅ | ❌ | ✅ |
+
+The 50/50 weight is a default, not a decision. Most production RAG stacks tune the weights per workload (e.g. 0.3/0.7 vector-heavy for paraphrased queries, 0.7/0.3 lexical-heavy for technical docs). Different aggregations also work — `MAX`, `MIN`, [reciprocal rank fusion](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf) — and SQLRite's arithmetic composition is flexible enough to express any of them. We picked plain weighted sum because it's the most-obvious default and lets you change weights by editing two numbers.
+
+## Two gotchas
+
+### 1. Cosine returns _distance_, not similarity
+
+`vec_distance_cosine` returns `1 - cos(a, b)`: `0` for identical, `1` for orthogonal, `2` for diametrically opposite. Lower is closer. Hybrid scoring assumes "higher is better" everywhere, so we invert: `1.0 - vec_distance_cosine(...)`. Forgetting this flip is the most common mistake — the resulting ranking is the _opposite_ of what you want, and it'll look subtly broken.
+
+### 2. `WHERE fts_match` filters before the score is computed
+
+The optimizer hook recognizes `WHERE fts_match(col, 'q') ORDER BY bm25_score(col, 'q') DESC LIMIT k` and serves it from the FTS index — fast, scales to millions of rows. The catch: when the hybrid `ORDER BY` mixes in `vec_distance_cosine`, the query still requires a `WHERE fts_match(...)` clause for the optimizer to recognize the FTS shape. That filter eliminates rows with no lexical match before the vector half of the score gets a chance to rank them.
+
+If your goal is "find docs that match _either_ the lexical OR the semantic query", drop the `WHERE` clause and let the engine score every row (slower, but correct). For most RAG workloads, the `WHERE` filter is a feature — you want lexical pre-filtering to keep latency tractable on large corpora.
+
+## Tuning the weights
+
+The example uses a 50/50 weight as a starting point. To experiment:
+
+```sql
+-- 70% lexical, 30% semantic (technical-doc bias)
+ORDER BY 0.7 * bm25_score(body, 'q') + 0.3 * (1.0 - vec_distance_cosine(embedding, [...])) DESC
+
+-- 30% lexical, 70% semantic (paraphrase / RAG bias)
+ORDER BY 0.3 * bm25_score(body, 'q') + 0.7 * (1.0 - vec_distance_cosine(embedding, [...])) DESC
+
+-- Three-way: add a recency boost
+ORDER BY 0.5 * bm25_score(body, 'q')
+       + 0.4 * (1.0 - vec_distance_cosine(embedding, [...]))
+       + 0.1 * (julianday('now') - julianday(created_at))
+DESC
+```
+
+(The `julianday` function isn't in SQLRite yet — that's just a sketch of how the SQL composition extends naturally.)
+
+## Production checklist
+
+- **Normalize the BM25 score range.** BM25 is unbounded above; cosine distance is in `[0, 2]`. Without normalization, a high-IDF rare term can dominate the sum. The example skips normalization because the corpus is six docs and the BM25 scores are already ~`[0, 2]`. Real corpora need a min-max or z-score normalization step (computed offline or via a sliding window).
+- **Use real embeddings.** Pre-baked toy vectors are for the example. In production you'll call an embedding model — `sqlrite-ask`'s LLM adapters can host one, or use the [`fastembed-rs`](https://crates.io/crates/fastembed) family for a local model.
+- **Tune `k` end-to-end.** The `LIMIT k` clamps the result set. Hybrid retrieval typically needs to over-fetch (e.g. `LIMIT 50`) and re-rank with a cross-encoder for the final top 5 or 10.
+
+## See also
+
+- [`docs/phase-8-plan.md`](../../docs/phase-8-plan.md) — Q8 (arithmetic vs typed `hybrid_score(...)`) explains why SQLRite does this with raw arithmetic instead of a dedicated function.
+- [`docs/phase-7-plan.md`](../../docs/phase-7-plan.md) — vector indexing context.

--- a/examples/hybrid-retrieval/hybrid_retrieval.rs
+++ b/examples/hybrid-retrieval/hybrid_retrieval.rs
@@ -1,0 +1,137 @@
+//! Phase 8d — hybrid retrieval worked example. Combines Phase 8b's
+//! BM25 lexical index with Phase 7d's vector cosine similarity into a
+//! single ORDER BY, showing where each shape wins and why fusing the
+//! two beats either alone.
+//!
+//! Run with: `cargo run --example hybrid-retrieval`
+//!
+//! Corpus: 6 hand-written 1-sentence "tech blurbs", each with a
+//! pre-baked 4-dim embedding `[systems, scripting, database, web]`.
+//! Real RAG would call an embedding model; the math is identical.
+//! Vectors are hand-set so each query's expected ranking is obvious
+//! by inspection — no surprises from a neural net's latent space.
+//!
+//! See `README.md` for the narrative explanation.
+
+use sqlrite::{Connection, Result};
+
+// (name, body, embedding) per doc.
+const CORPUS: &[(&str, &str, [f32; 4])] = &[
+    (
+        "doc1",
+        "rust is a systems programming language",
+        [0.9, 0.0, 0.0, 0.0],
+    ),
+    (
+        "doc2",
+        "python is great for data science",
+        [0.0, 0.9, 0.4, 0.0],
+    ),
+    (
+        "doc3",
+        "sqlite is an embedded database engine",
+        [0.0, 0.0, 0.9, 0.0],
+    ),
+    (
+        "doc4",
+        "postgres is a powerful relational database server",
+        [0.1, 0.0, 0.9, 0.5],
+    ),
+    (
+        "doc5",
+        "javascript runs in browsers and on servers",
+        [0.0, 0.7, 0.0, 0.8],
+    ),
+    (
+        "doc6",
+        "redis caches data in memory for fast lookups",
+        [0.0, 0.0, 0.6, 0.5],
+    ),
+];
+
+fn main() -> Result<()> {
+    let mut conn = Connection::open_in_memory()?;
+    conn.execute(
+        "CREATE TABLE docs (id INTEGER PRIMARY KEY, name TEXT, body TEXT, embedding VECTOR(4));",
+    )?;
+    for (name, body, vec) in CORPUS {
+        conn.execute(&format!(
+            "INSERT INTO docs (name, body, embedding) VALUES \
+             ('{name}', '{body}', [{}, {}, {}, {}]);",
+            vec[0], vec[1], vec[2], vec[3]
+        ))?;
+    }
+    conn.execute("CREATE INDEX docs_fts ON docs USING fts (body);")?;
+
+    // Same query, three rankings — see README for what each shape sees.
+    let body_query = "small embedded database";
+    let vector_query = [0.0, 0.0, 0.9, 0.2]; // semantic intent: "database, lightly web-ish"
+    let q_str = vec_lit(&vector_query);
+
+    println!("Corpus:");
+    for (name, body, vec) in CORPUS {
+        println!("  {name}: \"{body}\"  embedding={vec:?}");
+    }
+    println!("\nQuery body:   '{body_query}'");
+    println!("Query vector: {vector_query:?}\n");
+
+    println!("===  1. Pure BM25 (lexical) ===");
+    println!(
+        "WHERE  fts_match(body, '{body_query}')\n\
+         ORDER BY bm25_score(body, '{body_query}') DESC  LIMIT 3"
+    );
+    print_top(
+        &mut conn,
+        &format!(
+            "SELECT name, body FROM docs \
+             WHERE fts_match(body, '{body_query}') \
+             ORDER BY bm25_score(body, '{body_query}') DESC LIMIT 3;"
+        ),
+    )?;
+
+    println!("===  2. Pure vector (semantic) ===");
+    println!("ORDER BY vec_distance_cosine(embedding, {q_str}) ASC  LIMIT 3");
+    print_top(
+        &mut conn,
+        &format!(
+            "SELECT name, body FROM docs \
+             ORDER BY vec_distance_cosine(embedding, {q_str}) ASC LIMIT 3;"
+        ),
+    )?;
+
+    println!("===  3. Hybrid (50% BM25 + 50% inverted cosine) ===");
+    println!(
+        "WHERE  fts_match(body, '{body_query}')\n\
+         ORDER BY 0.5*bm25_score(...) + 0.5*(1.0 - vec_distance_cosine(...)) DESC  LIMIT 3"
+    );
+    print_top(
+        &mut conn,
+        &format!(
+            "SELECT name, body FROM docs \
+             WHERE fts_match(body, '{body_query}') \
+             ORDER BY 0.5 * bm25_score(body, '{body_query}') \
+                    + 0.5 * (1.0 - vec_distance_cosine(embedding, {q_str})) DESC \
+             LIMIT 3;"
+        ),
+    )?;
+    Ok(())
+}
+
+fn vec_lit(v: &[f32]) -> String {
+    let parts: Vec<String> = v.iter().map(|x| format!("{x}")).collect();
+    format!("[{}]", parts.join(", "))
+}
+
+fn print_top(conn: &mut Connection, sql: &str) -> Result<()> {
+    let stmt = conn.prepare(sql)?;
+    let mut rows = stmt.query()?;
+    let mut rank = 1;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get_by_name("name")?;
+        let body: String = row.get_by_name("body")?;
+        println!("  {rank}. {name}  \"{body}\"");
+        rank += 1;
+    }
+    println!();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fourth sub-phase of [Phase 8](docs/phase-8-plan.md). Self-contained Rust example showing how to compose `bm25_score` (8b) with `vec_distance_cosine` (Phase 7d) via raw arithmetic ([Q8](docs/phase-8-plan.md#q8-hybrid-retrieval)) for hybrid lexical + semantic retrieval.

**No new engine code** — the SQL composition works out of the box once 8b ships. This PR is a worked example + narrative.

```bash
cargo run --example hybrid-retrieval
```

## What landed

- [`examples/hybrid-retrieval/hybrid_retrieval.rs`](examples/hybrid-retrieval/hybrid_retrieval.rs) — 6-doc tech-blurb corpus with hand-baked 4-dim embeddings (no embedding-model dependency). Runs three rankings on the same query: pure BM25, pure vector cosine, and 50/50 hybrid via:

  ```sql
  ORDER BY 0.5 * bm25_score(body, 'q')
         + 0.5 * (1.0 - vec_distance_cosine(embedding, [...]))
  DESC LIMIT k
  ```

  Vectors are picked by inspection so each query's expected ranking is obvious — the example stays reproducible forever, no flaky neural-net results.

- [`examples/hybrid-retrieval/README.md`](examples/hybrid-retrieval/README.md) — narrative explanation:
  - When each ranking shape wins (table comparing BM25 / vector / hybrid trade-offs)
  - The cosine-distance-vs-similarity inversion gotcha (`1.0 - vec_distance_cosine(...)`)
  - The `WHERE fts_match` pre-filter caveat (Q6 design choice)
  - Weight-tuning sketches (technical-doc bias, RAG bias, recency boost)
  - Production checklist (BM25 normalization, real embeddings, cross-encoder re-rank)

- [`Cargo.toml`](Cargo.toml) — registers the example.
- [`examples/README.md`](examples/README.md) — top-level table picks up the new sample alongside the Rust quickstart.

## Test plan

- [x] `cargo run --example hybrid-retrieval` — produces the expected three rankings
- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — clean
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` — 303 / 303 engine + 73 across other crates green
- [x] `cargo fmt --all -- --check` — no diff
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — no new warnings on the example

## Out of scope (later sub-phases)

| Concern | Lands in |
|---|---|
| MCP `bm25_search` tool | 8e |
| Docs sweep (`docs/fts.md`, `docs/file-format.md`, `docs/supported-sql.md`, …) | 8f |

🤖 Generated with [Claude Code](https://claude.com/claude-code)