### PR TITLE
feat(fts): 8e — sqlrite-mcp bm25_search tool

### DIFF
--- a/sqlrite-mcp/src/tools/bm25_search.rs
+++ b/sqlrite-mcp/src/tools/bm25_search.rs
@@ -1,0 +1,232 @@
+//! `bm25_search` — top-k keyword retrieval against an FTS-indexed
+//! TEXT column.
+//!
+//! Convenience wrapper over `SELECT * FROM <t> WHERE fts_match(<col>,
+//! 'q') ORDER BY bm25_score(<col>, 'q') DESC LIMIT k`. The LLM could
+//! compose that query itself via the `query` tool, but a typed
+//! `bm25_search(table, column, query, k)` removes a few common
+//! mistakes — forgetting the `WHERE fts_match` pre-filter, dropping
+//! the `DESC` (BM25 is "higher = better"), or quoting the query
+//! string wrong.
+//!
+//! Picks up the engine's FTS optimizer hook automatically: if the
+//! column has a `CREATE INDEX … USING fts (col)` index built (Phase
+//! 8b), the engine recognizes the `ORDER BY bm25_score(col, 'q') DESC
+//! LIMIT k` shape and probes the posting list directly. No special
+//! handling needed at this layer — we just emit the canonical SQL.
+//!
+//! Symmetric with [`super::vector_search`] (Phase 7h), which does the
+//! same thing for vector cosine/L2/dot distances.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::error::ToolError;
+use crate::protocol::ServerState;
+use crate::tools::{TOOL_OUTPUT_CAP_BYTES, is_safe_identifier, value_to_json};
+
+const DEFAULT_K: usize = 10;
+const HARD_CAP_K: usize = 100;
+
+pub fn metadata() -> Value {
+    json!({
+        "name": "bm25_search",
+        "description": "Find the top-k rows ranked by BM25 keyword relevance against \
+                        an FTS-indexed TEXT column. Requires a `CREATE INDEX … USING fts \
+                        (column)` to exist on the column; errors otherwise. Uses any-term \
+                        OR semantics (a row matches if it contains ANY of the query \
+                        terms). Returns the table's columns for the k highest-scoring \
+                        rows, in descending BM25 order. Pairs naturally with `vector_search` \
+                        for hybrid retrieval — the LLM can call both and fuse results \
+                        client-side, or compose them in a single SQL via the `query` tool.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "table": {
+                    "type": "string",
+                    "description": "Table name. Must match `[A-Za-z_][A-Za-z0-9_]*`.",
+                },
+                "column": {
+                    "type": "string",
+                    "description": "FTS-indexed TEXT column on the table. Must match \
+                                    `[A-Za-z_][A-Za-z0-9_]*`.",
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Free-text query. Tokenized the same way the index \
+                                    was built (ASCII split + lowercase for the MVP).",
+                },
+                "k": {
+                    "type": "integer",
+                    "description": "Number of top-ranked rows to return (1..=100, default 10).",
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+            },
+            "required": ["table", "column", "query"],
+            "additionalProperties": false,
+        }
+    })
+}
+
+#[derive(Deserialize)]
+struct Args {
+    table: String,
+    column: String,
+    query: String,
+    #[serde(default)]
+    k: Option<usize>,
+}
+
+pub fn handle(args: Value, state: &mut ServerState) -> Result<String, ToolError> {
+    let args: Args = serde_json::from_value(args)
+        .map_err(|e| ToolError::new(format!("invalid arguments: {e}")))?;
+
+    if !is_safe_identifier(&args.table) {
+        return Err(ToolError::new(format!(
+            "invalid table name `{}`",
+            args.table
+        )));
+    }
+    if !is_safe_identifier(&args.column) {
+        return Err(ToolError::new(format!(
+            "invalid column name `{}`",
+            args.column
+        )));
+    }
+    if args.query.is_empty() {
+        return Err(ToolError::new(
+            "query must be a non-empty string".to_string(),
+        ));
+    }
+
+    let k = args.k.unwrap_or(DEFAULT_K).clamp(1, HARD_CAP_K);
+
+    // Pre-flight: confirm the column exists, is TEXT, and has an FTS
+    // index attached. Cheaper than a SQL-level error after a partial
+    // scan, and the message names exactly what's missing — useful for
+    // an LLM trying to recover.
+    {
+        let db = state.conn.database();
+        let table = db
+            .get_table(args.table.clone())
+            .map_err(|e| ToolError::new(format!("table `{}` not found: {e}", args.table)))?;
+        let target = table
+            .columns
+            .iter()
+            .find(|c| c.column_name == args.column)
+            .ok_or_else(|| {
+                ToolError::new(format!(
+                    "column `{}` not found on table `{}`",
+                    args.column, args.table,
+                ))
+            })?;
+        if !matches!(target.datatype, sqlrite::sql::db::table::DataType::Text) {
+            return Err(ToolError::new(format!(
+                "column `{}` on table `{}` is `{}`, not a TEXT column",
+                args.column, args.table, target.datatype,
+            )));
+        }
+        if !table
+            .fts_indexes
+            .iter()
+            .any(|i| i.column_name == args.column)
+        {
+            return Err(ToolError::new(format!(
+                "column `{}` on table `{}` has no FTS index — \
+                 run `CREATE INDEX <name> ON {} USING fts ({})` first",
+                args.column, args.table, args.table, args.column,
+            )));
+        }
+    }
+
+    // Embed the query string into a SQL literal. The engine's parser
+    // accepts single-quoted strings; escape any embedded apostrophes
+    // by doubling them (SQL standard).
+    let query_lit = sql_string_literal(&args.query);
+
+    // Canonical FTS top-k shape — matches `try_fts_probe`'s recognition.
+    // We intentionally include the WHERE clause even though the probe
+    // overwrites `matching` (Q6 trade-off in the Phase 8 plan); having
+    // it here keeps the SQL semantically correct on the brute-force
+    // fallback path and surfaces a clean error if the user's column
+    // happened to lose its FTS index between pre-flight and execution.
+    let sql = format!(
+        "SELECT * FROM {tbl} WHERE fts_match({col}, {q}) \
+         ORDER BY bm25_score({col}, {q}) DESC LIMIT {k}",
+        tbl = args.table,
+        col = args.column,
+        q = query_lit,
+        k = k,
+    );
+
+    let stmt = state.conn.prepare(&sql)?;
+    let mut rows = stmt.query()?;
+    let columns = rows.columns().to_vec();
+    let mut out: Vec<Value> = Vec::with_capacity(k);
+    let mut size_estimate = 0;
+    let mut byte_truncated = false;
+
+    while let Some(row) = rows.next()? {
+        let mut obj = serde_json::Map::with_capacity(columns.len());
+        for (i, col) in columns.iter().enumerate() {
+            let v: sqlrite::Value = row.get(i)?;
+            let json_val = value_to_json(&v);
+            size_estimate += col.len() + 8 + json_val.to_string().len();
+            obj.insert(col.clone(), json_val);
+        }
+        if size_estimate > TOOL_OUTPUT_CAP_BYTES {
+            byte_truncated = true;
+            break;
+        }
+        out.push(Value::Object(obj));
+    }
+
+    let mut result = json!({
+        "table": args.table,
+        "column": args.column,
+        "query": args.query,
+        "k_requested": k,
+        "rows": out,
+    });
+    if byte_truncated {
+        result["truncated"] = json!(true);
+        result["truncation_reason"] = json!(format!(
+            "response truncated at {} bytes ({} of {} rows shown)",
+            TOOL_OUTPUT_CAP_BYTES,
+            out.len(),
+            k,
+        ));
+    }
+    serde_json::to_string_pretty(&result)
+        .map_err(|e| ToolError::new(format!("internal: failed to serialize results: {e}")))
+}
+
+/// Wrap `s` as a single-quoted SQL string literal, doubling any
+/// embedded single quotes per SQL standard. The engine's tokenizer
+/// then strips both the wrapping quotes and reduces `''` back to `'`.
+fn sql_string_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_string_literal_doubles_quotes() {
+        assert_eq!(sql_string_literal("rust"), "'rust'");
+        assert_eq!(sql_string_literal("it's fast"), "'it''s fast'");
+        assert_eq!(sql_string_literal(""), "''");
+    }
+}

