### PR TITLE
release: v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ask"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-desktop"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-engine"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ffi"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-mcp"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "clap",
  "libc",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-nodejs"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-python"
-version = "0.1.25"
+version = "0.2.0"
 dependencies = [
  "pyo3",
  "sqlrite-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ resolver = "3"
 # dependency declaration change:
 #
 #     [dependencies]
-#     sqlrite-engine = "0.1"
+#     sqlrite-engine = "0.2"
 #     # then in code: use sqlrite::{Database, …};
 #
 # Any workspace member here that depends on the engine uses the
 # `package =` key so the import name stays `sqlrite` internally:
 #     sqlrite = { package = "sqlrite-engine", path = "…" }
 name = "sqlrite-engine"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -138,4 +138,4 @@ fs2 = { version = "0.4", optional = true }
 # crate publishes to crates.io, and a path-only dep without a
 # version field fails the manifest verification step. See PR #58
 # retrospective in docs/roadmap.md.
-sqlrite-ask = { version = "0.1", path = "sqlrite-ask", optional = true }
+sqlrite-ask = { version = "0.2", path = "sqlrite-ask", optional = true }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlrite-desktop-frontend",
   "private": true,
-  "version": "0.1.25",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-desktop"
-version = "0.1.25"
+version = "0.2.0"
 description = "SQLRite desktop app — Tauri 2 shell around the engine"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SQLRite",
-  "version": "0.1.25",
+  "version": "0.2.0",
   "identifier": "com.sqlrite.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/sdk/nodejs/Cargo.toml
+++ b/sdk/nodejs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-nodejs"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joaoh82/sqlrite",
-  "version": "0.1.25",
+  "version": "0.2.0",
   "description": "Node.js bindings for SQLRite — a small, embeddable SQLite clone written in Rust.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-python"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sqlrite"
-version = "0.1.25"
+version = "0.2.0"
 description = "Python bindings for SQLRite — a small, embeddable SQLite clone written in Rust."
 authors = [{ name = "Joao Henrique Machado Silva", email = "joaoh82@gmail.com" }]
 license = { text = "MIT" }

--- a/sdk/wasm/Cargo.toml
+++ b/sdk/wasm/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "sqlrite-wasm"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -46,7 +46,7 @@ sqlrite = { package = "sqlrite-engine", path = "../..", default-features = false
 # builds for wasm32). Per Q9, the WASM SDK never makes the HTTP call
 # itself — the JS caller does that. Browser → backend → LLM provider
 # → JS hands the raw response back to `db.askParse()`.
-sqlrite-ask = { version = "0.1", path = "../../sqlrite-ask", default-features = false }
+sqlrite-ask = { version = "0.2", path = "../../sqlrite-ask", default-features = false }
 
 # wasm-bindgen + friends. `serde-serialize` on wasm-bindgen gives
 # us `serde_wasm_bindgen` interop for structured row objects.

--- a/sqlrite-ask/Cargo.toml
+++ b/sqlrite-ask/Cargo.toml
@@ -10,7 +10,7 @@
 # Published to crates.io as `sqlrite-ask`. Joins the lockstep release
 # wave (`sqlrite-ask-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-ask"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-ask/README.md
+++ b/sqlrite-ask/README.md
@@ -26,7 +26,7 @@ This crate is the LLM transport layer. **Most callers don't need to use it direc
 
 ```toml
 [dependencies]
-sqlrite-engine = "0.1"
+sqlrite-engine = "0.2"
 # `sqlrite-engine`'s `ask` feature is on by default, which pulls
 # `sqlrite-ask` transitively. You don't usually need to depend on
 # this crate directly.

--- a/sqlrite-ffi/Cargo.toml
+++ b/sqlrite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-ffi"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-mcp/Cargo.toml
+++ b/sqlrite-mcp/Cargo.toml
@@ -18,7 +18,7 @@
 # Published to crates.io as `sqlrite-mcp`. Joins the lockstep
 # release wave (`sqlrite-mcp-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-mcp"
-version = "0.1.25"
+version = "0.2.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -52,7 +52,7 @@ ask = ["sqlrite/ask"]
 # off (which excludes the `cli` feature and its rustyline/clap pull
 # weight) and only enable `ask` when our own `ask` feature is on.
 # Keeps the MCP binary small + boot-fast.
-sqlrite = { package = "sqlrite-engine", path = "..", version = "0.1", default-features = false }
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.2", default-features = false }
 
 # JSON-RPC + tool I/O. The MCP wire format is JSON in / JSON out;
 # tool argument schemas are JSON; tool results are JSON. serde +


### PR DESCRIPTION
## Summary

First major-version bump of SQLRite. The 0.1.x cycle covered Phase 0 → Phase 7 (modernization → AI-era extensions). **v0.2.0 marks Phase 8 — full-text search + hybrid retrieval — and the on-disk file-format change that comes with it.**

## What ships in v0.2.0

Phase 8 across PRs [#78](https://github.com/joaoh82/rust_sqlite/pull/78) – [#83](https://github.com/joaoh82/rust_sqlite/pull/83):

| Sub-phase | What landed |
|---|---|
| **8a** ([#78](https://github.com/joaoh82/rust_sqlite/pull/78)) | Standalone FTS algorithms (tokenizer + BM25 + posting list) under `src/sql/fts/`, mirroring Phase 7d.1's HNSW shape |
| **8b** ([#79](https://github.com/joaoh82/rust_sqlite/pull/79)) | SQL surface: `CREATE INDEX … USING fts (col)`, `fts_match`, `bm25_score`, the `try_fts_probe` optimizer hook, INSERT/DELETE/UPDATE lifecycle |
| **8c** ([#80](https://github.com/joaoh82/rust_sqlite/pull/80)) | Cell-encoded persistence (`KIND_FTS_POSTING`, `0x06`), `stage_fts_btree` / `load_fts_postings`, and the on-demand v4 → v5 file-format bump |
| **8d** ([#81](https://github.com/joaoh82/rust_sqlite/pull/81)) | Hybrid retrieval worked example at [`examples/hybrid-retrieval/`](examples/hybrid-retrieval/) — BM25 + vector cosine via raw arithmetic |
| **8e** ([#82](https://github.com/joaoh82/rust_sqlite/pull/82)) | `sqlrite-mcp` `bm25_search` tool, symmetric with `vector_search`. The MCP server now exposes **8 tools** (was 7) |
| **8f** ([#83](https://github.com/joaoh82/rust_sqlite/pull/83)) | Final docs sweep — new [`docs/fts.md`](docs/fts.md) canonical reference + FTS sections added to every existing doc that needed one |

## File-format change

This is the headline reason for the major bump:

- **v4** (Phase 7) — value block dispatch gained the Vector tag (Phase 7a). Phase 7's JSON, HNSW, and `ask` additions all lived inside the v4 envelope.
- **v5** (Phase 8c) — adds `KIND_FTS_POSTING` (`0x06`). **On-demand**: only written when the database has at least one FTS index attached. Decoders accept v4 and v5; v0.2.0 readers can open v0.1.x files without surprise. **v0.1.x readers cannot open v5 files** (clean "unsupported version" error).

## Manifests bumped

12 files via `scripts/bump-version.sh 0.2.0`:

- `Cargo.toml` (root, `sqlrite-engine`)
- `sqlrite-ffi/Cargo.toml`, `sqlrite-ask/Cargo.toml`, `sqlrite-mcp/Cargo.toml`
- `sdk/python/Cargo.toml` + `pyproject.toml`
- `sdk/nodejs/Cargo.toml` + `package.json`
- `sdk/wasm/Cargo.toml`
- `desktop/src-tauri/Cargo.toml` + `tauri.conf.json`
- `desktop/package.json`

Plus inter-crate dep refs (`sqlrite-engine` → `sqlrite-ask`, `sqlrite-mcp` → `sqlrite-engine`, `sdk/wasm` → `sqlrite-ask`), the `Cargo.toml` comment block, and `sqlrite-ask/README.md`'s installation snippet.

## Test plan

- [x] `scripts/bump-version.sh 0.2.0` — clean, all 12 manifests verified
- [x] Inter-crate dep refs updated (3 sites: `Cargo.toml`, `sqlrite-mcp/Cargo.toml`, `sdk/wasm/Cargo.toml`)
- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — builds at v0.2.0; Cargo.lock refreshed
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` — engine **303** + MCP **19** + 73 across other crates green
- [x] `cargo fmt --all -- --check` — no diff
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — warning counts unchanged from main

## After this merges

Tag `v0.2.0` and run the publish workflow — `sqlrite-engine` + `sqlrite-ask` + `sqlrite-mcp` to crates.io, Python wheels to PyPI (`sqlrite`), Node.js + WASM to npm (`@joaoh82/sqlrite` + `@joaoh82/sqlrite-wasm`), Go module via `sdk/go/v0.2.0` git tag, plus C FFI tarballs, MCP binary tarballs, and unsigned desktop installers as GitHub Release assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)