### PR TITLE
feat(ddl): DEFAULT clause, DROP TABLE/INDEX, ALTER TABLE

### DIFF
--- a/docs/supported-sql.md
+++ b/docs/supported-sql.md
@@ -8,12 +8,14 @@ If you're looking for _how_ to use SQLRite (REPL flow, meta-commands, history, e
 
 | Statement | Supported today |
 |---|---|
-| [`CREATE TABLE`](#create-table) | Columns with `PRIMARY KEY` / `UNIQUE` / `NOT NULL`; typed columns; auto-indexes on constrained columns |
+| [`CREATE TABLE`](#create-table) | Columns with `PRIMARY KEY` / `UNIQUE` / `NOT NULL` / `DEFAULT <literal>`; typed columns; auto-indexes on constrained columns |
 | [`CREATE [UNIQUE] INDEX`](#create-index) | Single-column named indexes, `IF NOT EXISTS`, persisted as cell-based B-Trees |
-| [`INSERT INTO`](#insert-into) | Auto-ROWID, UNIQUE/PK enforcement, clean type errors, NULL padding |
+| [`INSERT INTO`](#insert-into) | Auto-ROWID, UNIQUE/PK enforcement, clean type errors, NULL/DEFAULT padding |
 | [`SELECT`](#select) | `*` or column list, `WHERE`, single-column `ORDER BY`, `LIMIT`; index probing on `col = literal` |
 | [`UPDATE`](#update) | Multi-column `SET`, `WHERE`, arithmetic RHS, type + UNIQUE enforcement |
 | [`DELETE`](#delete) | `WHERE` predicate or whole-table |
+| [`ALTER TABLE`](#alter-table) | `RENAME TO`, `RENAME COLUMN`, `ADD COLUMN`, `DROP COLUMN` (one operation per statement) |
+| [`DROP TABLE`](#drop-table) / [`DROP INDEX`](#drop-index) | `IF EXISTS`; single target; auto-indexes refused for `DROP INDEX` |
 | [`BEGIN`](#transactions) / [`COMMIT`](#transactions) / [`ROLLBACK`](#transactions) | Snapshot-based; single-level; WAL-backed commit; auto-rollback on COMMIT disk failure |
 
 Statements the parser accepts (because sqlparser understands them in the SQLite dialect) but SQLRite doesn't execute yet return `SQL Statement not supported yet`. The [Not yet supported](#not-yet-supported) section below enumerates the common ones.
@@ -41,12 +43,12 @@ CREATE TABLE <name> (<col> <type> [column_constraint]* [, ...]);
 
 - `PRIMARY KEY` — one column per table; the column **must** be `INTEGER` and gets auto-ROWID behavior (omitted on INSERT → auto-assigned). Auto-creates an index named `sqlrite_autoindex_<table>_<column>`.
 - `UNIQUE` — enforced at INSERT/UPDATE time. Auto-creates an index with the same naming scheme.
-- `NOT NULL` — rejects NULL at INSERT/UPDATE. Omitted columns on INSERT are NULL by default, so a `NOT NULL` without an INSERT-time value is an error.
+- `NOT NULL` — rejects NULL at INSERT/UPDATE. Omitted columns on INSERT are NULL by default (or pick up the column's `DEFAULT`, if any), so a `NOT NULL` without an INSERT-time value or DEFAULT is an error.
+- `DEFAULT <literal>` — value substituted when the column is omitted from an INSERT. Accepts integer / real / text / boolean / NULL literals (and unary `+` / `-` on numerics). Function-call defaults like `CURRENT_TIMESTAMP` and other non-literal expressions are rejected at CREATE TABLE time. Explicit `INSERT ... VALUES (..., NULL, ...)` is preserved as NULL — the default only fires for omitted columns (matches SQLite).
 
 ### What's **not** enforced at CREATE TABLE time
 
 - **Table-level constraints** (`PRIMARY KEY (col1, col2)`, `FOREIGN KEY`, `CHECK`, `UNIQUE (col1, col2)`) are parsed but ignored.
-- **`DEFAULT` values** are parsed but ignored.
 - **Multi-column `PRIMARY KEY`** — only single-column PKs work; a composite PK is accepted by the parser but treated as no PK.
 
 ### Errors returned
@@ -205,6 +207,72 @@ DELETE FROM <table> [WHERE <expr>];
 - **No `WHERE`** deletes every row (tables and indexes are preserved; only row data is removed).
 - **`WHERE`** uses the same [expression](#expressions) evaluator as `SELECT`.
 - Secondary indexes are updated alongside the row deletes so a subsequent `WHERE col = ...` doesn't return stale hits.
+
+---
+
+## `ALTER TABLE`
+
+```sql
+ALTER TABLE [IF EXISTS] <table> RENAME TO <new_table>;
+ALTER TABLE [IF EXISTS] <table> RENAME COLUMN <old_col> TO <new_col>;
+ALTER TABLE [IF EXISTS] <table> ADD COLUMN <col_def>;
+ALTER TABLE [IF EXISTS] <table> DROP COLUMN <col>;
+```
+
+One operation per statement (SQLite-style). `ALTER TABLE foo RENAME TO bar, ADD COLUMN x ...` is rejected — issue separate statements instead.
+
+### `RENAME TO`
+
+- Reserved-name rejection: cannot rename to `sqlrite_master`.
+- Errors if the target name is already a table.
+- Auto-indexes whose names embed the old table name (`sqlrite_autoindex_<old>_<col>`) are renamed in lockstep so the schema catalog stays consistent. Explicit indexes carry their user-given name unchanged.
+
+### `RENAME COLUMN`
+
+- Errors if the old column doesn't exist or the new name already exists in the table.
+- Re-keys the row storage and updates every dependent index (auto + explicit, secondary / HNSW / FTS) — including auto-index name regeneration.
+- Renaming the PRIMARY KEY column is allowed; the table's `primary_key` pointer follows the new name.
+
+### `ADD COLUMN`
+
+- The column definition reuses the same parser that handles CREATE TABLE columns: same types, same `NOT NULL` / `DEFAULT` semantics.
+- **Rejected:** `PRIMARY KEY` and `UNIQUE` constraints on the added column. Both would require backfilling the column under uniqueness constraints against existing rows; that path will land alongside multi-column UNIQUE.
+- **`NOT NULL` on a non-empty table requires `DEFAULT`.** Without one there's no value to backfill existing rowids with. Same rule SQLite applies.
+- With a `DEFAULT`, every existing rowid is backfilled with the default value at ADD COLUMN time. Without a `DEFAULT`, existing rowids read as NULL for the new column.
+
+### `DROP COLUMN`
+
+- **Rejected:** dropping the PRIMARY KEY column.
+- **Rejected:** dropping the only remaining column (degenerate table).
+- Cascades to every dependent index (auto + explicit, secondary / HNSW / FTS) on the dropped column.
+- `CASCADE` / `RESTRICT` modifiers are accepted by the parser and ignored — SQLite has no real distinction here either.
+
+---
+
+## `DROP TABLE`
+
+```sql
+DROP TABLE [IF EXISTS] <table>;
+```
+
+- Single target per statement. `DROP TABLE a, b, c;` is parsed but rejected with a NotImplemented error.
+- Reserved-name rejection: `DROP TABLE sqlrite_master` errors with the same message `CREATE TABLE` uses.
+- All indexes attached to the table (auto, explicit, HNSW, FTS) disappear with the table — they live inside the `Table` struct and ride along.
+- Without `IF EXISTS`, dropping a table that doesn't exist errors. With it, that's a benign 0-tables-dropped no-op.
+- **Disk pages are orphaned, not freed.** SQLRite has no free-list yet — the file size doesn't shrink until a future `VACUUM`. The behavior is safe (orphan pages are unreachable from `sqlrite_master` after reopen) but means a write-heavy schema churn won't reclaim space until VACUUM lands.
+
+---
+
+## `DROP INDEX`
+
+```sql
+DROP INDEX [IF EXISTS] <index_name>;
+```
+
+- Single target per statement.
+- Walks every table searching for an index with the given name across the secondary B-Tree, HNSW, and FTS index families.
+- **Refuses to drop auto-indexes.** `sqlrite_autoindex_*` names are constraint-bound to the column they index — the only way to remove them is to drop the underlying column or table. Same rule SQLite enforces for its `sqlite_autoindex_*` indexes.
+- `IF EXISTS` makes a missing index a benign no-op.
 
 ---
 
@@ -405,11 +473,12 @@ For context when you hit `NotImplemented`. See [Roadmap](roadmap.md) for when th
 - Built-in functions (`LENGTH`, `UPPER`, `LOWER`, `COALESCE`, `IFNULL`, date/time, `printf`, …)
 
 ### DDL
-- `ALTER TABLE` (add column, rename column, rename table)
-- `DROP TABLE`, `DROP INDEX`
+- `ALTER TABLE` extras: multi-operation (`ALTER TABLE foo RENAME TO bar, ADD COLUMN x ...`), `ALTER COLUMN ... SET / DROP DEFAULT`, `ALTER COLUMN ... TYPE`
+- `ADD COLUMN` constraint extras: `PRIMARY KEY` and `UNIQUE` on the added column (would need backfill + uniqueness against existing rows)
+- `DROP TABLE` / `DROP INDEX` extras: multi-target (`DROP TABLE a, b, c;`)
 - `CREATE VIEW`, `CREATE TRIGGER`
 - Table-level constraints (composite PK, composite UNIQUE, `FOREIGN KEY`, `CHECK`)
-- Column defaults (`DEFAULT <value>`)
+- Non-literal `DEFAULT` expressions (`CURRENT_TIMESTAMP`, function calls, column references)
 - Composite / multi-column indexes
 
 ### Transactions

--- a/src/sql/db/table.rs
+++ b/src/sql/db/table.rs
@@ -207,12 +207,13 @@ impl Table {
             if col.is_pk {
                 primary_key = col_name.to_string();
             }
-            table_cols.push(Column::new(
+            table_cols.push(Column::with_default(
                 col_name.to_string(),
                 col.datatype.to_string(),
                 col.is_pk,
                 col.not_null,
                 col.is_unique,
+                col.default.clone(),
             ));
 
             let dt = DataType::new(col.datatype.to_string());
@@ -822,10 +823,12 @@ impl Table {
         for i in 0..column_names.len() {
             let mut val = String::from("Null");
             let key = &column_names[i];
+            let mut column_supplied = false;
 
             if let Some(supplied_key) = cols.get(j) {
                 if supplied_key == &column_names[i] {
                     val = values[j].to_string();
+                    column_supplied = true;
                     j += 1;
                 } else if self.primary_key == column_names[i] {
                     // PK already stored in the auto-assign branch above.
@@ -833,6 +836,17 @@ impl Table {
                 }
             } else if self.primary_key == column_names[i] {
                 continue;
+            }
+
+            // Column was omitted from the INSERT column list. Substitute its
+            // DEFAULT literal if one was declared at CREATE TABLE time;
+            // otherwise it stays as the "Null" sentinel set above. SQLite
+            // semantics: an *explicit* NULL is preserved as NULL — the
+            // default only fires for omitted columns.
+            if !column_supplied {
+                if let Some(default) = &self.columns[i].default {
+                    val = default.to_default_insert_string();
+                }
             }
 
             // Step 1: write into row storage and compute the typed Value
@@ -1129,15 +1143,36 @@ pub struct Column {
     pub is_pk: bool,
     pub not_null: bool,
     pub is_unique: bool,
+    /// Literal value to substitute when this column is omitted from an
+    /// INSERT. Restricted to literal expressions at CREATE TABLE time.
+    /// `None` means "no DEFAULT declared"; an INSERT that omits the column
+    /// gets `Value::Null` instead.
+    pub default: Option<Value>,
 }
 
 impl Column {
+    /// Builds a `Column` without a `DEFAULT` clause. Existing call sites
+    /// (catalog-table setup, test fixtures) keep working unchanged.
     pub fn new(
         name: String,
         datatype: String,
         is_pk: bool,
         not_null: bool,
         is_unique: bool,
+    ) -> Self {
+        Self::with_default(name, datatype, is_pk, not_null, is_unique, None)
+    }
+
+    /// Builds a `Column` with an optional `DEFAULT` literal. Used by the
+    /// CREATE TABLE / `parse_create_sql` paths that propagate user-supplied
+    /// defaults from `ParsedColumn`.
+    pub fn with_default(
+        name: String,
+        datatype: String,
+        is_pk: bool,
+        not_null: bool,
+        is_unique: bool,
+        default: Option<Value>,
     ) -> Self {
         let dt = DataType::new(datatype);
         Column {
@@ -1146,6 +1181,7 @@ impl Column {
             is_pk,
             not_null,
             is_unique,
+            default,
         }
     }
 }
@@ -1273,6 +1309,25 @@ impl Value {
             Value::Bool(b) => b.to_string(),
             Value::Vector(v) => format_vector_for_display(v),
             Value::Null => String::from("NULL"),
+        }
+    }
+
+    /// Renders this value in the same stringly format that
+    /// [`crate::sql::parser::insert::InsertQuery::new`] produces for INSERT
+    /// values, so a DEFAULT can be substituted into the existing
+    /// `insert_row` parse pipeline without a parallel typed path.
+    ///
+    /// The differences from [`Self::to_display_string`] that matter:
+    ///   - `NULL` renders as the `"Null"` sentinel that `insert_row` matches.
+    ///   - Text stays unquoted (the insert pipeline strips quotes upstream).
+    pub fn to_default_insert_string(&self) -> String {
+        match self {
+            Value::Integer(v) => v.to_string(),
+            Value::Text(s) => s.clone(),
+            Value::Real(f) => f.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Vector(v) => format_vector_for_display(v),
+            Value::Null => String::from("Null"),
         }
     }
 }

--- a/src/sql/db/table.rs
+++ b/src/sql/db/table.rs
@@ -2,7 +2,7 @@ use crate::error::{Result, SQLRiteError};
 use crate::sql::db::secondary_index::{IndexOrigin, SecondaryIndex};
 use crate::sql::fts::PostingList;
 use crate::sql::hnsw::HnswIndex;
-use crate::sql::parser::create::CreateQuery;
+use crate::sql::parser::create::{CreateQuery, ParsedColumn};
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -327,11 +327,233 @@ impl Table {
     }
 
     /// Finds a secondary index by its own name (e.g., `sqlrite_autoindex_users_email`
-    /// or a user-provided CREATE INDEX name). Used by Phase 3e.2 to look up
-    /// explicit indexes when DROP INDEX lands.
-    #[allow(dead_code)]
+    /// or a user-provided CREATE INDEX name). Used by DROP INDEX and the
+    /// rename helpers below.
     pub fn index_by_name(&self, name: &str) -> Option<&SecondaryIndex> {
         self.secondary_indexes.iter().find(|i| i.name == name)
+    }
+
+    /// Renames a column in place. Updates row storage, the `Column`
+    /// metadata, every secondary / HNSW / FTS index whose `column_name`
+    /// matches, the `primary_key` pointer if the renamed column is the
+    /// PK, and any auto-index name that embedded the old column name.
+    ///
+    /// Caller-side validation (table existence, source-column existence
+    /// at the surface level, IF EXISTS) lives in the executor; this
+    /// method enforces the column-level invariants that have to be
+    /// checked under the `Table` borrow anyway.
+    pub fn rename_column(&mut self, old: &str, new: &str) -> Result<()> {
+        if !self.columns.iter().any(|c| c.column_name == old) {
+            return Err(SQLRiteError::General(format!(
+                "column '{old}' does not exist in table '{}'",
+                self.tb_name
+            )));
+        }
+        if old != new && self.columns.iter().any(|c| c.column_name == new) {
+            return Err(SQLRiteError::General(format!(
+                "column '{new}' already exists in table '{}'",
+                self.tb_name
+            )));
+        }
+        if old == new {
+            return Ok(());
+        }
+
+        for col in self.columns.iter_mut() {
+            if col.column_name == old {
+                col.column_name = new.to_string();
+            }
+        }
+
+        // Re-key the per-column row map.
+        {
+            let mut rows = self.rows.lock().expect("rows mutex poisoned");
+            if let Some(storage) = rows.remove(old) {
+                rows.insert(new.to_string(), storage);
+            }
+        }
+
+        if self.primary_key == old {
+            self.primary_key = new.to_string();
+        }
+
+        let table_name = self.tb_name.clone();
+        for idx in self.secondary_indexes.iter_mut() {
+            if idx.column_name == old {
+                idx.column_name = new.to_string();
+                if idx.origin == IndexOrigin::Auto
+                    && idx.name == SecondaryIndex::auto_name(&table_name, old)
+                {
+                    idx.name = SecondaryIndex::auto_name(&table_name, new);
+                }
+            }
+        }
+        for entry in self.hnsw_indexes.iter_mut() {
+            if entry.column_name == old {
+                entry.column_name = new.to_string();
+            }
+        }
+        for entry in self.fts_indexes.iter_mut() {
+            if entry.column_name == old {
+                entry.column_name = new.to_string();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Appends a new column to this table from a parsed column spec.
+    /// The new column's row storage is allocated empty; existing rowids
+    /// read NULL for the new column unless `parsed.default` is set, in
+    /// which case those rowids are backfilled with the default value.
+    ///
+    /// Rejects PK / UNIQUE on the added column (would require
+    /// backfill-with-uniqueness-check against existing rows). Rejects
+    /// NOT NULL without DEFAULT on a non-empty table — same rule SQLite
+    /// applies, and necessary because we have no other backfill source.
+    pub fn add_column(&mut self, parsed: ParsedColumn) -> Result<()> {
+        if self.contains_column(parsed.name.clone()) {
+            return Err(SQLRiteError::General(format!(
+                "column '{}' already exists in table '{}'",
+                parsed.name, self.tb_name
+            )));
+        }
+        if parsed.is_pk {
+            return Err(SQLRiteError::General(
+                "cannot ADD COLUMN with PRIMARY KEY constraint on existing table".to_string(),
+            ));
+        }
+        if parsed.is_unique {
+            return Err(SQLRiteError::General(
+                "cannot ADD COLUMN with UNIQUE constraint on existing table".to_string(),
+            ));
+        }
+        let table_has_rows = self
+            .columns
+            .first()
+            .map(|c| {
+                self.rows
+                    .lock()
+                    .expect("rows mutex poisoned")
+                    .get(&c.column_name)
+                    .map(|r| r.rowids().len())
+                    .unwrap_or(0)
+                    > 0
+            })
+            .unwrap_or(false);
+        if parsed.not_null && parsed.default.is_none() && table_has_rows {
+            return Err(SQLRiteError::General(format!(
+                "cannot ADD COLUMN '{}' NOT NULL without DEFAULT to a non-empty table",
+                parsed.name
+            )));
+        }
+
+        let new_column = Column::with_default(
+            parsed.name.clone(),
+            parsed.datatype.clone(),
+            parsed.is_pk,
+            parsed.not_null,
+            parsed.is_unique,
+            parsed.default.clone(),
+        );
+
+        // Allocate empty row storage for the new column. Mirrors the
+        // dispatch in `Table::new` so the new column behaves identically
+        // to one declared at CREATE TABLE time.
+        let row_storage = match &new_column.datatype {
+            DataType::Integer => Row::Integer(BTreeMap::new()),
+            DataType::Real => Row::Real(BTreeMap::new()),
+            DataType::Text => Row::Text(BTreeMap::new()),
+            DataType::Bool => Row::Bool(BTreeMap::new()),
+            DataType::Vector(_dim) => Row::Vector(BTreeMap::new()),
+            DataType::Json => Row::Text(BTreeMap::new()),
+            DataType::Invalid | DataType::None => Row::None,
+        };
+        {
+            let mut rows = self.rows.lock().expect("rows mutex poisoned");
+            rows.insert(parsed.name.clone(), row_storage);
+        }
+
+        // Backfill existing rowids with the default value, if any.
+        // NULL defaults are a no-op — a missing key in the BTreeMap reads
+        // as NULL anyway. Type mismatches were caught at `parse_one_column`
+        // time when the DEFAULT was evaluated against the declared
+        // datatype; reaching the `_` arm here would indicate a bug.
+        if let Some(default) = &parsed.default {
+            let existing_rowids = self.rowids();
+            let mut rows = self.rows.lock().expect("rows mutex poisoned");
+            let storage = rows.get_mut(&parsed.name).expect("just inserted");
+            match (storage, default) {
+                (Row::Integer(tree), Value::Integer(v)) => {
+                    let v32 = *v as i32;
+                    for rowid in existing_rowids {
+                        tree.insert(rowid, v32);
+                    }
+                }
+                (Row::Real(tree), Value::Real(v)) => {
+                    let v32 = *v as f32;
+                    for rowid in existing_rowids {
+                        tree.insert(rowid, v32);
+                    }
+                }
+                (Row::Text(tree), Value::Text(v)) => {
+                    for rowid in existing_rowids {
+                        tree.insert(rowid, v.clone());
+                    }
+                }
+                (Row::Bool(tree), Value::Bool(v)) => {
+                    for rowid in existing_rowids {
+                        tree.insert(rowid, *v);
+                    }
+                }
+                (_, Value::Null) => {} // no-op
+                (storage_ref, _) => {
+                    return Err(SQLRiteError::Internal(format!(
+                        "DEFAULT type does not match column storage for '{}': storage variant {:?}, default {:?}",
+                        parsed.name,
+                        std::mem::discriminant(storage_ref),
+                        default
+                    )));
+                }
+            }
+        }
+
+        self.columns.push(new_column);
+        Ok(())
+    }
+
+    /// Removes a column from this table. Refuses to drop the PRIMARY KEY
+    /// column or the only remaining column. Cascades to every index
+    /// (auto, explicit, HNSW, FTS) that referenced the column.
+    pub fn drop_column(&mut self, name: &str) -> Result<()> {
+        if !self.contains_column(name.to_string()) {
+            return Err(SQLRiteError::General(format!(
+                "column '{name}' does not exist in table '{}'",
+                self.tb_name
+            )));
+        }
+        if self.primary_key == name {
+            return Err(SQLRiteError::General(format!(
+                "cannot drop primary key column '{name}'"
+            )));
+        }
+        if self.columns.len() == 1 {
+            return Err(SQLRiteError::General(format!(
+                "cannot drop the only column of table '{}'",
+                self.tb_name
+            )));
+        }
+
+        self.columns.retain(|c| c.column_name != name);
+        {
+            let mut rows = self.rows.lock().expect("rows mutex poisoned");
+            rows.remove(name);
+        }
+        self.secondary_indexes.retain(|i| i.column_name != name);
+        self.hnsw_indexes.retain(|i| i.column_name != name);
+        self.fts_indexes.retain(|i| i.column_name != name);
+
+        Ok(())
     }
 
     /// Returns a `bool` informing if a `Column` with a specific name exists or not

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -5,9 +5,10 @@ use std::cmp::Ordering;
 
 use prettytable::{Cell as PrintCell, Row as PrintRow, Table as PrintTable};
 use sqlparser::ast::{
-    AssignmentTarget, BinaryOperator, CreateIndex, Delete, Expr, FromTable, FunctionArg,
-    FunctionArgExpr, FunctionArguments, IndexType, ObjectName, ObjectNamePart, Statement,
-    TableFactor, TableWithJoins, UnaryOperator, Update, Value as AstValue,
+    AlterTable, AlterTableOperation, AssignmentTarget, BinaryOperator, CreateIndex, Delete, Expr,
+    FromTable, FunctionArg, FunctionArgExpr, FunctionArguments, IndexType, ObjectName,
+    ObjectNamePart, RenameTableNameKind, Statement, TableFactor, TableWithJoins, UnaryOperator,
+    Update, Value as AstValue,
 };
 
 use crate::error::{Result, SQLRiteError};
@@ -602,6 +603,156 @@ pub fn execute_drop_index(
             "Index '{name}' does not exist"
         )))
     }
+}
+
+/// Executes `ALTER TABLE [IF EXISTS] <name> <op>;` for one operation per
+/// statement. Supports four sub-operations matching SQLite:
+///
+///   - `RENAME TO <new>`
+///   - `RENAME COLUMN <old> TO <new>`
+///   - `ADD COLUMN <coldef>` (NOT NULL requires DEFAULT on a non-empty table;
+///     PK / UNIQUE constraints rejected — would need backfill + uniqueness)
+///   - `DROP COLUMN <name>` (refuses PK column and only-column)
+///
+/// Multi-operation ALTER (`ALTER TABLE foo RENAME TO bar, ADD COLUMN x ...`)
+/// is rejected; SQLite forbids it too.
+pub fn execute_alter_table(alter: AlterTable, db: &mut Database) -> Result<String> {
+    let table_name = alter.name.to_string();
+
+    if table_name == crate::sql::pager::MASTER_TABLE_NAME {
+        return Err(SQLRiteError::General(format!(
+            "'{}' is a reserved name used by the internal schema catalog",
+            crate::sql::pager::MASTER_TABLE_NAME
+        )));
+    }
+
+    if !db.contains_table(table_name.clone()) {
+        return if alter.if_exists {
+            Ok("ALTER TABLE: no-op (table does not exist)".to_string())
+        } else {
+            Err(SQLRiteError::General(format!(
+                "Table '{table_name}' does not exist"
+            )))
+        };
+    }
+
+    if alter.operations.len() != 1 {
+        return Err(SQLRiteError::NotImplemented(
+            "ALTER TABLE supports one operation per statement".to_string(),
+        ));
+    }
+
+    match &alter.operations[0] {
+        AlterTableOperation::RenameTable { table_name: kind } => {
+            let new_name = match kind {
+                RenameTableNameKind::To(name) => name.to_string(),
+                RenameTableNameKind::As(_) => {
+                    return Err(SQLRiteError::NotImplemented(
+                        "ALTER TABLE ... RENAME AS (MySQL-only) is not supported; use RENAME TO"
+                            .to_string(),
+                    ));
+                }
+            };
+            alter_rename_table(db, &table_name, &new_name)?;
+            Ok(format!(
+                "ALTER TABLE '{table_name}' RENAME TO '{new_name}' executed."
+            ))
+        }
+        AlterTableOperation::RenameColumn {
+            old_column_name,
+            new_column_name,
+        } => {
+            let old = old_column_name.value.clone();
+            let new = new_column_name.value.clone();
+            db.get_table_mut(table_name.clone())?
+                .rename_column(&old, &new)?;
+            Ok(format!(
+                "ALTER TABLE '{table_name}' RENAME COLUMN '{old}' TO '{new}' executed."
+            ))
+        }
+        AlterTableOperation::AddColumn {
+            column_def,
+            if_not_exists,
+            ..
+        } => {
+            let parsed = crate::sql::parser::create::parse_one_column(column_def)?;
+            let table = db.get_table_mut(table_name.clone())?;
+            if *if_not_exists && table.contains_column(parsed.name.clone()) {
+                return Ok(format!(
+                    "ALTER TABLE '{table_name}' ADD COLUMN: no-op (column '{}' already exists)",
+                    parsed.name
+                ));
+            }
+            let col_name = parsed.name.clone();
+            table.add_column(parsed)?;
+            Ok(format!(
+                "ALTER TABLE '{table_name}' ADD COLUMN '{col_name}' executed."
+            ))
+        }
+        AlterTableOperation::DropColumn {
+            column_names,
+            if_exists,
+            ..
+        } => {
+            if column_names.len() != 1 {
+                return Err(SQLRiteError::NotImplemented(
+                    "ALTER TABLE DROP COLUMN supports a single column per statement".to_string(),
+                ));
+            }
+            let col_name = column_names[0].value.clone();
+            let table = db.get_table_mut(table_name.clone())?;
+            if *if_exists && !table.contains_column(col_name.clone()) {
+                return Ok(format!(
+                    "ALTER TABLE '{table_name}' DROP COLUMN: no-op (column '{col_name}' does not exist)"
+                ));
+            }
+            table.drop_column(&col_name)?;
+            Ok(format!(
+                "ALTER TABLE '{table_name}' DROP COLUMN '{col_name}' executed."
+            ))
+        }
+        other => Err(SQLRiteError::NotImplemented(format!(
+            "ALTER TABLE operation {other:?} is not supported"
+        ))),
+    }
+}
+
+/// Renames a table in `db.tables`. Updates `tb_name`, every secondary
+/// index's `table_name` field, and any auto-index whose name embedded
+/// the old table name. HNSW / FTS index entries don't carry a
+/// `table_name` field — they're addressed implicitly via the `Table`
+/// they live inside, so they move with the rename for free.
+fn alter_rename_table(db: &mut Database, old: &str, new: &str) -> Result<()> {
+    if new == crate::sql::pager::MASTER_TABLE_NAME {
+        return Err(SQLRiteError::General(format!(
+            "'{}' is a reserved name used by the internal schema catalog",
+            crate::sql::pager::MASTER_TABLE_NAME
+        )));
+    }
+    if old == new {
+        return Ok(());
+    }
+    if db.contains_table(new.to_string()) {
+        return Err(SQLRiteError::General(format!(
+            "target table '{new}' already exists"
+        )));
+    }
+
+    let mut table = db
+        .tables
+        .remove(old)
+        .ok_or_else(|| SQLRiteError::General(format!("Table '{old}' does not exist")))?;
+    table.tb_name = new.to_string();
+    for idx in table.secondary_indexes.iter_mut() {
+        idx.table_name = new.to_string();
+        if idx.origin == IndexOrigin::Auto
+            && idx.name == SecondaryIndex::auto_name(old, &idx.column_name)
+        {
+            idx.name = SecondaryIndex::auto_name(new, &idx.column_name);
+        }
+    }
+    db.tables.insert(new.to_string(), table);
+    Ok(())
 }
 
 /// `USING <method>` choices recognized by `execute_create_index`. A

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -6,8 +6,8 @@ use std::cmp::Ordering;
 use prettytable::{Cell as PrintCell, Row as PrintRow, Table as PrintTable};
 use sqlparser::ast::{
     AssignmentTarget, BinaryOperator, CreateIndex, Delete, Expr, FromTable, FunctionArg,
-    FunctionArgExpr, FunctionArguments, IndexType, ObjectNamePart, Statement, TableFactor,
-    TableWithJoins, UnaryOperator, Update, Value as AstValue,
+    FunctionArgExpr, FunctionArguments, IndexType, ObjectName, ObjectNamePart, Statement,
+    TableFactor, TableWithJoins, UnaryOperator, Update, Value as AstValue,
 };
 
 use crate::error::{Result, SQLRiteError};
@@ -509,6 +509,98 @@ pub fn execute_create_index(stmt: &Statement, db: &mut Database) -> Result<Strin
             *unique,
             &existing_rowids_and_values,
         ),
+    }
+}
+
+/// Executes `DROP TABLE [IF EXISTS] <name>;`. Mirrors SQLite's single-target
+/// shape: sqlparser parses `DROP TABLE a, b` as one statement with
+/// `names: vec![a, b]`, but we reject the multi-target form to keep error
+/// semantics simple (no partial-failure rollback).
+///
+/// On success the table — and every index attached to it — disappears from
+/// the in-memory `Database`. The next auto-save rebuilds `sqlrite_master`
+/// from scratch and simply doesn't write a row for the dropped table or
+/// its indexes; pages previously occupied by them become orphans on disk
+/// (no free-list yet — file size doesn't shrink until a future VACUUM).
+pub fn execute_drop_table(
+    names: &[ObjectName],
+    if_exists: bool,
+    db: &mut Database,
+) -> Result<usize> {
+    if names.len() != 1 {
+        return Err(SQLRiteError::NotImplemented(
+            "DROP TABLE supports a single table per statement".to_string(),
+        ));
+    }
+    let name = names[0].to_string();
+
+    if name == crate::sql::pager::MASTER_TABLE_NAME {
+        return Err(SQLRiteError::General(format!(
+            "'{}' is a reserved name used by the internal schema catalog",
+            crate::sql::pager::MASTER_TABLE_NAME
+        )));
+    }
+
+    if !db.contains_table(name.clone()) {
+        return if if_exists {
+            Ok(0)
+        } else {
+            Err(SQLRiteError::General(format!(
+                "Table '{name}' does not exist"
+            )))
+        };
+    }
+
+    db.tables.remove(&name);
+    Ok(1)
+}
+
+/// Executes `DROP INDEX [IF EXISTS] <name>;`. The statement does not name a
+/// table, so we walk every table looking for the index across all three
+/// index families (B-Tree secondary, HNSW, FTS).
+///
+/// Refuses to drop auto-indexes (`origin == IndexOrigin::Auto`) — those are
+/// invariants of the table's PRIMARY KEY / UNIQUE constraints and should
+/// only disappear when the column or table they depend on is dropped.
+/// SQLite has the same rule for its `sqlite_autoindex_*` indexes.
+pub fn execute_drop_index(
+    names: &[ObjectName],
+    if_exists: bool,
+    db: &mut Database,
+) -> Result<usize> {
+    if names.len() != 1 {
+        return Err(SQLRiteError::NotImplemented(
+            "DROP INDEX supports a single index per statement".to_string(),
+        ));
+    }
+    let name = names[0].to_string();
+
+    for table in db.tables.values_mut() {
+        if let Some(secondary) = table.secondary_indexes.iter().find(|i| i.name == name) {
+            if secondary.origin == IndexOrigin::Auto {
+                return Err(SQLRiteError::General(format!(
+                    "cannot drop auto-created index '{name}' (drop the column or table instead)"
+                )));
+            }
+            table.secondary_indexes.retain(|i| i.name != name);
+            return Ok(1);
+        }
+        if table.hnsw_indexes.iter().any(|i| i.name == name) {
+            table.hnsw_indexes.retain(|i| i.name != name);
+            return Ok(1);
+        }
+        if table.fts_indexes.iter().any(|i| i.name == name) {
+            table.fts_indexes.retain(|i| i.name != name);
+            return Ok(1);
+        }
+    }
+
+    if if_exists {
+        Ok(0)
+    } else {
+        Err(SQLRiteError::General(format!(
+            "Index '{name}' does not exist"
+        )))
     }
 }
 

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -335,6 +335,9 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
                 )));
             }
         },
+        Statement::AlterTable(alter) => {
+            message = executor::execute_alter_table(alter, db)?;
+        }
         _ => {
             return Err(SQLRiteError::NotImplemented(
                 "SQL Statement not supported yet.".to_string(),
@@ -2355,6 +2358,389 @@ mod tests {
 
         let mut ro = open_database_read_only(&path, "t".to_string()).unwrap();
         for stmt in ["DROP TABLE notes;", "DROP INDEX notes_body;"] {
+            let err = process_command(stmt, &mut ro).unwrap_err();
+            assert!(
+                format!("{err}").contains("read-only"),
+                "{stmt:?} should surface read-only error, got: {err}"
+            );
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let mut wal = path.as_os_str().to_owned();
+        wal.push("-wal");
+        let _ = std::fs::remove_file(std::path::PathBuf::from(wal));
+    }
+
+    // -------------------------------------------------------------------
+    // ALTER TABLE — RENAME TO / RENAME COLUMN / ADD COLUMN / DROP COLUMN
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn alter_rename_table_basic() {
+        let mut db = seed_users_table();
+        process_command("ALTER TABLE users RENAME TO members;", &mut db).expect("rename table");
+        assert!(!db.contains_table("users".to_string()));
+        assert!(db.contains_table("members".to_string()));
+        // Data still queryable under the new name.
+        let response = process_command("SELECT * FROM members;", &mut db).expect("select");
+        assert!(response.contains("3 rows returned"));
+    }
+
+    #[test]
+    fn alter_rename_table_renames_auto_indexes() {
+        // Use a fresh table with both PK and a UNIQUE column so we
+        // exercise both auto-index renames in one shot.
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, email TEXT UNIQUE);",
+            &mut db,
+        )
+        .unwrap();
+        {
+            let accounts = db.get_table("accounts".to_string()).unwrap();
+            assert!(
+                accounts
+                    .index_by_name("sqlrite_autoindex_accounts_id")
+                    .is_some()
+            );
+            assert!(
+                accounts
+                    .index_by_name("sqlrite_autoindex_accounts_email")
+                    .is_some()
+            );
+        }
+        process_command("ALTER TABLE accounts RENAME TO members;", &mut db).expect("rename");
+        let members = db.get_table("members".to_string()).unwrap();
+        assert!(
+            members
+                .index_by_name("sqlrite_autoindex_members_id")
+                .is_some(),
+            "PK auto-index should be renamed to match new table"
+        );
+        assert!(
+            members
+                .index_by_name("sqlrite_autoindex_members_email")
+                .is_some()
+        );
+        // The old-named auto-indexes should be gone.
+        assert!(
+            members
+                .index_by_name("sqlrite_autoindex_accounts_id")
+                .is_none()
+        );
+        // table_name field on each index should also reflect the rename.
+        for idx in &members.secondary_indexes {
+            assert_eq!(idx.table_name, "members");
+        }
+    }
+
+    #[test]
+    fn alter_rename_table_to_existing_errors() {
+        let mut db = seed_users_table();
+        process_command("CREATE TABLE other (id INTEGER PRIMARY KEY);", &mut db).unwrap();
+        let err = process_command("ALTER TABLE users RENAME TO other;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("already exists"), "got: {err}");
+        // Both tables still present.
+        assert!(db.contains_table("users".to_string()));
+        assert!(db.contains_table("other".to_string()));
+    }
+
+    #[test]
+    fn alter_rename_table_to_reserved_name_errors() {
+        let mut db = seed_users_table();
+        let err =
+            process_command("ALTER TABLE users RENAME TO sqlrite_master;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("reserved"), "got: {err}");
+    }
+
+    #[test]
+    fn alter_rename_column_basic() {
+        let mut db = seed_users_table();
+        process_command(
+            "ALTER TABLE users RENAME COLUMN name TO full_name;",
+            &mut db,
+        )
+        .expect("rename column");
+
+        let users = db.get_table("users".to_string()).unwrap();
+        assert!(users.contains_column("full_name".to_string()));
+        assert!(!users.contains_column("name".to_string()));
+
+        // Existing data is queryable under the new column name and value
+        // is preserved at the same rowid.
+        let bob_rowid = users
+            .rowids()
+            .into_iter()
+            .find(|r| users.get_value("full_name", *r) == Some(Value::Text("bob".to_string())))
+            .expect("bob row should be findable under the new column name");
+        assert_eq!(
+            users.get_value("full_name", bob_rowid),
+            Some(Value::Text("bob".to_string()))
+        );
+    }
+
+    #[test]
+    fn alter_rename_column_collision_errors() {
+        let mut db = seed_users_table();
+        let err =
+            process_command("ALTER TABLE users RENAME COLUMN name TO age;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("already exists"), "got: {err}");
+    }
+
+    #[test]
+    fn alter_rename_column_updates_indexes() {
+        // `accounts.email` is UNIQUE → has a renameable auto-index.
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, email TEXT UNIQUE);",
+            &mut db,
+        )
+        .unwrap();
+        process_command(
+            "ALTER TABLE accounts RENAME COLUMN email TO contact;",
+            &mut db,
+        )
+        .unwrap();
+        let accounts = db.get_table("accounts".to_string()).unwrap();
+        assert!(
+            accounts
+                .index_by_name("sqlrite_autoindex_accounts_contact")
+                .is_some()
+        );
+        assert!(
+            accounts
+                .index_by_name("sqlrite_autoindex_accounts_email")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn alter_add_column_basic() {
+        let mut db = seed_users_table();
+        process_command("ALTER TABLE users ADD COLUMN nickname TEXT;", &mut db)
+            .expect("add column");
+        let users = db.get_table("users".to_string()).unwrap();
+        assert!(users.contains_column("nickname".to_string()));
+        // Existing rows read NULL for the new column (no default given).
+        let any_rowid = *users.rowids().first().expect("seed has rows");
+        assert_eq!(users.get_value("nickname", any_rowid), None);
+
+        // A new INSERT supplying the new column works.
+        process_command(
+            "INSERT INTO users (name, age, nickname) VALUES ('dan', 22, 'd');",
+            &mut db,
+        )
+        .expect("insert with new col");
+        let users = db.get_table("users".to_string()).unwrap();
+        let dan_rowid = users
+            .rowids()
+            .into_iter()
+            .find(|r| users.get_value("name", *r) == Some(Value::Text("dan".to_string())))
+            .unwrap();
+        assert_eq!(
+            users.get_value("nickname", dan_rowid),
+            Some(Value::Text("d".to_string()))
+        );
+    }
+
+    #[test]
+    fn alter_add_column_with_default_backfills_existing_rows() {
+        let mut db = seed_users_table();
+        process_command(
+            "ALTER TABLE users ADD COLUMN status TEXT DEFAULT 'active';",
+            &mut db,
+        )
+        .expect("add column with default");
+        let users = db.get_table("users".to_string()).unwrap();
+        for rowid in users.rowids() {
+            assert_eq!(
+                users.get_value("status", rowid),
+                Some(Value::Text("active".to_string())),
+                "rowid {rowid} should have been backfilled with the default"
+            );
+        }
+    }
+
+    #[test]
+    fn alter_add_column_not_null_with_default_works_on_nonempty_table() {
+        let mut db = seed_users_table();
+        process_command(
+            "ALTER TABLE users ADD COLUMN score INTEGER NOT NULL DEFAULT 0;",
+            &mut db,
+        )
+        .expect("NOT NULL ADD with DEFAULT should succeed even with existing rows");
+        let users = db.get_table("users".to_string()).unwrap();
+        for rowid in users.rowids() {
+            assert_eq!(users.get_value("score", rowid), Some(Value::Integer(0)));
+        }
+    }
+
+    #[test]
+    fn alter_add_column_not_null_without_default_errors_on_nonempty_table() {
+        let mut db = seed_users_table();
+        let err = process_command(
+            "ALTER TABLE users ADD COLUMN score INTEGER NOT NULL;",
+            &mut db,
+        )
+        .unwrap_err();
+        let msg = format!("{err}").to_lowercase();
+        assert!(
+            msg.contains("not null") && msg.contains("default"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn alter_add_column_pk_rejected() {
+        let mut db = seed_users_table();
+        let err = process_command(
+            "ALTER TABLE users ADD COLUMN extra INTEGER PRIMARY KEY;",
+            &mut db,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("primary key"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn alter_add_column_unique_rejected() {
+        let mut db = seed_users_table();
+        let err = process_command(
+            "ALTER TABLE users ADD COLUMN extra INTEGER UNIQUE;",
+            &mut db,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("unique"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn alter_add_column_existing_name_errors() {
+        let mut db = seed_users_table();
+        let err =
+            process_command("ALTER TABLE users ADD COLUMN age INTEGER;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("already exists"), "got: {err}");
+    }
+
+    // Note: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...` is not in the
+    // SQLite dialect (PG/MSSQL extension); the AST `if_not_exists` flag is
+    // still honoured by the executor if some other dialect ever produces
+    // it, but there's no way to feed it via SQL in our default dialect.
+
+    #[test]
+    fn alter_drop_column_basic() {
+        let mut db = seed_users_table();
+        process_command("ALTER TABLE users DROP COLUMN age;", &mut db).expect("drop column");
+        let users = db.get_table("users".to_string()).unwrap();
+        assert!(!users.contains_column("age".to_string()));
+        // Other columns and rowids still intact.
+        assert!(users.contains_column("name".to_string()));
+        assert_eq!(users.rowids().len(), 3);
+    }
+
+    #[test]
+    fn alter_drop_column_drops_dependent_indexes() {
+        let mut db = seed_users_table();
+        process_command("CREATE INDEX users_age_idx ON users (age);", &mut db).unwrap();
+        process_command("ALTER TABLE users DROP COLUMN age;", &mut db).unwrap();
+        let users = db.get_table("users".to_string()).unwrap();
+        assert!(users.index_by_name("users_age_idx").is_none());
+    }
+
+    #[test]
+    fn alter_drop_column_pk_errors() {
+        let mut db = seed_users_table();
+        let err = process_command("ALTER TABLE users DROP COLUMN id;", &mut db).unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("primary key"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn alter_drop_column_only_column_errors() {
+        let mut db = Database::new("t".to_string());
+        process_command("CREATE TABLE solo (only_col TEXT);", &mut db).unwrap();
+        let err = process_command("ALTER TABLE solo DROP COLUMN only_col;", &mut db).unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("only column"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn alter_unknown_table_errors_without_if_exists() {
+        let mut db = Database::new("t".to_string());
+        let err = process_command("ALTER TABLE missing RENAME TO other;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn alter_unknown_table_if_exists_noop() {
+        let mut db = Database::new("t".to_string());
+        let response = process_command("ALTER TABLE IF EXISTS missing RENAME TO other;", &mut db)
+            .expect("IF EXISTS makes missing-table ALTER a no-op");
+        assert!(response.contains("no-op"));
+    }
+
+    #[test]
+    fn alter_inside_transaction_rolls_back() {
+        let mut db = seed_users_table();
+        process_command("BEGIN;", &mut db).unwrap();
+        process_command(
+            "ALTER TABLE users ADD COLUMN status TEXT DEFAULT 'active';",
+            &mut db,
+        )
+        .unwrap();
+        // Confirm in-flight visibility.
+        assert!(
+            db.get_table("users".to_string())
+                .unwrap()
+                .contains_column("status".to_string())
+        );
+        process_command("ROLLBACK;", &mut db).unwrap();
+        // Snapshot restore should erase the ALTER.
+        assert!(
+            !db.get_table("users".to_string())
+                .unwrap()
+                .contains_column("status".to_string())
+        );
+    }
+
+    #[test]
+    fn alter_rejected_on_readonly_db() {
+        use crate::sql::pager::{open_database_read_only, save_database};
+
+        let mut seed = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT);",
+            &mut seed,
+        )
+        .unwrap();
+        let path = {
+            let mut p = std::env::temp_dir();
+            let pid = std::process::id();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            p.push(format!("sqlrite-alter-ro-{pid}-{nanos}.sqlrite"));
+            p
+        };
+        save_database(&mut seed, &path).unwrap();
+        drop(seed);
+
+        let mut ro = open_database_read_only(&path, "t".to_string()).unwrap();
+        for stmt in [
+            "ALTER TABLE notes RENAME TO n2;",
+            "ALTER TABLE notes RENAME COLUMN body TO b;",
+            "ALTER TABLE notes ADD COLUMN extra TEXT;",
+            "ALTER TABLE notes DROP COLUMN body;",
+        ] {
             let err = process_command(stmt, &mut ro).unwrap_err();
             assert!(
                 format!("{err}").contains("read-only"),

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -2097,4 +2097,103 @@ mod tests {
             "got: {msg}"
         );
     }
+
+    // -------------------------------------------------------------------
+    // DEFAULT clause on CREATE TABLE columns
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn default_literal_int_applies_when_column_omitted() {
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER DEFAULT 42);",
+            &mut db,
+        )
+        .unwrap();
+        process_command("INSERT INTO t (id) VALUES (1);", &mut db).unwrap();
+
+        let table = db.get_table("t".to_string()).unwrap();
+        assert_eq!(table.get_value("n", 1), Some(Value::Integer(42)));
+    }
+
+    #[test]
+    fn default_literal_text_applies_when_column_omitted() {
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, status TEXT DEFAULT 'active');",
+            &mut db,
+        )
+        .unwrap();
+        process_command("INSERT INTO users (id) VALUES (1);", &mut db).unwrap();
+
+        let table = db.get_table("users".to_string()).unwrap();
+        assert_eq!(
+            table.get_value("status", 1),
+            Some(Value::Text("active".to_string()))
+        );
+    }
+
+    #[test]
+    fn default_literal_real_negative_applies_when_column_omitted() {
+        // `DEFAULT -1.5` arrives as a UnaryOp(Minus, Number) — exercise that path.
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, score REAL DEFAULT -1.5);",
+            &mut db,
+        )
+        .unwrap();
+        process_command("INSERT INTO t (id) VALUES (1);", &mut db).unwrap();
+
+        let table = db.get_table("t".to_string()).unwrap();
+        assert_eq!(table.get_value("score", 1), Some(Value::Real(-1.5)));
+    }
+
+    #[test]
+    fn default_with_type_mismatch_errors_at_create_time() {
+        let mut db = Database::new("t".to_string());
+        let result = process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, n INTEGER DEFAULT 'oops');",
+            &mut db,
+        );
+        let err = result.expect_err("text default on INTEGER column should be rejected");
+        let msg = format!("{err}").to_lowercase();
+        assert!(msg.contains("default"), "got: {msg}");
+    }
+
+    #[test]
+    fn default_with_non_literal_expression_errors_at_create_time() {
+        let mut db = Database::new("t".to_string());
+        // Function-call DEFAULT (e.g. CURRENT_TIMESTAMP) → rejected; we only
+        // accept literal expressions for now.
+        let result = process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, ts TEXT DEFAULT CURRENT_TIMESTAMP);",
+            &mut db,
+        );
+        let err = result.expect_err("non-literal DEFAULT should be rejected");
+        let msg = format!("{err}").to_lowercase();
+        assert!(
+            msg.contains("default") && msg.contains("literal"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn default_null_is_accepted_at_create_time() {
+        // `DEFAULT NULL` is a no-op equivalent to no DEFAULT clause; the
+        // important thing is that CREATE TABLE accepts it without error
+        // (some DDL exporters emit `DEFAULT NULL` redundantly).
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, note TEXT DEFAULT NULL);",
+            &mut db,
+        )
+        .expect("CREATE TABLE with DEFAULT NULL should be accepted");
+        let table = db.get_table("t".to_string()).unwrap();
+        let note = table
+            .columns
+            .iter()
+            .find(|c| c.column_name == "note")
+            .unwrap();
+        assert_eq!(note.default, Some(Value::Null));
+    }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -10,7 +10,7 @@ use parser::create::CreateQuery;
 use parser::insert::InsertQuery;
 use parser::select::SelectQuery;
 
-use sqlparser::ast::Statement;
+use sqlparser::ast::{ObjectType, Statement};
 use sqlparser::dialect::SQLiteDialect;
 use sqlparser::parser::{Parser, ParserError};
 
@@ -167,6 +167,8 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
             | Statement::Insert(_)
             | Statement::Update(_)
             | Statement::Delete(_)
+            | Statement::Drop { .. }
+            | Statement::AlterTable(_)
     );
 
     // Early-reject mutations on a read-only database before they touch
@@ -311,6 +313,28 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
             let name = executor::execute_create_index(&query, db)?;
             message = format!("CREATE INDEX '{name}' executed.");
         }
+        Statement::Drop {
+            object_type,
+            if_exists,
+            names,
+            ..
+        } => match object_type {
+            ObjectType::Table => {
+                let count = executor::execute_drop_table(&names, if_exists, db)?;
+                let plural = if count == 1 { "table" } else { "tables" };
+                message = format!("DROP TABLE Statement executed. {count} {plural} dropped.");
+            }
+            ObjectType::Index => {
+                let count = executor::execute_drop_index(&names, if_exists, db)?;
+                let plural = if count == 1 { "index" } else { "indexes" };
+                message = format!("DROP INDEX Statement executed. {count} {plural} dropped.");
+            }
+            other => {
+                return Err(SQLRiteError::NotImplemented(format!(
+                    "DROP {other:?} is not supported (only TABLE and INDEX)"
+                )));
+            }
+        },
         _ => {
             return Err(SQLRiteError::NotImplemented(
                 "SQL Statement not supported yet.".to_string(),
@@ -601,8 +625,10 @@ mod tests {
     #[test]
     fn process_command_unsupported_statement_test() {
         let mut db = Database::new("tempdb".to_string());
-        // Nothing in Phase 1 handles DROP.
-        let result = process_command("DROP TABLE users;", &mut db);
+        // CREATE VIEW is firmly in the "Not yet supported" list — used as
+        // the canary for the dispatcher's NotImplemented arm. (DROP TABLE
+        // moved out of unsupported in this branch.)
+        let result = process_command("CREATE VIEW v AS SELECT * FROM users;", &mut db);
         assert!(result.is_err());
     }
 
@@ -2195,5 +2221,150 @@ mod tests {
             .find(|c| c.column_name == "note")
             .unwrap();
         assert_eq!(note.default, Some(Value::Null));
+    }
+
+    // -------------------------------------------------------------------
+    // DROP TABLE / DROP INDEX
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn drop_table_basic() {
+        let mut db = seed_users_table();
+        let response = process_command("DROP TABLE users;", &mut db).expect("drop table");
+        assert!(response.contains("1 table dropped"));
+        assert!(!db.contains_table("users".to_string()));
+    }
+
+    #[test]
+    fn drop_table_if_exists_noop_on_missing() {
+        let mut db = Database::new("t".to_string());
+        let response =
+            process_command("DROP TABLE IF EXISTS missing;", &mut db).expect("drop if exists");
+        assert!(response.contains("0 tables dropped"));
+    }
+
+    #[test]
+    fn drop_table_missing_errors_without_if_exists() {
+        let mut db = Database::new("t".to_string());
+        let err = process_command("DROP TABLE missing;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn drop_table_reserved_name_errors() {
+        let mut db = Database::new("t".to_string());
+        let err = process_command("DROP TABLE sqlrite_master;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("reserved"), "got: {err}");
+    }
+
+    #[test]
+    fn drop_table_multi_target_rejected() {
+        let mut db = seed_users_table();
+        process_command("CREATE TABLE other (id INTEGER PRIMARY KEY);", &mut db).unwrap();
+        // sqlparser accepts `DROP TABLE a, b` as one statement; we reject
+        // to keep error semantics simple (no partial-failure rollback).
+        let err = process_command("DROP TABLE users, other;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("single table"), "got: {err}");
+    }
+
+    #[test]
+    fn drop_table_cascades_indexes_in_memory() {
+        let mut db = seed_users_table();
+        process_command("CREATE INDEX users_age_idx ON users (age);", &mut db).unwrap();
+        // PK auto-index + UNIQUE-on-name auto-index + the explicit one.
+        let users = db.get_table("users".to_string()).unwrap();
+        assert!(
+            users
+                .secondary_indexes
+                .iter()
+                .any(|i| i.name == "users_age_idx")
+        );
+
+        process_command("DROP TABLE users;", &mut db).unwrap();
+
+        // After DROP TABLE, no other table should claim the dropped indexes.
+        for table in db.tables.values() {
+            assert!(
+                !table
+                    .secondary_indexes
+                    .iter()
+                    .any(|i| i.name.contains("users")),
+                "dropped table's indexes should not survive on any other table"
+            );
+        }
+    }
+
+    #[test]
+    fn drop_index_explicit_basic() {
+        let mut db = seed_users_table();
+        process_command("CREATE INDEX users_age_idx ON users (age);", &mut db).unwrap();
+        let response = process_command("DROP INDEX users_age_idx;", &mut db).expect("drop index");
+        assert!(response.contains("1 index dropped"));
+
+        let users = db.get_table("users".to_string()).unwrap();
+        assert!(users.index_by_name("users_age_idx").is_none());
+    }
+
+    #[test]
+    fn drop_index_refuses_auto_index() {
+        let mut db = seed_users_table();
+        // `users` was created with `id INTEGER PRIMARY KEY` → auto-index
+        // named `sqlrite_autoindex_users_id`.
+        let err = process_command("DROP INDEX sqlrite_autoindex_users_id;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("auto-created"), "got: {err}");
+    }
+
+    #[test]
+    fn drop_index_if_exists_noop_on_missing() {
+        let mut db = Database::new("t".to_string());
+        let response =
+            process_command("DROP INDEX IF EXISTS nope;", &mut db).expect("drop index if exists");
+        assert!(response.contains("0 indexes dropped"));
+    }
+
+    #[test]
+    fn drop_index_missing_errors_without_if_exists() {
+        let mut db = Database::new("t".to_string());
+        let err = process_command("DROP INDEX nope;", &mut db).unwrap_err();
+        assert!(format!("{err}").contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn drop_statements_rejected_on_readonly_db() {
+        use crate::sql::pager::{open_database_read_only, save_database};
+
+        let mut seed = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT);",
+            &mut seed,
+        )
+        .unwrap();
+        process_command("CREATE INDEX notes_body ON notes (body);", &mut seed).unwrap();
+        let path = {
+            let mut p = std::env::temp_dir();
+            let pid = std::process::id();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            p.push(format!("sqlrite-drop-ro-{pid}-{nanos}.sqlrite"));
+            p
+        };
+        save_database(&mut seed, &path).unwrap();
+        drop(seed);
+
+        let mut ro = open_database_read_only(&path, "t".to_string()).unwrap();
+        for stmt in ["DROP TABLE notes;", "DROP INDEX notes_body;"] {
+            let err = process_command(stmt, &mut ro).unwrap_err();
+            assert!(
+                format!("{err}").contains("read-only"),
+                "{stmt:?} should surface read-only error, got: {err}"
+            );
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let mut wal = path.as_os_str().to_owned();
+        wal.push("-wal");
+        let _ = std::fs::remove_file(std::path::PathBuf::from(wal));
     }
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -2190,6 +2190,30 @@ mod tests {
     }
 
     #[test]
+    fn default_for_json_column_must_be_valid_json() {
+        // ADD COLUMN ... JSON DEFAULT 'not-json' would otherwise backfill
+        // every existing row with invalid JSON (insert_row's validation
+        // is bypassed for the backfill path).
+        let mut db = Database::new("t".to_string());
+        let err = process_command(
+            "CREATE TABLE t (id INTEGER PRIMARY KEY, doc JSON DEFAULT 'not-json{');",
+            &mut db,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err}").to_lowercase().contains("json"),
+            "got: {err}"
+        );
+
+        // Valid JSON DEFAULT works.
+        process_command(
+            "CREATE TABLE t2 (id INTEGER PRIMARY KEY, doc JSON DEFAULT '{\"k\":1}');",
+            &mut db,
+        )
+        .expect("valid JSON DEFAULT should be accepted");
+    }
+
+    #[test]
     fn default_with_non_literal_expression_errors_at_create_time() {
         let mut db = Database::new("t".to_string());
         // Function-call DEFAULT (e.g. CURRENT_TIMESTAMP) → rejected; we only
@@ -2685,6 +2709,23 @@ mod tests {
         let response = process_command("ALTER TABLE IF EXISTS missing RENAME TO other;", &mut db)
             .expect("IF EXISTS makes missing-table ALTER a no-op");
         assert!(response.contains("no-op"));
+    }
+
+    #[test]
+    fn drop_table_inside_transaction_rolls_back() {
+        // Exercises Database::deep_clone snapshot path with DROP TABLE.
+        // A wholesale tables-HashMap restore on ROLLBACK should resurrect
+        // the dropped table — including its data and dependent indexes.
+        let mut db = seed_users_table();
+        process_command("CREATE INDEX users_age_idx ON users (age);", &mut db).unwrap();
+        process_command("BEGIN;", &mut db).unwrap();
+        process_command("DROP TABLE users;", &mut db).unwrap();
+        assert!(!db.contains_table("users".to_string()));
+        process_command("ROLLBACK;", &mut db).unwrap();
+        assert!(db.contains_table("users".to_string()));
+        let users = db.get_table("users".to_string()).unwrap();
+        assert_eq!(users.rowids().len(), 3);
+        assert!(users.index_by_name("users_age_idx").is_some());
     }
 
     #[test]

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -2557,6 +2557,118 @@ mod tests {
     }
 
     #[test]
+    fn alter_rename_table_survives_save_and_reopen() {
+        let path = tmp_path("alter_rename_table_roundtrip");
+        let mut db = seed_db();
+        save_database(&mut db, &path).expect("save");
+
+        process_command("ALTER TABLE users RENAME TO members;", &mut db).expect("rename");
+        save_database(&mut db, &path).expect("save after rename");
+
+        let loaded = open_database(&path, "t".to_string()).expect("reopen");
+        assert!(!loaded.contains_table("users".to_string()));
+        assert!(loaded.contains_table("members".to_string()));
+        let members = loaded.get_table("members".to_string()).unwrap();
+        assert_eq!(members.rowids().len(), 2, "rows should survive");
+        // Auto-indexes followed the rename.
+        assert!(
+            members
+                .index_by_name("sqlrite_autoindex_members_id")
+                .is_some()
+        );
+        assert!(
+            members
+                .index_by_name("sqlrite_autoindex_members_name")
+                .is_some()
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn alter_rename_column_survives_save_and_reopen() {
+        let path = tmp_path("alter_rename_col_roundtrip");
+        let mut db = seed_db();
+        save_database(&mut db, &path).expect("save");
+
+        process_command(
+            "ALTER TABLE users RENAME COLUMN name TO full_name;",
+            &mut db,
+        )
+        .expect("rename column");
+        save_database(&mut db, &path).expect("save after rename");
+
+        let loaded = open_database(&path, "t".to_string()).expect("reopen");
+        let users = loaded.get_table("users".to_string()).unwrap();
+        assert!(users.contains_column("full_name".to_string()));
+        assert!(!users.contains_column("name".to_string()));
+        // Verify a row's value survived the rename round-trip.
+        let alice_rowid = users
+            .rowids()
+            .into_iter()
+            .find(|r| users.get_value("full_name", *r) == Some(Value::Text("alice".to_string())))
+            .expect("alice row should be findable under renamed column");
+        assert_eq!(
+            users.get_value("full_name", alice_rowid),
+            Some(Value::Text("alice".to_string()))
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn alter_add_column_with_default_survives_save_and_reopen() {
+        let path = tmp_path("alter_add_default_roundtrip");
+        let mut db = seed_db();
+        save_database(&mut db, &path).expect("save");
+
+        process_command(
+            "ALTER TABLE users ADD COLUMN status TEXT DEFAULT 'active';",
+            &mut db,
+        )
+        .expect("add column");
+        save_database(&mut db, &path).expect("save after add");
+
+        let loaded = open_database(&path, "t".to_string()).expect("reopen");
+        let users = loaded.get_table("users".to_string()).unwrap();
+        assert!(users.contains_column("status".to_string()));
+        for rowid in users.rowids() {
+            assert_eq!(
+                users.get_value("status", rowid),
+                Some(Value::Text("active".to_string())),
+                "backfilled default should round-trip for rowid {rowid}"
+            );
+        }
+        // The DEFAULT clause itself should still be on the column metadata
+        // so a subsequent INSERT picks it up.
+        let status_col = users
+            .columns
+            .iter()
+            .find(|c| c.column_name == "status")
+            .unwrap();
+        assert_eq!(status_col.default, Some(Value::Text("active".to_string())));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn alter_drop_column_survives_save_and_reopen() {
+        let path = tmp_path("alter_drop_col_roundtrip");
+        let mut db = seed_db();
+        save_database(&mut db, &path).expect("save");
+
+        process_command("ALTER TABLE users DROP COLUMN age;", &mut db).expect("drop column");
+        save_database(&mut db, &path).expect("save after drop");
+
+        let loaded = open_database(&path, "t".to_string()).expect("reopen");
+        let users = loaded.get_table("users".to_string()).unwrap();
+        assert!(!users.contains_column("age".to_string()));
+        assert!(users.contains_column("name".to_string()));
+
+        cleanup(&path);
+    }
+
+    #[test]
     fn drop_table_survives_save_and_reopen() {
         let path = tmp_path("drop_table_roundtrip");
         let mut db = seed_db();

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -2557,6 +2557,62 @@ mod tests {
     }
 
     #[test]
+    fn drop_table_survives_save_and_reopen() {
+        let path = tmp_path("drop_table_roundtrip");
+        let mut db = seed_db();
+        save_database(&mut db, &path).expect("save");
+
+        // Verify both tables landed.
+        {
+            let loaded = open_database(&path, "t".to_string()).expect("open");
+            assert!(loaded.contains_table("users".to_string()));
+            assert!(loaded.contains_table("notes".to_string()));
+        }
+
+        process_command("DROP TABLE users;", &mut db).expect("drop users");
+        save_database(&mut db, &path).expect("save after drop");
+
+        let loaded = open_database(&path, "t".to_string()).expect("reopen");
+        assert!(
+            !loaded.contains_table("users".to_string()),
+            "dropped table should not resurface on reopen"
+        );
+        assert!(
+            loaded.contains_table("notes".to_string()),
+            "untouched table should survive"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn drop_index_survives_save_and_reopen() {
+        let path = tmp_path("drop_index_roundtrip");
+        let mut db = Database::new("t".to_string());
+        process_command(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        process_command("CREATE INDEX notes_body_idx ON notes (body);", &mut db).unwrap();
+        save_database(&mut db, &path).expect("save");
+
+        process_command("DROP INDEX notes_body_idx;", &mut db).unwrap();
+        save_database(&mut db, &path).expect("save after drop");
+
+        let loaded = open_database(&path, "t".to_string()).expect("reopen");
+        let notes = loaded.get_table("notes".to_string()).unwrap();
+        assert!(
+            notes.index_by_name("notes_body_idx").is_none(),
+            "dropped index should not resurface on reopen"
+        );
+        // The auto-index for the PK should still be there.
+        assert!(notes.index_by_name("sqlrite_autoindex_notes_id").is_some());
+
+        cleanup(&path);
+    }
+
+    #[test]
     fn default_clause_survives_save_and_reopen() {
         let path = tmp_path("default_roundtrip");
         let mut db = Database::new("t".to_string());

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -443,9 +443,35 @@ fn table_to_create_sql(table: &Table) -> String {
                 piece.push_str(" NOT NULL");
             }
         }
+        if let Some(default) = &c.default {
+            piece.push_str(" DEFAULT ");
+            piece.push_str(&render_default_literal(default));
+        }
         parts.push(piece);
     }
     format!("CREATE TABLE {} ({});", table.tb_name, parts.join(", "))
+}
+
+/// Renders a DEFAULT value back to SQL-literal form so the synthesized
+/// CREATE TABLE round-trips through `parse_create_sql`. Text values get
+/// single-quoted with single-quote doubling for escaping. Vector defaults
+/// are not currently expressible at CREATE TABLE time, so we render them
+/// as their bracket-array form (matches the INSERT literal grammar).
+fn render_default_literal(value: &Value) -> String {
+    match value {
+        Value::Integer(i) => i.to_string(),
+        Value::Real(f) => f.to_string(),
+        Value::Bool(b) => {
+            if *b {
+                "TRUE".to_string()
+            } else {
+                "FALSE".to_string()
+            }
+        }
+        Value::Text(s) => format!("'{}'", s.replace('\'', "''")),
+        Value::Null => "NULL".to_string(),
+        Value::Vector(_) => value.to_display_string(),
+    }
 }
 
 /// Reverses `table_to_create_sql`: feeds the SQL back through `sqlparser`
@@ -460,7 +486,16 @@ fn parse_create_sql(sql: &str) -> Result<(String, Vec<Column>)> {
     let columns = create
         .columns
         .into_iter()
-        .map(|pc| Column::new(pc.name, pc.datatype, pc.is_pk, pc.not_null, pc.is_unique))
+        .map(|pc| {
+            Column::with_default(
+                pc.name,
+                pc.datatype,
+                pc.is_pk,
+                pc.not_null,
+                pc.is_unique,
+                pc.default,
+            )
+        })
         .collect();
     Ok((create.table_name, columns))
 }
@@ -2517,6 +2552,56 @@ mod tests {
             PageType::InteriorNode as u8,
             "expected 3-level tree: root's leftmost child should also be InteriorNode",
         );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn default_clause_survives_save_and_reopen() {
+        let path = tmp_path("default_roundtrip");
+        let mut db = Database::new("t".to_string());
+
+        process_command(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, status TEXT DEFAULT 'active', score INTEGER DEFAULT 0);",
+            &mut db,
+        )
+        .unwrap();
+        save_database(&mut db, &path).expect("save");
+
+        let mut loaded = open_database(&path, "t".to_string()).expect("open");
+
+        // The reloaded column metadata should still carry the DEFAULT.
+        let users = loaded.get_table("users".to_string()).expect("users table");
+        let status_col = users
+            .columns
+            .iter()
+            .find(|c| c.column_name == "status")
+            .expect("status column");
+        assert_eq!(
+            status_col.default,
+            Some(Value::Text("active".to_string())),
+            "DEFAULT 'active' should round-trip"
+        );
+        let score_col = users
+            .columns
+            .iter()
+            .find(|c| c.column_name == "score")
+            .expect("score column");
+        assert_eq!(
+            score_col.default,
+            Some(Value::Integer(0)),
+            "DEFAULT 0 should round-trip"
+        );
+
+        // Now exercise the runtime path: an INSERT that omits both DEFAULT
+        // columns should pick them up from the reloaded schema.
+        process_command("INSERT INTO users (id) VALUES (1);", &mut loaded).unwrap();
+        let users = loaded.get_table("users".to_string()).unwrap();
+        assert_eq!(
+            users.get_value("status", 1),
+            Some(Value::Text("active".to_string()))
+        );
+        assert_eq!(users.get_value("score", 1), Some(Value::Integer(0)));
 
         cleanup(&path);
     }

--- a/src/sql/parser/create.rs
+++ b/src/sql/parser/create.rs
@@ -229,7 +229,19 @@ fn eval_literal_default(expr: &Expr, datatype: &str, col_name: &str) -> Result<V
             }
         }
         AstValue::SingleQuotedString(s) => {
-            if datatype == "Text" || datatype == "Json" {
+            if datatype == "Text" {
+                Ok(Value::Text(s.clone()))
+            } else if datatype == "Json" {
+                // JSON columns accept text literals only if they parse as
+                // JSON — otherwise an ALTER TABLE ADD COLUMN ... JSON
+                // DEFAULT '<garbage>' would silently backfill every row
+                // with invalid JSON (insert_row's per-row JSON validation
+                // is bypassed during the backfill path).
+                serde_json::from_str::<serde_json::Value>(s).map_err(|e| {
+                    SQLRiteError::General(format!(
+                        "DEFAULT type mismatch for column '{col_name}': '{s}' is not valid JSON: {e}"
+                    ))
+                })?;
                 Ok(Value::Text(s.clone()))
             } else {
                 Err(SQLRiteError::General(format!(

--- a/src/sql/parser/create.rs
+++ b/src/sql/parser/create.rs
@@ -1,6 +1,10 @@
-use sqlparser::ast::{ColumnOption, CreateTable, DataType, ObjectName, ObjectNamePart, Statement};
+use sqlparser::ast::{
+    ColumnDef, ColumnOption, CreateTable, DataType, Expr, ObjectName, ObjectNamePart, Statement,
+    UnaryOperator, Value as AstValue,
+};
 
 use crate::error::{Result, SQLRiteError};
+use crate::sql::db::table::Value;
 
 /// True when an `ObjectName` resolves to a single identifier `VECTOR`
 /// (case-insensitive). Phase 7a adds the `VECTOR(N)` column type as a
@@ -43,7 +47,7 @@ fn parse_vector_dim(args: &[String]) -> std::result::Result<usize, String> {
 
 /// The schema for each SQL column in every table is represented by
 /// the following structure after parsed and tokenized
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct ParsedColumn {
     /// Name of the column
     pub name: String,
@@ -55,6 +59,10 @@ pub struct ParsedColumn {
     pub not_null: bool,
     /// Value representing if column was declared with the UNIQUE Constraint
     pub is_unique: bool,
+    /// Literal value to use when this column is omitted from an INSERT.
+    /// Restricted to literal expressions (integer, real, text, bool, NULL);
+    /// non-literal `DEFAULT` expressions are rejected at CREATE TABLE time.
+    pub default: Option<Value>,
 }
 
 /// The following structure represents a CREATE TABLE query already parsed
@@ -66,6 +74,192 @@ pub struct CreateQuery {
     pub table_name: String,
     /// Vector of `ParsedColumn` type with column metadata information
     pub columns: Vec<ParsedColumn>,
+}
+
+/// Parses a single sqlparser `ColumnDef` into our internal `ParsedColumn`
+/// representation. Extracted from `CreateQuery::new` so `ALTER TABLE ADD
+/// COLUMN` can reuse the same column-shape parsing without re-implementing
+/// the type / constraint / default plumbing.
+///
+/// Caller-side responsibilities not handled here:
+/// - duplicate column name detection (a multi-column invariant)
+/// - "more than one PRIMARY KEY" detection (a multi-column invariant)
+pub fn parse_one_column(col: &ColumnDef) -> Result<ParsedColumn> {
+    let name = col.name.to_string();
+
+    // Parsing each column for it data type
+    // For now only accepting basic data types
+    let datatype: String = match &col.data_type {
+        DataType::TinyInt(_)
+        | DataType::SmallInt(_)
+        | DataType::Int2(_)
+        | DataType::Int(_)
+        | DataType::Int4(_)
+        | DataType::Int8(_)
+        | DataType::Integer(_)
+        | DataType::BigInt(_) => "Integer".to_string(),
+        DataType::Boolean => "Bool".to_string(),
+        DataType::Text => "Text".to_string(),
+        DataType::Varchar(_bytes) => "Text".to_string(),
+        DataType::Real => "Real".to_string(),
+        DataType::Float(_precision) => "Real".to_string(),
+        DataType::Double(_) => "Real".to_string(),
+        DataType::Decimal(_) => "Real".to_string(),
+        // Phase 7e — `JSON` parses as a unit variant in
+        // sqlparser's DataType enum. JSONB is treated as
+        // an alias (matches PostgreSQL's permissive
+        // behaviour); both store as text under the hood.
+        DataType::JSON | DataType::JSONB => "Json".to_string(),
+        // Phase 7a — `VECTOR(N)` parses as Custom("VECTOR", ["N"]).
+        // sqlparser's SQLite dialect doesn't have a built-in
+        // Vector variant; Custom is what unrecognized type
+        // names + their parenthesized args fall through to.
+        DataType::Custom(name, args) if is_vector_type(name) => match parse_vector_dim(args) {
+            Ok(dim) => format!("vector({dim})"),
+            Err(e) => {
+                return Err(SQLRiteError::General(format!(
+                    "Invalid VECTOR column '{}': {e}",
+                    col.name
+                )));
+            }
+        },
+        other => {
+            eprintln!("not matched on custom type: {other:?}");
+            "Invalid".to_string()
+        }
+    };
+
+    let mut is_pk: bool = false;
+    let mut is_unique: bool = false;
+    let mut not_null: bool = false;
+    let mut default: Option<Value> = None;
+    for column_option in &col.options {
+        match &column_option.option {
+            ColumnOption::PrimaryKey(_) => {
+                // For now, only Integer and Text types can be PRIMARY KEY and Unique
+                // Therefore Indexed.
+                if datatype != "Real" && datatype != "Bool" {
+                    is_pk = true;
+                    is_unique = true;
+                    not_null = true;
+                }
+            }
+            ColumnOption::Unique(_) => {
+                // For now, only Integer and Text types can be UNIQUE
+                // Therefore Indexed.
+                if datatype != "Real" && datatype != "Bool" {
+                    is_unique = true;
+                }
+            }
+            ColumnOption::NotNull => {
+                not_null = true;
+            }
+            ColumnOption::Default(expr) => {
+                default = Some(eval_literal_default(expr, &datatype, &name)?);
+            }
+            _ => (),
+        };
+    }
+
+    Ok(ParsedColumn {
+        name,
+        datatype,
+        is_pk,
+        not_null,
+        is_unique,
+        default,
+    })
+}
+
+/// Evaluates a `DEFAULT <expr>` clause to a runtime `Value`. Restricted to
+/// literal expressions — anything else (function calls, column references,
+/// arithmetic on non-literals, `CURRENT_TIMESTAMP`, …) is rejected with a
+/// typed error so users see the limit at `CREATE TABLE` time rather than
+/// silently accepting a `DEFAULT` we can't honour at INSERT time.
+///
+/// Negative numeric literals come through sqlparser as `UnaryOp { Minus, Value(N) }`;
+/// we unwrap one level of leading `+`/`-` to support `DEFAULT -1` / `DEFAULT +3.14`.
+///
+/// Type-checks the literal against the column's declared datatype and
+/// rejects mismatches (e.g. `INTEGER ... DEFAULT 'foo'`).
+fn eval_literal_default(expr: &Expr, datatype: &str, col_name: &str) -> Result<Value> {
+    let value = match expr {
+        Expr::Value(v) => &v.value,
+        Expr::UnaryOp {
+            op: UnaryOperator::Minus,
+            expr: inner,
+        } => {
+            return match inner.as_ref() {
+                Expr::Value(v) => match &v.value {
+                    AstValue::Number(n, _) => {
+                        let neg = format!("-{n}");
+                        coerce_number_default(&neg, datatype, col_name)
+                    }
+                    _ => Err(SQLRiteError::General(format!(
+                        "DEFAULT for column '{col_name}' must be a literal value"
+                    ))),
+                },
+                _ => Err(SQLRiteError::General(format!(
+                    "DEFAULT for column '{col_name}' must be a literal value"
+                ))),
+            };
+        }
+        Expr::UnaryOp {
+            op: UnaryOperator::Plus,
+            expr: inner,
+        } => {
+            return eval_literal_default(inner, datatype, col_name);
+        }
+        _ => {
+            return Err(SQLRiteError::General(format!(
+                "DEFAULT for column '{col_name}' must be a literal value"
+            )));
+        }
+    };
+
+    match value {
+        AstValue::Null => Ok(Value::Null),
+        AstValue::Boolean(b) => {
+            if datatype == "Bool" {
+                Ok(Value::Bool(*b))
+            } else {
+                Err(SQLRiteError::General(format!(
+                    "DEFAULT type mismatch for column '{col_name}': boolean is not a {datatype}"
+                )))
+            }
+        }
+        AstValue::SingleQuotedString(s) => {
+            if datatype == "Text" || datatype == "Json" {
+                Ok(Value::Text(s.clone()))
+            } else {
+                Err(SQLRiteError::General(format!(
+                    "DEFAULT type mismatch for column '{col_name}': text is not a {datatype}"
+                )))
+            }
+        }
+        AstValue::Number(n, _) => coerce_number_default(n, datatype, col_name),
+        _ => Err(SQLRiteError::General(format!(
+            "DEFAULT for column '{col_name}' must be a literal value"
+        ))),
+    }
+}
+
+fn coerce_number_default(n: &str, datatype: &str, col_name: &str) -> Result<Value> {
+    match datatype {
+        "Integer" => n.parse::<i64>().map(Value::Integer).map_err(|_| {
+            SQLRiteError::General(format!(
+                "DEFAULT type mismatch for column '{col_name}': '{n}' is not a valid INTEGER"
+            ))
+        }),
+        "Real" => n.parse::<f64>().map(Value::Real).map_err(|_| {
+            SQLRiteError::General(format!(
+                "DEFAULT type mismatch for column '{col_name}': '{n}' is not a valid REAL"
+            ))
+        }),
+        other => Err(SQLRiteError::General(format!(
+            "DEFAULT type mismatch for column '{col_name}': numeric literal is not a {other}"
+        ))),
+    }
 }
 
 impl CreateQuery {
@@ -84,113 +278,34 @@ impl CreateQuery {
                 // Iterating over the columns returned form the Parser::parse:sql
                 // in the mod sql
                 for col in columns {
-                    let name = col.name.to_string();
-
                     // Checks if columm already added to parsed_columns, if so, returns an error
-                    if parsed_columns.iter().any(|col| col.name == name) {
+                    let name = col.name.to_string();
+                    if parsed_columns.iter().any(|c| c.name == name) {
                         return Err(SQLRiteError::Internal(format!(
                             "Duplicate column name: {}",
                             &name
                         )));
                     }
 
-                    // Parsing each column for it data type
-                    // For now only accepting basic data types
-                    let datatype: String = match &col.data_type {
-                        DataType::TinyInt(_)
-                        | DataType::SmallInt(_)
-                        | DataType::Int2(_)
-                        | DataType::Int(_)
-                        | DataType::Int4(_)
-                        | DataType::Int8(_)
-                        | DataType::Integer(_)
-                        | DataType::BigInt(_) => "Integer".to_string(),
-                        DataType::Boolean => "Bool".to_string(),
-                        DataType::Text => "Text".to_string(),
-                        DataType::Varchar(_bytes) => "Text".to_string(),
-                        DataType::Real => "Real".to_string(),
-                        DataType::Float(_precision) => "Real".to_string(),
-                        DataType::Double(_) => "Real".to_string(),
-                        DataType::Decimal(_) => "Real".to_string(),
-                        // Phase 7e — `JSON` parses as a unit variant in
-                        // sqlparser's DataType enum. JSONB is treated as
-                        // an alias (matches PostgreSQL's permissive
-                        // behaviour); both store as text under the hood.
-                        DataType::JSON | DataType::JSONB => "Json".to_string(),
-                        // Phase 7a — `VECTOR(N)` parses as Custom("VECTOR", ["N"]).
-                        // sqlparser's SQLite dialect doesn't have a built-in
-                        // Vector variant; Custom is what unrecognized type
-                        // names + their parenthesized args fall through to.
-                        DataType::Custom(name, args) if is_vector_type(name) => {
-                            match parse_vector_dim(args) {
-                                Ok(dim) => format!("vector({dim})"),
-                                Err(e) => {
-                                    return Err(SQLRiteError::General(format!(
-                                        "Invalid VECTOR column '{}': {e}",
-                                        col.name
-                                    )));
-                                }
-                            }
-                        }
-                        other => {
-                            eprintln!("not matched on custom type: {other:?}");
-                            "Invalid".to_string()
-                        }
-                    };
+                    let parsed = parse_one_column(col)?;
 
-                    // checking if column is PRIMARY KEY
-                    let mut is_pk: bool = false;
-                    // chekcing if column is UNIQUE
-                    let mut is_unique: bool = false;
-                    // chekcing if column is NULLABLE
-                    let mut not_null: bool = false;
-                    for column_option in &col.options {
-                        match &column_option.option {
-                            ColumnOption::PrimaryKey(_) => {
-                                // For now, only Integer and Text types can be PRIMARY KEY and Unique
-                                // Therefore Indexed.
-                                if datatype != "Real" && datatype != "Bool" {
-                                    // Checks if table being created already has a PRIMARY KEY, if so, returns an error
-                                    if parsed_columns.iter().any(|col| col.is_pk) {
-                                        return Err(SQLRiteError::Internal(format!(
-                                            "Table '{}' has more than one primary key",
-                                            &table_name
-                                        )));
-                                    }
-                                    is_pk = true;
-                                    is_unique = true;
-                                    not_null = true;
-                                }
-                            }
-                            ColumnOption::Unique(_) => {
-                                // For now, only Integer and Text types can be UNIQUE
-                                // Therefore Indexed.
-                                if datatype != "Real" && datatype != "Bool" {
-                                    is_unique = true;
-                                }
-                            }
-                            ColumnOption::NotNull => {
-                                not_null = true;
-                            }
-                            _ => (),
-                        };
+                    // Multi-column invariant: only one PRIMARY KEY per table.
+                    if parsed.is_pk && parsed_columns.iter().any(|c| c.is_pk) {
+                        return Err(SQLRiteError::Internal(format!(
+                            "Table '{}' has more than one primary key",
+                            &table_name
+                        )));
                     }
 
-                    parsed_columns.push(ParsedColumn {
-                        name,
-                        datatype: datatype.to_string(),
-                        is_pk,
-                        not_null,
-                        is_unique,
-                    });
+                    parsed_columns.push(parsed);
                 }
-                // TODO: handle constraints + default values + check
-                // constraints + ON DELETE / ON UPDATE referential actions
-                // properly. They're currently parsed by `sqlparser` and
-                // dropped on the floor here. (Previously we `println!`-ed
-                // them to stdout as a debug aid — removed in the
-                // engine-stdout-pollution cleanup; flip to a `tracing`
-                // span if we ever want them visible in dev builds.)
+                // TODO: handle constraints + check constraints + ON DELETE /
+                // ON UPDATE referential actions properly. They're currently
+                // parsed by `sqlparser` and dropped on the floor here.
+                // (Previously we `println!`-ed them to stdout as a debug
+                // aid — removed in the engine-stdout-pollution cleanup;
+                // flip to a `tracing` span if we ever want them visible in
+                // dev builds.)
                 let _ = constraints;
                 Ok(CreateQuery {
                     table_name: table_name.to_string(),


### PR DESCRIPTION
## Summary

Brings DDL surface to SQLite parity for the schema-modification statements that were previously listed under [\"Not yet supported\"](docs/supported-sql.md). Closes SQLR-2.

- **`DEFAULT <literal>`** on CREATE TABLE columns — landed first as a prerequisite so `ALTER TABLE ADD COLUMN ... NOT NULL` has a value to backfill with. Literal expressions only (integer/real/text/bool/null + unary `+`/`-`); non-literal expressions like `CURRENT_TIMESTAMP` are rejected at CREATE time.
- **`DROP TABLE [IF EXISTS] <name>`** and **`DROP INDEX [IF EXISTS] <name>`** — single target per statement. DROP INDEX refuses auto-indexes (`sqlrite_autoindex_*`), matching SQLite.
- **`ALTER TABLE [IF EXISTS] <t> <op>`** — one operation per statement, four sub-operations: `RENAME TO`, `RENAME COLUMN`, `ADD COLUMN`, `DROP COLUMN`. ADD COLUMN allows `NOT NULL` only with `DEFAULT` (matches SQLite). DROP COLUMN refuses the PK column and the only-column case.

Persistence is full-rebuild-on-save: dropped objects are simply absent from the next `sqlrite_master` write. Pages previously occupied by them become orphans on disk (no free-list yet — file size doesn't shrink until a future VACUUM).

## Test plan

- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets`
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` — 421 passing (380 baseline + 41 new), 1 ignored
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — warning count unchanged from baseline (41)
- [x] End-to-end REPL smoke: CREATE w/ DEFAULT → INSERT → ALTER RENAME COLUMN → ALTER ADD COLUMN NOT NULL DEFAULT → ALTER RENAME TO → reopen → DROP TABLE → reopen confirms catalog cleared
- [x] Round-trip-through-save-and-reopen tests for every new sub-operation
- [x] Read-only enforcement tests for both DROP variants and all four ALTER ops
- [x] Transaction-rollback tests for ADD COLUMN and DROP TABLE inside `BEGIN`

## Known limitations (documented in [docs/supported-sql.md](docs/supported-sql.md))

- `DEFAULT` accepts literals only — no `CURRENT_TIMESTAMP` / function calls / column refs
- `DROP TABLE` / `DROP INDEX` leave orphan pages on disk (no free-list)
- `ADD COLUMN` rejects `PRIMARY KEY` / `UNIQUE` (would need backfill + uniqueness against existing rows)
- One operation per `ALTER TABLE`; one target per `DROP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)