--- a/sqlrite-mcp/src/tools/mod.rs
+++ b/sqlrite-mcp/src/tools/mod.rs
@@ -27,6 +27,7 @@ use crate::protocol::ServerState;
 
 #[cfg(feature = "ask")]
 mod ask;
+mod bm25_search;
 mod describe_table;
 mod execute;
 mod list_tables;
@@ -37,9 +38,9 @@ mod vector_search;
 /// MCP `tools/list` result. Returns the metadata for each tool —
 /// name, description, JSON Schema for input. The order matters
 /// only for human readability in the client UI; we go DB-discovery
-/// → SELECT → DML → vector → ask.
+/// → SELECT → DML → retrieval (vector + bm25) → ask.
 pub fn list(read_only: bool) -> Vec<Value> {
-    let mut tools = Vec::with_capacity(7);
+    let mut tools = Vec::with_capacity(8);
 
     tools.push(list_tables::metadata());
     tools.push(describe_table::metadata());
@@ -55,6 +56,7 @@ pub fn list(read_only: bool) -> Vec<Value> {
 
     tools.push(schema_dump::metadata());
     tools.push(vector_search::metadata());
+    tools.push(bm25_search::metadata());
 
     #[cfg(feature = "ask")]
     tools.push(ask::metadata());
@@ -76,6 +78,7 @@ pub fn dispatch(name: &str, args: Value, state: &mut ServerState) -> Result<Stri
         "execute" => execute::handle(args, state),
         "schema_dump" => schema_dump::handle(args, state),
         "vector_search" => vector_search::handle(args, state),
+        "bm25_search" => bm25_search::handle(args, state),
         #[cfg(feature = "ask")]
         "ask" => ask::handle(args, state),
         // Unknown tool: this is a tool-error not a protocol-error,

--- a/sqlrite-mcp/tests/protocol.rs
+++ b/sqlrite-mcp/tests/protocol.rs
@@ -169,6 +169,7 @@ fn tools_list_returns_expected_set_in_default_mode() {
         "execute",
         "schema_dump",
         "vector_search",
+        "bm25_search",
     ];
     if cfg!(feature = "ask") {
         expected.push("ask");
@@ -484,6 +485,128 @@ fn vector_search_returns_nearest_rows() {
     assert_eq!(rows.len(), 2);
     // Closest should be id=1 ([1.0, 0.0] — distance 0).
     assert_eq!(rows[0]["id"], 1);
+}
+
+#[test]
+fn bm25_search_returns_top_ranked_rows() {
+    let mut srv = Server::spawn(&["--in-memory"]);
+    srv.handshake();
+    let _ = call_tool(
+        &mut srv,
+        1,
+        "execute",
+        json!({"sql": "CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)"}),
+    );
+    for (i, body) in [
+        "rust embedded database",   // id=1: 'rust' once
+        "rust web framework",       // id=2: 'rust' once
+        "go embedded systems",      // id=3: no 'rust'
+        "rust rust embedded power", // id=4: 'rust' twice — should win
+    ]
+    .iter()
+    .enumerate()
+    {
+        let _ = call_tool(
+            &mut srv,
+            (10 + i) as u64,
+            "execute",
+            json!({
+                "sql": format!("INSERT INTO docs (body) VALUES ('{body}')")
+            }),
+        );
+    }
+    let _ = call_tool(
+        &mut srv,
+        20,
+        "execute",
+        json!({"sql": "CREATE INDEX docs_fts ON docs USING fts (body)"}),
+    );
+
+    let r = call_tool(
+        &mut srv,
+        21,
+        "bm25_search",
+        json!({
+            "table": "docs",
+            "column": "body",
+            "query": "rust",
+            "k": 3,
+        }),
+    );
+    assert_tool_success(&r);
+    let parsed: Value = serde_json::from_str(&tool_text(&r)).unwrap();
+    let rows = parsed["rows"].as_array().unwrap();
+    assert_eq!(rows.len(), 3, "three docs contain 'rust'");
+    // Top-ranked must be id=4 (tf=2 in a 5-token doc → highest BM25).
+    assert_eq!(rows[0]["id"], 4);
+    // id=3 (no 'rust') must NOT appear.
+    for row in rows {
+        assert_ne!(row["id"], 3, "doc without 'rust' must not be in results");
+    }
+}
+
+#[test]
+fn bm25_search_without_index_errors_clearly() {
+    let mut srv = Server::spawn(&["--in-memory"]);
+    srv.handshake();
+    let _ = call_tool(
+        &mut srv,
+        1,
+        "execute",
+        json!({"sql": "CREATE TABLE docs (id INTEGER PRIMARY KEY, body TEXT)"}),
+    );
+    let _ = call_tool(
+        &mut srv,
+        2,
+        "execute",
+        json!({"sql": "INSERT INTO docs (body) VALUES ('hello')"}),
+    );
+    // No CREATE INDEX … USING fts — bm25_search must surface a
+    // clear, actionable error pointing the LLM at the missing step.
+    let r = call_tool(
+        &mut srv,
+        3,
+        "bm25_search",
+        json!({
+            "table": "docs",
+            "column": "body",
+            "query": "hello",
+        }),
+    );
+    assert_eq!(r["result"]["isError"], true);
+    let text = tool_text(&r);
+    assert!(
+        text.contains("no FTS index"),
+        "expected no-FTS-index error: {text}"
+    );
+}
+
+#[test]
+fn bm25_search_rejects_non_text_column() {
+    let mut srv = Server::spawn(&["--in-memory"]);
+    srv.handshake();
+    let _ = call_tool(
+        &mut srv,
+        1,
+        "execute",
+        json!({"sql": "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER)"}),
+    );
+    let r = call_tool(
+        &mut srv,
+        2,
+        "bm25_search",
+        json!({
+            "table": "t",
+            "column": "n",
+            "query": "anything",
+        }),
+    );
+    assert_eq!(r["result"]["isError"], true);
+    let text = tool_text(&r);
+    assert!(
+        text.to_lowercase().contains("text"),
+        "expected non-TEXT-column error: {text}"
+    );
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fifth sub-phase of [Phase 8](docs/phase-8-plan.md). Adds the `bm25_search` MCP tool — symmetric with `vector_search` (Phase 7h), surfaces FTS prominently to LLM clients driving SQLRite over MCP. Resolves [Q9](docs/phase-8-plan.md#q9-mcp-tool).

```jsonc
// MCP tool call
{
  "name": "bm25_search",
  "arguments": {
    "table": "docs",
    "column": "body",
    "query": "rust embedded database",
    "k": 5
  }
}
// → { rows: [...], k_requested: 5, ... }
```

Wraps `SELECT * FROM <t> WHERE fts_match(<col>, 'q') ORDER BY bm25_score(<col>, 'q') DESC LIMIT k` so the LLM doesn't have to remember the `WHERE` pre-filter, the `DESC` direction, or SQL string quoting. Picks up the Phase 8b optimizer hook automatically.

## What landed

- **New tool** [`sqlrite-mcp/src/tools/bm25_search.rs`](sqlrite-mcp/src/tools/bm25_search.rs):
  - Metadata declares the JSON schema (required: `table`, `column`, `query`; optional: `k` clamped to 1..=100, default 10).
  - Pre-flight checks (table exists, column is TEXT, FTS index attached) surface clean errors before any SQL runs — useful for an LLM trying to recover.
  - SQL string-literal escaper handles embedded apostrophes per SQL standard (doubled quote).
- **Wiring** [`sqlrite-mcp/src/tools/mod.rs`](sqlrite-mcp/src/tools/mod.rs):
  - `mod bm25_search;`
  - `tools/list` lists it after `vector_search` and before `ask`.
  - `tools/call` dispatches by name.

## Test plan

MCP test count went 16 → 19 (+3 bm25-specific):

- [x] `bm25_search_returns_top_ranked_rows` — 4-doc corpus, the doc with tf=2 wins; the doc without `rust` is filtered out (verifies the optimizer hook + WHERE pre-filter both work end-to-end through MCP).
- [x] `bm25_search_without_index_errors_clearly` — actionable error pointing at the missing `CREATE INDEX … USING fts` step.
- [x] `bm25_search_rejects_non_text_column` — clean error on INTEGER columns.
- [x] `tools_list_returns_expected_set_in_default_mode` updated to include `bm25_search`.
- [x] Internal: `tools::bm25_search::tests::sql_string_literal_doubles_quotes`.
- [x] `cargo test -p sqlrite-mcp` — **19 / 19** green
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` — engine 303 + 73 across other crates green
- [x] `cargo fmt --all -- --check` — no diff
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — no new warnings on bm25_search code
- [x] `cargo doc --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --no-deps` — no doc warnings on bm25_search

## Out of scope (last sub-phase)

| Concern | Lands in |
|---|---|
| Docs sweep — `docs/fts.md`, `docs/file-format.md`, `docs/supported-sql.md`, `docs/mcp.md` (bm25_search entry) | 8f |

🤖 Generated with [Claude Code](https://claude.com/claude-code)