### PR TITLE
fix(release): swap publish-ask / publish-crate ordering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,14 @@ jobs:
   # click Approve before this job actually runs).
   publish-crate:
     name: Publish sqlrite crate to crates.io
-    needs: [detect, tag-all]
+    # Engine depends on sqlrite-ask (post-v0.1.19 dep-direction flip), so
+    # publish-ask must complete first — otherwise crates.io rejects the
+    # engine publish with "failed to select a version for the requirement
+    # `sqlrite-ask = "^X.Y"`". This was masked through 0.1.x because old
+    # sqlrite-ask versions were already on crates.io and the engine's
+    # version requirement (`^0.1`) matched them; the v0.2.0 cut surfaced
+    # the latent bug.
+    needs: [detect, tag-all, publish-ask]
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: release
@@ -203,9 +210,11 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Step 3a': publish the `sqlrite-ask` crate (Phase 7g.1) — natural-
-  # language → SQL adapter built on top of the engine. Same shape as
-  # `publish-crate` above; separate job so a registry hiccup on one
-  # doesn't block the other and re-runs are surgical.
+  # language → SQL adapter. Since the v0.1.19 dep-direction flip,
+  # sqlrite-ask is dep-free of sqlrite-engine — it's a pure-string-in /
+  # string-out adapter. The engine depends on IT, not the other way
+  # around. So this job runs FIRST in the publish chain; publish-crate
+  # waits on it.
   #
   # Crate name on crates.io: `sqlrite-ask`. Library name (the `use`
   # path): `sqlrite_ask`. No alias-renaming this time — the short
@@ -213,7 +222,7 @@ jobs:
   # for why the engine had to rename).
   publish-ask:
     name: Publish sqlrite-ask crate to crates.io
-    needs: [detect, tag-all, publish-crate]
+    needs: [detect, tag-all]
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: release
@@ -230,13 +239,9 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         # `--no-verify` mirrors `publish-crate` — Release-PR CI
-        # already validated this commit.
-        #
-        # `needs: [..., publish-crate]` is load-bearing: sqlrite-ask
-        # depends on sqlrite-engine, and crates.io rejects publishes
-        # whose path-deps haven't yet resolved to a published version
-        # at the same number. Sequencing makes the dep visible by the
-        # time we publish.
+        # already validated this commit. sqlrite-ask has no
+        # SQLRite-internal path-deps after the v0.1.19 dep-direction
+        # flip, so this job is unblocked the moment `tag-all` lands.
         run: cargo publish -p sqlrite-ask --no-verify
 
       - name: GitHub Release


### PR DESCRIPTION
## Summary

The v0.2.0 release ([Action run 25290833060](https://github.com/joaoh82/rust_sqlite/actions/runs/25290833060)) failed at \`Publish sqlrite crate to crates.io\`:

\`\`\`
failed to select a version for the requirement \`sqlrite-ask = "^0.2"\`
candidate versions found which didn't match: 0.1.25, 0.1.24, ...
\`\`\`

**Root cause:** the publish ordering reflected the **pre-v0.1.19** dep direction (\`sqlrite-ask → sqlrite-engine\`) — but the v0.1.19 dep-direction-flip retrospective ([roadmap.md L488](docs/roadmap.md)) records that sqlrite-ask became pure-string-in/string-out and the engine took on the sqlrite-ask dependency (gated by the \`ask\` feature). Through 0.1.x this latent bug was masked because the engine's published version requirement was \`^0.1\` and old \`sqlrite-ask 0.1.x\` versions were already on crates.io. The v0.2.0 bump (\`^0.2\`) had no matching crate yet, so the publish failed loudly.

## Fix

- \`publish-ask\` now runs **first** (depends only on \`detect\` + \`tag-all\`). No internal SQLRite path-deps after the dep-direction flip.
- \`publish-crate\` (engine) now waits on \`publish-ask\`. Comment updated to flag the latent bug + the retrospective.
- \`publish-mcp\`'s \`needs: [..., publish-crate, publish-ask]\` is unchanged — sqlrite-mcp still depends on the engine.

Resulting chain: \`detect → tag-all → publish-ask → publish-crate → publish-mcp\`.

## Path forward for v0.2.0

After this merges, two options to finish the v0.2.0 cut:

| Option | What | Tradeoff |
|---|---|---|
| **A. Fire \`workflow_dispatch\`** with \`version=0.2.0\` | Re-runs the whole release flow under the fixed ordering. The 3 Rust crate publishes succeed cleanly. | Already-shipped publishes (Python wheels, npm packages, Go SDK Release) re-run; PyPI/npm reject duplicate-version uploads, so those jobs fail noisily but don't undo anything. |
| **B. Local \`cargo publish\`** | From your machine: \`cargo publish -p sqlrite-ask --no-verify && cargo publish -p sqlrite-engine --no-verify && cargo publish -p sqlrite-mcp --no-verify\`. Manually upload the missing GitHub Release assets if needed. | Fastest path to "v0.2.0 fully shipped". Skips the workflow's GitHub Release creation steps for those three crates; you'd add the tags manually. |
| **C. Cut v0.2.1** | Ship a "release plumbing fix" v0.2.1 right after this merges. The fixed workflow runs cleanly end-to-end. | Wastes a version; pins users to v0.2.1 unnecessarily. |

I'd recommend **A** — the duplicate-publish failures are noisy but harmless, and it keeps the release pipeline as the single source of truth for v0.2.0's ship state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)