### PR TITLE
fix(release): bump-version.sh rewrites inter-workspace dep pins (SQLR-9)

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -84,6 +84,25 @@ for file in "${TOML_FILES[@]}"; do
     fi
     sed "s/^version = \"[^\"]*\"/version = \"${VERSION}\"/" "$file" > "$file.tmp"
     mv "$file.tmp" "$file"
+
+    # Inter-workspace dep pins — lines like:
+    #   sqlrite-ask = { version = "0.3", path = "sqlrite-ask", ... }
+    #   sqlrite     = { package = "sqlrite-engine", path = "..", version = "0.3", ... }
+    #
+    # These carry BOTH version and path because crates.io publishing
+    # rejects path-only deps (see PR #58 retrospective). The version
+    # field has to track the workspace bump or `cargo build` fails to
+    # resolve a candidate (SQLR-9; failed run for v0.3.0 hit exactly
+    # this — `failed to select a version for the requirement
+    # sqlrite-ask = "^0.2"`).
+    #
+    # Detection: any line containing both `version = "..."` and
+    # `path = "..."`. The package-level `^version = "..."` line at
+    # the top of each manifest has no `path` on it and can't match.
+    # Both inline-table orderings (version-first and path-first) work
+    # because sed acts per-line, not per-token-order.
+    sed -E '/path *= *"[^"]*"/ s/version *= *"[^"]*"/version = "'"${VERSION}"'"/' "$file" > "$file.tmp"
+    mv "$file.tmp" "$file"
 done
 
 # ---------------------------------------------------------------------------
@@ -143,6 +162,22 @@ for file in "${JSON_FILES[@]}"; do
     else
         actual="$(grep -E '^  "version": ' "$file" | head -1)"
         echo "  ✗ $file — expected version \"${VERSION}\", got: $actual" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+
+# Inter-workspace pin sweep — any surviving `version = "X"` on a TOML
+# line that also has `path = "..."` and isn't already at $VERSION is a
+# pin we missed. Catches future refactors that change pin shape (e.g.
+# someone splits a long dep line across multiple TOML lines, where the
+# single-line address would no longer match).
+for file in "${TOML_FILES[@]}"; do
+    bad="$(grep -nE 'path *= *"[^"]*"' "$file" \
+           | grep -E 'version *= *"[^"]*"' \
+           | grep -vE "version *= *\"${VERSION}\"" || true)"
+    if [[ -n "$bad" ]]; then
+        echo "  ✗ $file — inter-workspace pin not at ${VERSION}:" >&2
+        echo "$bad" | sed 's/^/      /' >&2
         FAILURES=$((FAILURES + 1))
     fi
 done

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -6,8 +6,8 @@
 #     scripts/bump-version.sh 0.2.0
 #
 # Rewrites the version field in every manifest that carries one
-# (eight Cargo.toml / pyproject.toml files, plus three JSON manifests
-# — eleven files total). Then you run `cargo build` yourself to
+# (nine Cargo.toml / pyproject.toml files, plus three JSON manifests
+# — twelve files total). Then you run `cargo build` yourself to
 # refresh Cargo.lock. Idempotent: running twice with the same version
 # is a no-op; running twice with different versions lands on the
 # second.
@@ -192,5 +192,5 @@ fi
 echo
 echo "Done. Next steps:"
 echo "  cargo build    # refresh Cargo.lock with the new versions"
-echo "  git diff       # inspect the ten-file bump"
+echo "  git diff       # inspect the twelve-file bump"
 echo "  git checkout . # or back out if it looks wrong"


### PR DESCRIPTION
## Summary

- Teach `scripts/bump-version.sh` to rewrite the three inter-workspace `version = "..."` pins it currently misses (engine→sqlrite-ask, sqlrite-mcp→engine, wasm SDK→sqlrite-ask). The v0.3.0 release-pr.yml dispatch failed at `cargo build` with `failed to select a version for the requirement sqlrite-ask = "^0.2"` because of this gap; PR #87 patched the three pins by hand. Closes SQLR-9.
- Detection rule: any TOML line with both `version = "..."` and `path = "..."`. Unambiguous in this repo, handles both inline-table orderings, future-proof for new workspace crates with the same shape.
- Format: full `X.Y.Z[-pre][+build]` (e.g. `0.3.0`, `0.3.0-rc.1`). Catches drift inside a minor and works with prerelease dispatches. Visible cosmetic side-effect on the next release PR: pins flip from `"0.3"` → `"0.3.0"`.
- Verify-loop extension flags any same-line `path` + `version` pin not at `$VERSION`, so a future shape change (e.g. multi-line deps) fails loudly instead of silently producing a broken release branch.
- Drive-by: fixed pre-existing off-by-one in the banner ("eleven files total" / "ten-file bump" → "twelve files total" / "twelve-file bump") to match the actual nine TOML + three JSON manifests.

## Test plan

- [x] `./scripts/bump-version.sh 9.9.9-test` rewrites all three pins (verified both inline-table orderings: version-first in `Cargo.toml` / `sdk/wasm/Cargo.toml`, path-first in `sqlrite-mcp/Cargo.toml`).
- [x] Re-running with the same arg is byte-exact idempotent (snapshot + diff against the three target manifests).
- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` resolves cleanly at `9.9.9-test` — the original SQLR-9 failure mode no longer reproduces.
- [x] Verify-loop logic catches a manually-staled pin (proven against `version = "0.0.0"` injected into `sqlrite-mcp/Cargo.toml`).
- [ ] Reviewer: confirm the format flip from `"0.3"` to `"0.3.0"` is the expected cosmetic delta on the next release PR (matches the lockstep release-wave story in `docs/release-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)