### PR TITLE
feat(storage): free-list + VACUUM to reclaim orphan pages (SQLR-6)

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -4,7 +4,7 @@ A SQLRite database is a single file, by convention named `*.sqlrite`. The file i
 
 All multi-byte integers in this format are **little-endian**.
 
-The current on-disk format is **version 4** (Phase 7) by default, with **version 5** written on demand whenever an FTS index is attached to the database (Phase 8c). Decoders accept both v4 and v5; writers preserve the existing version on no-op resaves so a v4 database without FTS stays v4. Files produced by versions 1 – 3 are rejected on open.
+The current on-disk format is **version 4** (Phase 7) by default, with **version 5** written on demand whenever an FTS index is attached to the database (Phase 8c) and **version 6** written on demand whenever a save produces a non-empty freelist (SQLR-6). Decoders accept v4, v5, and v6; writers preserve the existing version on no-op resaves so a v4 database without FTS or freelist stays v4. Files produced by versions 1 – 3 are rejected on open.
 
 ## Page 0 — the database header
 
@@ -15,17 +15,18 @@ The first 4096 bytes of every file are the header page. Only the first 28 bytes 
 │ offset │ length │ content                                         │
 ├────────┼────────┼─────────────────────────────────────────────────┤
 │     0  │   16   │ magic:  "SQLRiteFormat\0\0\0"                   │
-│    16  │    2   │ format version (u16 LE) = 4 or 5                │
+│    16  │    2   │ format version (u16 LE) = 4, 5, or 6            │
 │    18  │    2   │ page size      (u16 LE) = 4096                  │
 │    20  │    4   │ total page count (u32 LE), includes page 0      │
 │    24  │    4   │ root page of sqlrite_master (u32 LE)            │
-│    28  │ 4068   │ reserved / zero                                 │
+│    28  │    4   │ freelist head    (u32 LE; 0 = empty) — v6 only  │
+│    32  │ 4064   │ reserved / zero                                 │
 └────────┴────────┴─────────────────────────────────────────────────┘
 ```
 
 The magic string is 14 ASCII bytes (`SQLRiteFormat`) padded with two NUL bytes to fill 16 bytes. It's deliberately different from SQLite's `"SQLite format 3\0"` so the two formats can't be confused on inspection.
 
-`decode_header` in [`src/sql/pager/header.rs`](../src/sql/pager/header.rs) validates all three of (magic, format version, page size) on open. A wrong magic produces `not a SQLRite database`; a wrong version or page size produces `unsupported ...` errors. The decoder accepts both v4 and v5 (anything else is rejected); the parsed `format_version` is propagated through the in-memory `DbHeader` so the writer can preserve it on resave when no version-bumping feature has been added.
+`decode_header` in [`src/sql/pager/header.rs`](../src/sql/pager/header.rs) validates all three of (magic, format version, page size) on open. A wrong magic produces `not a SQLRite database`; a wrong version or page size produces `unsupported ...` errors. The decoder accepts v4, v5, and v6 (anything else is rejected); the parsed `format_version` is propagated through the in-memory `DbHeader` so the writer can preserve it on resave when no version-bumping feature has been added. `freelist_head` is read from bytes [28..32]: v4/v5 files leave that region zero so it always decodes as `0` (an empty freelist), and v6 files store the page number of the first freelist trunk there.
 
 ## Pages 1..page_count — payload pages
 
@@ -53,6 +54,7 @@ Every non-header page starts with a 7-byte header:
 | `2` | `TableLeaf` | Holds a slot directory and a set of cells representing rows of a table. Leaves for one table are linked by sibling `next_page` pointers. |
 | `3` | `Overflow` | Continuation page carrying the spilled body of a single oversized cell. |
 | `4` | `InteriorNode` | Interior B-Tree node. Holds a slot directory of divider cells routing to child pages plus a rightmost-child pointer in the payload header. |
+| `5` | `FreelistTrunk` | One link of the persisted free-page list (SQLR-6). Payload carries `count: u16` followed by `count × u32` free leaf-page numbers; `next_page` chains to the next trunk (0 = end). |
 
 Tag `1` is reserved (it was `SchemaRoot` in format v1; unused in v2). Any other tag on open is a corruption error.
 
@@ -307,6 +309,7 @@ These are not all enforced on open — we validate the header strictly and rely 
 - **v3** (Phase 3e) — `sqlrite_master` gains a `type` column; secondary indexes persist as their own cell-based B-Trees whose leaves carry `KIND_INDEX` cells.
 - **v4** (Phase 7a) — value block dispatch gains the `0x04 Vector` tag for the new `VECTOR(N)` column type. Per the [Phase 7 plan's Q8](phase-7-plan.md#q8-file-format-version-bump), later Phase 7 sub-phases (JSON storage, HNSW indexes) added their own value/cell tags inside this same v4 envelope. The `CREATE TABLE` SQL stored in `sqlrite_master` carries vector columns as `VECTOR(N)` in the type position; on open, the engine re-parses that SQL and reconstructs `DataType::Vector(N)` from the `Custom` AST node sqlparser produces.
 - **v5** (Phase 8c, current for FTS-bearing files) — adds the `KIND_FTS_POSTING` cell tag for persisted FTS posting lists. Bumped **on demand** per the [Phase 8 plan's Q10](phase-8-plan.md#q10-file-format-version-bump-strategy): existing v4 databases without FTS keep writing v4 across non-FTS saves; the first save with at least one FTS index attached promotes the file to v5. Decoders accept both v4 and v5; opening a v4 file with a build that supports v5 is a no-op until the user creates an FTS index.
+- **v6** (SQLR-6, current for files with persisted free-page lists) — adds the `freelist_head` field at header bytes [28..32] and the `FreelistTrunk` page tag (`5`). Bumped **on demand**: a save that ends with an empty freelist preserves the existing version; the first save that produces a non-empty freelist promotes the file to v6. Decoders accept v4, v5, and v6; v6 is a strict superset, so opening a v4/v5 file with a v6-aware build is a no-op until the user creates a freelist (e.g., by dropping a table or index). VACUUM clears the freelist but doesn't downgrade.
 
 The page header (7 bytes) and chaining mechanism are stable across future phases. Phase 4's WAL introduces a sibling file (`.sqlrite-wal`) rather than changing the main file format.
 

--- a/docs/pager.md
+++ b/docs/pager.md
@@ -187,10 +187,23 @@ Without the diff, step 3's "re-serialize every table" would trigger a full file 
 
 This only works because `save_database` iterates tables in sorted order — if the order were random, a table that didn't change might land at a different page number, appearing dirty. See [Design decisions §7](design-decisions.md#7-deterministic-page-number-ordering-when-saving).
 
+## Free-page list and VACUUM (SQLR-6)
+
+Save now uses a [`PageAllocator`](../src/sql/pager/allocator.rs) instead of a bare `next_free_page` counter. The allocator pulls pages from three sources, in preference order:
+
+1. **Per-table preferred pool** — every table/index/master is given the page numbers it occupied last save (collected by walking from its old `rootpage`). An unchanged table re-stages byte-identical pages at the same numbers, so the diff pager skips every write for it.
+2. **Global freelist** — pages from dropped tables/indexes that are recorded in the persisted freelist (rooted at `header.freelist_head`).
+3. **Extend** — `next_extend++`, monotonic past the high-water mark.
+
+After staging, pages that were live before this save but didn't get restaged this round (e.g., the leaves of a dropped table) move onto the new freelist. The freelist itself is encoded into a chain of `FreelistTrunk` pages — each trunk holds up to 1021 free leaf-page numbers plus a `next_page` pointer to the following trunk. Trunks consume some of the free pages they describe (a trunk page IS a free page borrowed for metadata), so a freelist of N pages takes `ceil(N / 1022)` trunks and persists `N − T` leaf entries.
+
+`VACUUM;` (a SQL statement) calls [`vacuum_database`](../src/sql/pager/mod.rs), which is `save_database` with empty per-table preferred pools and an empty initial freelist. Allocation falls through to extend on every page → contiguous layout from page 1, no freelist trunks, file truncates to the new high-water mark on the next checkpoint.
+
+Format-version side effect: a save that produces a non-empty freelist promotes the file from v4/v5 to v6 (mirrors Phase 8c's v4→v5 FTS rule). VACUUM clears the freelist but doesn't downgrade — v6 is a strict superset.
+
 ## What it doesn't do (yet)
 
 - **No LRU eviction.** `on_disk` + `wal_cache` together grow with the page count. For a 1 GiB database, that's ~1 GiB of page cache. Bounded cache is future work.
-- **No free-page management.** When a table shrinks, the main file's tail pages are truncated at checkpoint, but there's no free-list to reuse pages inside a grown file.
 - **No per-statement granularity.** The whole database is re-serialized on every commit; the diff keeps the *written* set small but the CPU cost of reserialization is unchanged.
 - **No concurrent reader-and-writer.** Phase 4e graduated to shared/exclusive lock modes (multi-reader *or* single-writer), but POSIX flock can't give us both at once. True concurrent access would need a shared-memory coordination file with read marks — not on the roadmap.
 - **Savepoints / nested transactions.** Phase 4f added top-level `BEGIN` / `COMMIT` / `ROLLBACK` (snapshot-based rollback, auto-save suppressed inside a transaction), but nested `BEGIN` is rejected — real savepoints aren't on the roadmap.

--- a/docs/supported-sql.md
+++ b/docs/supported-sql.md
@@ -17,6 +17,7 @@ If you're looking for _how_ to use SQLRite (REPL flow, meta-commands, history, e
 | [`ALTER TABLE`](#alter-table) | `RENAME TO`, `RENAME COLUMN`, `ADD COLUMN`, `DROP COLUMN` (one operation per statement) |
 | [`DROP TABLE`](#drop-table) / [`DROP INDEX`](#drop-index) | `IF EXISTS`; single target; auto-indexes refused for `DROP INDEX` |
 | [`BEGIN`](#transactions) / [`COMMIT`](#transactions) / [`ROLLBACK`](#transactions) | Snapshot-based; single-level; WAL-backed commit; auto-rollback on COMMIT disk failure |
+| [`VACUUM`](#vacuum) | Compacts the file: rewrites every live B-Tree contiguously from page 1 and clears the freelist. Bare `VACUUM;` only — no modifiers. |
 
 Statements the parser accepts (because sqlparser understands them in the SQLite dialect) but SQLRite doesn't execute yet return `SQL Statement not supported yet`. The [Not yet supported](#not-yet-supported) section below enumerates the common ones.
 
@@ -259,7 +260,7 @@ DROP TABLE [IF EXISTS] <table>;
 - Reserved-name rejection: `DROP TABLE sqlrite_master` errors with the same message `CREATE TABLE` uses.
 - All indexes attached to the table (auto, explicit, HNSW, FTS) disappear with the table — they live inside the `Table` struct and ride along.
 - Without `IF EXISTS`, dropping a table that doesn't exist errors. With it, that's a benign 0-tables-dropped no-op.
-- **Disk pages are orphaned, not freed.** SQLRite has no free-list yet — the file size doesn't shrink until a future `VACUUM`. The behavior is safe (orphan pages are unreachable from `sqlrite_master` after reopen) but means a write-heavy schema churn won't reclaim space until VACUUM lands.
+- **Disk pages move onto the freelist.** Pages the dropped table occupied are pushed onto a persisted free-page list (SQLR-6) so subsequent `CREATE TABLE` or inserts can reuse them. The file doesn't shrink until [`VACUUM;`](#vacuum) compacts it.
 
 ---
 
@@ -425,6 +426,24 @@ ROLLBACK;  -- nothing was actually deleted
 - **`COMMIT`'s disk write failing DOES auto-rollback.** If the save at COMMIT time errors (disk full, permission denied, checksum mismatch), SQLRite restores the pre-BEGIN snapshot and surfaces `COMMIT failed — transaction rolled back: <underlying error>`. Leaving in-flight mutations live after a failed COMMIT would be unsafe — any subsequent non-transactional statement's auto-save would silently publish partial work.
 - **Cost**: `BEGIN` is `O(N)` in the total size of the in-memory database because of the snapshot clone. On a huge database, opening a transaction just to run a single read-only query is wasteful — use a plain `SELECT` instead.
 - **Visibility to other processes**: with POSIX file locks (Phase 4a–4e), a writer excludes all concurrent readers anyway, so "uncommitted transaction state leaking to a concurrent reader" isn't a concern — no concurrent reader exists during an open transaction.
+
+---
+
+## `VACUUM`
+
+```sql
+VACUUM;
+```
+
+Compacts the database file: rewrites every live table, index, HNSW graph, FTS posting tree, and `sqlrite_master` itself contiguously from page 1, drops the freelist, and lets the next checkpoint truncate the tail.
+
+- **Bare `VACUUM;` only.** Modifiers — `VACUUM FULL`, `VACUUM REINDEX`, table targets, `TO ... PERCENT`, `BOOST` — are parsed (sqlparser supports them) but rejected at execution with `VACUUM modifiers (FULL, REINDEX, table targets, etc.) are not supported`.
+- **Refused inside a transaction.** `BEGIN; VACUUM;` errors with `VACUUM cannot run inside a transaction`. Use `COMMIT;` first, then `VACUUM;`.
+- **No-op on in-memory databases.** Returns a `VACUUM is a no-op for in-memory databases` status string and does nothing — there's no file to compact.
+- **Status string** carries pages and bytes reclaimed: `VACUUM completed. <N> pages reclaimed (<B> bytes).`
+- **Format-version side effect.** A v4/v5 file that has been promoted to v6 by an earlier drop stays at v6 after VACUUM (v6 is a strict superset; we don't downgrade). A file that's already at v4/v5 because no drop ever happened on it doesn't get bumped by VACUUM.
+
+When to run it: any time after a string of `DROP TABLE` / `DROP INDEX` / `ALTER TABLE DROP COLUMN` operations if you care about file size. SQLRite reuses freelist pages on subsequent inserts, so a write-heavy workload may not need VACUUM at all — its main use is reclaiming space when you don't expect to grow back.
 
 ---
 

--- a/src/sql/executor.rs
+++ b/src/sql/executor.rs
@@ -717,6 +717,60 @@ pub fn execute_alter_table(alter: AlterTable, db: &mut Database) -> Result<Strin
     }
 }
 
+/// Executes `VACUUM;` (SQLR-6). Compacts the database file: rewrites
+/// every live table, index, and the catalog contiguously from page 1,
+/// drops the freelist, and truncates the tail at the next checkpoint.
+///
+/// Refuses to run inside a transaction (would publish in-flight writes
+/// out of band); refuses on read-only databases (handled upstream by
+/// the read-only mutation gate); and is a no-op on in-memory databases
+/// (no file to compact). Bare `VACUUM;` only — non-default options
+/// (`FULL`, `REINDEX`, table targets, etc.) are rejected.
+pub fn execute_vacuum(db: &mut Database) -> Result<String> {
+    if db.in_transaction() {
+        return Err(SQLRiteError::General(
+            "VACUUM cannot run inside a transaction".to_string(),
+        ));
+    }
+    let path = match db.source_path.clone() {
+        Some(p) => p,
+        None => {
+            return Ok("VACUUM is a no-op for in-memory databases".to_string());
+        }
+    };
+    // Checkpoint before AND after VACUUM so the main-file size we report
+    // reflects only what VACUUM actually reclaimed — without the leading
+    // checkpoint, `size_before` would be the stale main-file snapshot
+    // (typically 2 pages) while WAL holds the live bytes, making the
+    // bytes-reclaimed delta meaningless.
+    if let Some(pager) = db.pager.as_mut() {
+        let _ = pager.checkpoint();
+    }
+    let size_before = std::fs::metadata(&path).ok().map(|m| m.len()).unwrap_or(0);
+    let pages_before = db
+        .pager
+        .as_ref()
+        .map(|p| p.header().page_count)
+        .unwrap_or(0);
+    crate::sql::pager::vacuum_database(db, &path)?;
+    // Second checkpoint so the main file shrinks now — VACUUM's whole
+    // purpose is to reclaim bytes, so paying the I/O up front is fair.
+    if let Some(pager) = db.pager.as_mut() {
+        let _ = pager.checkpoint();
+    }
+    let size_after = std::fs::metadata(&path).ok().map(|m| m.len()).unwrap_or(0);
+    let pages_after = db
+        .pager
+        .as_ref()
+        .map(|p| p.header().page_count)
+        .unwrap_or(0);
+    let pages_reclaimed = pages_before.saturating_sub(pages_after);
+    let bytes_reclaimed = size_before.saturating_sub(size_after);
+    Ok(format!(
+        "VACUUM completed. {pages_reclaimed} pages reclaimed ({bytes_reclaimed} bytes)."
+    ))
+}
+
 /// Renames a table in `db.tables`. Updates `tb_name`, every secondary
 /// index's `table_name` field, and any auto-index whose name embedded
 /// the old table name. HNSW / FTS index entries don't carry a

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -160,6 +160,9 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
 
     // Statements that mutate state — trigger auto-save on success. Read-only
     // SELECTs skip the save entirely to avoid pointless file writes.
+    // VACUUM is a write statement (rewrites the entire file) but it does
+    // its own save internally, so it's also explicitly excluded from the
+    // post-dispatch auto-save block at the bottom.
     let is_write_statement = matches!(
         &query,
         Statement::CreateTable(_)
@@ -169,7 +172,9 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
             | Statement::Delete(_)
             | Statement::Drop { .. }
             | Statement::AlterTable(_)
+            | Statement::Vacuum(_)
     );
+    let is_vacuum = matches!(&query, Statement::Vacuum(_));
 
     // Early-reject mutations on a read-only database before they touch
     // in-memory state. Phase 4e: without this, a user running INSERT
@@ -338,6 +343,27 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
         Statement::AlterTable(alter) => {
             message = executor::execute_alter_table(alter, db)?;
         }
+        Statement::Vacuum(vac) => {
+            // SQLR-6 — only bare `VACUUM;` is supported. The crate-level
+            // `VacuumStatement` carries Redshift-style modifiers we don't
+            // implement; reject any non-default flag rather than silently
+            // ignoring it.
+            if vac.full
+                || vac.sort_only
+                || vac.delete_only
+                || vac.reindex
+                || vac.recluster
+                || vac.boost
+                || vac.table_name.is_some()
+                || vac.threshold.is_some()
+            {
+                return Err(SQLRiteError::NotImplemented(
+                    "VACUUM modifiers (FULL, REINDEX, table targets, etc.) are not supported; use bare VACUUM;"
+                        .to_string(),
+                ));
+            }
+            message = executor::execute_vacuum(db)?;
+        }
         _ => {
             return Err(SQLRiteError::NotImplemented(
                 "SQL Statement not supported yet.".to_string(),
@@ -355,7 +381,10 @@ pub fn process_command_with_render(query: &str, db: &mut Database) -> Result<Com
     // mutated, so the caller should know disk is out of sync. The
     // Pager held on `db` diffs against its last-committed snapshot,
     // so only pages whose bytes actually changed are written.
-    if is_write_statement && db.source_path.is_some() && !db.in_transaction() {
+    //
+    // VACUUM is a write-shaped statement but already wrote the file
+    // internally — skip the second save to avoid undoing the compact.
+    if is_write_statement && !is_vacuum && db.source_path.is_some() && !db.in_transaction() {
         let path = db.source_path.clone().unwrap();
         pager::save_database(db, &path)?;
     }

--- a/src/sql/pager/allocator.rs
+++ b/src/sql/pager/allocator.rs
@@ -1,0 +1,222 @@
+//! Page allocator for `save_database` (SQLR-6).
+//!
+//! Replaces the bare `next_free_page: u32` counter that the staging code
+//! used to thread through every `stage_*_btree` function. The allocator
+//! draws from three pools, in order of preference:
+//!
+//! 1. **Per-table preferred pool** — pages the table previously occupied,
+//!    seeded by [`set_preferred`]. An unchanged table's stage produces
+//!    byte-identical pages at the same numbers, so the diff pager skips
+//!    every write for it.
+//! 2. **Global freelist** — pages dropped tables/indexes used to occupy
+//!    plus the trunk pages of the previously-persisted freelist.
+//! 3. **Extend** — `next_extend++`, monotonic past the current high water.
+//!
+//! After staging finishes, [`high_water`] is the new `page_count` and
+//! [`used`] enumerates every page actually written this save (so the
+//! caller can compute the new freelist as `old_live − used`).
+
+use std::collections::{HashSet, VecDeque};
+
+/// Hands out page numbers during a save.
+///
+/// Lifetime: one allocator per `save_database` call. Not thread-safe; not
+/// shared across saves.
+pub struct PageAllocator {
+    /// Pages available globally. Drained after the per-table pool is empty.
+    /// Stored as a VecDeque so callers can append (push_back) and we always
+    /// hand them out front-first for ascending-order determinism.
+    freelist: VecDeque<u32>,
+    /// The current table's preferred pool (its previous-rootpage pages).
+    /// Drained before [`freelist`]. Cleared between tables by
+    /// [`finish_preferred`].
+    preferred: VecDeque<u32>,
+    /// Next page number for fresh extension. Page 0 is the header, so
+    /// the first alloc always returns ≥ 1.
+    next_extend: u32,
+    /// Every page handed out this save. Used to compute the newly-freed
+    /// set after staging completes.
+    used: HashSet<u32>,
+}
+
+impl PageAllocator {
+    /// `freelist` carries the pages from the previously-persisted
+    /// freelist (sorted ascending by the caller). `next_extend` is
+    /// typically `1` for a brand-new save.
+    pub fn new(freelist: VecDeque<u32>, next_extend: u32) -> Self {
+        let mut alloc = Self {
+            freelist,
+            preferred: VecDeque::new(),
+            next_extend,
+            used: HashSet::new(),
+        };
+        // Defensive: a corrupt freelist could push the high-water mark
+        // higher than `next_extend` claims. Bump so we never hand out a
+        // duplicate page on extend.
+        let max_free = alloc.freelist.iter().copied().max().unwrap_or(0);
+        if max_free + 1 > alloc.next_extend {
+            alloc.next_extend = max_free + 1;
+        }
+        alloc
+    }
+
+    /// Seeds the per-table preferred pool. Drained on subsequent
+    /// [`allocate`] calls before any other source.
+    pub fn set_preferred(&mut self, mut pool: Vec<u32>) {
+        // Sort ascending so the order matches the linear staging order
+        // and unchanged tables get byte-identical leaves.
+        pool.sort_unstable();
+        pool.dedup();
+        // Filter out anything the allocator has already handed out
+        // (defensive — shouldn't happen but keeps the invariant tidy).
+        pool.retain(|p| !self.used.contains(p));
+        self.preferred = VecDeque::from(pool);
+    }
+
+    /// Empties the per-table preferred pool, returning any leftover
+    /// pages to the global freelist (they're now free again).
+    pub fn finish_preferred(&mut self) {
+        while let Some(p) = self.preferred.pop_front() {
+            if !self.used.contains(&p) {
+                self.freelist.push_back(p);
+            }
+        }
+    }
+
+    /// Returns the next page to write. Picks from preferred → freelist →
+    /// extend. Records the result in `used` and bumps `next_extend` if
+    /// the page came from one of the pools and was past the current
+    /// high water.
+    pub fn allocate(&mut self) -> u32 {
+        let page = if let Some(p) = self.preferred.pop_front() {
+            p
+        } else if let Some(p) = self.freelist.pop_front() {
+            p
+        } else {
+            let p = self.next_extend;
+            self.next_extend += 1;
+            p
+        };
+        if page >= self.next_extend {
+            self.next_extend = page + 1;
+        }
+        // A double-allocation is an internal bug; assert in debug.
+        debug_assert!(
+            !self.used.contains(&page),
+            "PageAllocator handed out page {page} twice"
+        );
+        self.used.insert(page);
+        page
+    }
+
+    /// Adds pages to the global freelist. Used to drop pages that the
+    /// caller traversed but didn't end up restaging (e.g., a dropped
+    /// table's leaves; the previous freelist's trunk pages).
+    ///
+    /// Bumps `next_extend` past any added page so the final page_count
+    /// covers freelist trunks even if they live past the highest used
+    /// payload page.
+    pub fn add_to_freelist(&mut self, pages: impl IntoIterator<Item = u32>) {
+        for p in pages {
+            // Skip pages already used (we already restaged them) or
+            // already on the list.
+            if !self.used.contains(&p) && !self.freelist.contains(&p) {
+                self.freelist.push_back(p);
+                if p + 1 > self.next_extend {
+                    self.next_extend = p + 1;
+                }
+            }
+        }
+    }
+
+    /// Page-count to publish in the new header. Equal to
+    /// `1 + max page handed out` after staging.
+    pub fn high_water(&self) -> u32 {
+        self.next_extend
+    }
+
+    /// Every page handed out this save.
+    pub fn used(&self) -> &HashSet<u32> {
+        &self.used
+    }
+
+    /// Snapshot of pages still on the global freelist (i.e., free pages
+    /// that need to be persisted into trunk pages). Sorted ascending so
+    /// the encoded freelist trunks are deterministic.
+    pub fn drain_freelist(&mut self) -> Vec<u32> {
+        let mut v: Vec<u32> = self.freelist.drain(..).collect();
+        v.sort_unstable();
+        v.dedup();
+        v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocate_extends_when_pools_empty() {
+        let mut a = PageAllocator::new(VecDeque::new(), 1);
+        assert_eq!(a.allocate(), 1);
+        assert_eq!(a.allocate(), 2);
+        assert_eq!(a.allocate(), 3);
+        assert_eq!(a.high_water(), 4);
+    }
+
+    #[test]
+    fn preferred_pool_drains_first() {
+        let mut a = PageAllocator::new(VecDeque::from([8, 9]), 1);
+        a.set_preferred(vec![3, 4]);
+        assert_eq!(a.allocate(), 3);
+        assert_eq!(a.allocate(), 4);
+        // After preferred drains, freelist takes over.
+        assert_eq!(a.allocate(), 8);
+        assert_eq!(a.allocate(), 9);
+        // Then extend.
+        assert_eq!(a.allocate(), 10);
+    }
+
+    #[test]
+    fn freelist_drains_after_preferred() {
+        let mut a = PageAllocator::new(VecDeque::from([5, 7]), 1);
+        assert_eq!(a.allocate(), 5);
+        assert_eq!(a.allocate(), 7);
+        assert_eq!(a.allocate(), 8); // extend bumped because max free was 7
+    }
+
+    #[test]
+    fn finish_preferred_returns_leftovers_to_freelist() {
+        let mut a = PageAllocator::new(VecDeque::new(), 1);
+        a.set_preferred(vec![3, 4, 5]);
+        assert_eq!(a.allocate(), 3); // used 3
+        a.finish_preferred();
+        // Now 4 and 5 should be on the freelist.
+        assert_eq!(a.allocate(), 4);
+        assert_eq!(a.allocate(), 5);
+    }
+
+    #[test]
+    fn add_to_freelist_skips_already_used() {
+        let mut a = PageAllocator::new(VecDeque::new(), 1);
+        let p = a.allocate(); // 1
+        a.add_to_freelist([p, 5, 6]);
+        let drained = a.drain_freelist();
+        assert!(
+            !drained.contains(&p),
+            "used page should not land on freelist"
+        );
+        assert_eq!(drained, vec![5, 6]);
+    }
+
+    #[test]
+    fn next_extend_respects_max_free() {
+        // High pages on the freelist should bump next_extend so the
+        // allocator never collides with them on extend.
+        let mut a = PageAllocator::new(VecDeque::from([100]), 1);
+        // First alloc draws from freelist.
+        assert_eq!(a.allocate(), 100);
+        // Subsequent extend lands at 101, not 1.
+        assert_eq!(a.allocate(), 101);
+    }
+}

--- a/src/sql/pager/freelist.rs
+++ b/src/sql/pager/freelist.rs
@@ -1,0 +1,258 @@
+//! Persisted free-page list (SQLR-6).
+//!
+//! After `DROP TABLE` / `DROP INDEX` / `ALTER TABLE DROP COLUMN`, the next
+//! `save_database` no longer references the dropped object's pages. Without
+//! a freelist those pages would either be re-numbered (every later table
+//! shifts down → high write amplification) or stranded as orphans on disk.
+//!
+//! The freelist solves both: pages no longer referenced from `sqlrite_master`
+//! go on a persisted stack rooted at `header.freelist_head`, so subsequent
+//! saves can pull from there before extending the file. The unrelated tables
+//! that didn't change keep their page numbers and their pages re-stage byte-
+//! identical → the diff pager skips writing them.
+//!
+//! ## On-disk layout
+//!
+//! Each freelist trunk page carries the standard 7-byte page header with
+//! `page_type = PAGE_TYPE_FREELIST_TRUNK (5)` and `next_page` pointing at the
+//! next trunk in the chain (`0` = end). The 4089-byte payload area holds:
+//!
+//! ```text
+//!   0..2      count: u16 LE       — number of free leaf-page IDs that follow
+//!   2..2+4*N  page_ids[N]: u32 LE — free leaf-page numbers, ascending
+//! ```
+//!
+//! A trunk holds up to `(PAYLOAD_PER_PAGE - 2) / 4 = 1021` free page IDs.
+//! Larger freelists chain across multiple trunks. The trunk pages themselves
+//! are part of the live page set (they hold metadata) and are *not* on the
+//! freelist they encode.
+
+use std::collections::VecDeque;
+
+use crate::error::{Result, SQLRiteError};
+use crate::sql::pager::page::{PAGE_HEADER_SIZE, PAGE_SIZE, PAYLOAD_PER_PAGE};
+use crate::sql::pager::pager::Pager;
+
+/// Page-type tag for a freelist trunk page. Distinct from existing page tags
+/// (`2 = TableLeaf`, `3 = Overflow`, `4 = InteriorNode`); `1` was retired.
+pub const PAGE_TYPE_FREELIST_TRUNK: u8 = 5;
+
+/// Maximum number of free page IDs a single trunk page can hold.
+/// `PAYLOAD_PER_PAGE` is 4089; we reserve 2 bytes for the count and 4 bytes
+/// per ID, giving `(4089 - 2) / 4 = 1021`.
+pub const FREELIST_IDS_PER_TRUNK: usize = (PAYLOAD_PER_PAGE - 2) / 4;
+
+/// Encodes a single freelist trunk page into the given buffer.
+///
+/// `next_trunk` is the page number of the next trunk in the chain, or `0`
+/// to mark the end. `page_ids` must have at most `FREELIST_IDS_PER_TRUNK`
+/// entries.
+pub fn encode_trunk(buf: &mut [u8; PAGE_SIZE], next_trunk: u32, page_ids: &[u32]) -> Result<()> {
+    if page_ids.len() > FREELIST_IDS_PER_TRUNK {
+        return Err(SQLRiteError::Internal(format!(
+            "freelist trunk overflow: {} ids exceeds capacity {}",
+            page_ids.len(),
+            FREELIST_IDS_PER_TRUNK
+        )));
+    }
+    // Zero out the buffer; trailing payload bytes after the encoded IDs are
+    // unused and must be deterministic so the diff pager can skip an
+    // unchanged trunk.
+    buf.fill(0);
+    buf[0] = PAGE_TYPE_FREELIST_TRUNK;
+    buf[1..5].copy_from_slice(&next_trunk.to_le_bytes());
+    // Per-page `payload_length` field (bytes 5..7) is unused for trunks —
+    // the count field inside the payload self-describes the entries.
+    buf[5..7].copy_from_slice(&0u16.to_le_bytes());
+    let count = page_ids.len() as u16;
+    buf[PAGE_HEADER_SIZE..PAGE_HEADER_SIZE + 2].copy_from_slice(&count.to_le_bytes());
+    let mut off = PAGE_HEADER_SIZE + 2;
+    for id in page_ids {
+        buf[off..off + 4].copy_from_slice(&id.to_le_bytes());
+        off += 4;
+    }
+    Ok(())
+}
+
+/// Decodes one freelist trunk page. Returns `(next_trunk, page_ids)`.
+fn decode_trunk(buf: &[u8; PAGE_SIZE]) -> Result<(u32, Vec<u32>)> {
+    if buf[0] != PAGE_TYPE_FREELIST_TRUNK {
+        return Err(SQLRiteError::General(format!(
+            "expected freelist trunk page (tag {PAGE_TYPE_FREELIST_TRUNK}), got tag {}",
+            buf[0]
+        )));
+    }
+    let next_trunk = u32::from_le_bytes(buf[1..5].try_into().unwrap());
+    let count = u16::from_le_bytes(
+        buf[PAGE_HEADER_SIZE..PAGE_HEADER_SIZE + 2]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    if count > FREELIST_IDS_PER_TRUNK {
+        return Err(SQLRiteError::General(format!(
+            "freelist trunk count {count} exceeds capacity {FREELIST_IDS_PER_TRUNK}"
+        )));
+    }
+    let mut ids = Vec::with_capacity(count);
+    let mut off = PAGE_HEADER_SIZE + 2;
+    for _ in 0..count {
+        let id = u32::from_le_bytes(buf[off..off + 4].try_into().unwrap());
+        ids.push(id);
+        off += 4;
+    }
+    Ok((next_trunk, ids))
+}
+
+/// Walks the freelist chain rooted at `head` and returns every free leaf-page
+/// ID. The trunk pages themselves are *not* included — they're live metadata.
+/// Returns the trunk page numbers separately so the caller can release them
+/// (the next save re-encodes the freelist from scratch and frees the old
+/// trunks for reuse).
+///
+/// `head == 0` → empty freelist; returns `(vec![], vec![])`.
+pub fn read_freelist(pager: &Pager, head: u32) -> Result<(Vec<u32>, Vec<u32>)> {
+    let mut leaves: Vec<u32> = Vec::new();
+    let mut trunks: Vec<u32> = Vec::new();
+    let mut cursor = head;
+    let mut visited: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    while cursor != 0 {
+        if !visited.insert(cursor) {
+            return Err(SQLRiteError::General(format!(
+                "freelist cycle detected at trunk page {cursor}"
+            )));
+        }
+        let buf = pager.read_page(cursor).ok_or_else(|| {
+            SQLRiteError::General(format!(
+                "freelist trunk page {cursor} is past page_count or unreadable"
+            ))
+        })?;
+        let (next, ids) = decode_trunk(buf)?;
+        leaves.extend(ids);
+        trunks.push(cursor);
+        cursor = next;
+    }
+    Ok((leaves, trunks))
+}
+
+/// Stages the freelist chain into the pager. `free_pages` is the full set
+/// of pages that need persisted-on-the-freelist treatment — both the trunk
+/// pages (metadata) and the leaf entries (the actually-free leaves).
+///
+/// The chain consumes some of `free_pages` as its own trunks: a trunk
+/// page IS a free page that's been temporarily borrowed for metadata.
+/// Returns the new `freelist_head` (or `0` if `free_pages` is empty).
+///
+/// Encoding: `T = ceil(N / (IDS_PER_TRUNK + 1))` trunks; each trunk
+/// (except possibly the last) carries `IDS_PER_TRUNK` leaf IDs. Leaves
+/// are stored ascending within each trunk for deterministic on-disk
+/// bytes (so an unchanged freelist re-stages byte-identical → diff skip).
+pub fn stage_freelist(pager: &mut Pager, free_pages: Vec<u32>) -> Result<u32> {
+    if free_pages.is_empty() {
+        return Ok(0);
+    }
+    // Sort + dedup so the on-disk ordering is deterministic. A duplicate
+    // in the freelist would be a serious bug elsewhere (double-free), but
+    // dedupping here is a cheap defensive guardrail.
+    let mut ids = free_pages;
+    ids.sort_unstable();
+    ids.dedup();
+
+    // Solve N = T + L where L = number of leaf slots used, T = number of
+    // trunks, and L ≤ T * IDS_PER_TRUNK. Smallest T satisfying that is
+    // ceil(N / (IDS_PER_TRUNK + 1)) — the +1 accounts for the trunk
+    // page itself absorbing one of the N pages.
+    let n = ids.len();
+    let t = n.div_ceil(FREELIST_IDS_PER_TRUNK + 1);
+
+    // Take the highest-numbered T pages as trunks. This keeps the leaf
+    // IDs ascending within each trunk and matches the "drain low first"
+    // policy of the allocator on subsequent saves.
+    let leaves_count = n - t;
+    let trunk_pages: Vec<u32> = ids.split_off(leaves_count);
+    let leaves = ids;
+
+    // Lay out leaves across trunks, IDS_PER_TRUNK per trunk.
+    let mut chunks: Vec<&[u32]> = leaves.chunks(FREELIST_IDS_PER_TRUNK).collect();
+    // If there are more trunks than chunks (e.g. N=1 → T=1, L=0), pad
+    // with empty chunks so every trunk gets staged.
+    while chunks.len() < trunk_pages.len() {
+        chunks.push(&[]);
+    }
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let next = if i + 1 < trunk_pages.len() {
+            trunk_pages[i + 1]
+        } else {
+            0
+        };
+        let mut buf = [0u8; PAGE_SIZE];
+        encode_trunk(&mut buf, next, chunk)?;
+        pager.stage_page(trunk_pages[i], buf);
+    }
+
+    Ok(trunk_pages[0])
+}
+
+/// Helper: collect a freelist into a `VecDeque<u32>` sorted ascending —
+/// the ordering the `PageAllocator` uses to draw next free pages from.
+pub fn freelist_to_deque(leaves: Vec<u32>) -> VecDeque<u32> {
+    let mut sorted = leaves;
+    sorted.sort_unstable();
+    sorted.dedup();
+    VecDeque::from(sorted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_freelist_round_trip() {
+        let mut buf = [0u8; PAGE_SIZE];
+        encode_trunk(&mut buf, 0, &[]).unwrap();
+        let (next, ids) = decode_trunk(&buf).unwrap();
+        assert_eq!(next, 0);
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn single_chunk_round_trip() {
+        let mut buf = [0u8; PAGE_SIZE];
+        let pages = [3u32, 7, 12, 99];
+        encode_trunk(&mut buf, 42, &pages).unwrap();
+        let (next, ids) = decode_trunk(&buf).unwrap();
+        assert_eq!(next, 42);
+        assert_eq!(ids, pages);
+    }
+
+    #[test]
+    fn full_chunk_fits_capacity() {
+        let mut buf = [0u8; PAGE_SIZE];
+        let pages: Vec<u32> = (1..=FREELIST_IDS_PER_TRUNK as u32).collect();
+        encode_trunk(&mut buf, 0, &pages).unwrap();
+        let (next, ids) = decode_trunk(&buf).unwrap();
+        assert_eq!(next, 0);
+        assert_eq!(ids.len(), FREELIST_IDS_PER_TRUNK);
+        assert_eq!(ids[0], 1);
+        assert_eq!(
+            ids[FREELIST_IDS_PER_TRUNK - 1],
+            FREELIST_IDS_PER_TRUNK as u32
+        );
+    }
+
+    #[test]
+    fn over_capacity_errors() {
+        let mut buf = [0u8; PAGE_SIZE];
+        let pages: Vec<u32> = (1..=(FREELIST_IDS_PER_TRUNK as u32 + 1)).collect();
+        let err = encode_trunk(&mut buf, 0, &pages).unwrap_err();
+        assert!(format!("{err}").contains("freelist trunk overflow"));
+    }
+
+    #[test]
+    fn wrong_tag_errors_on_decode() {
+        let mut buf = [0u8; PAGE_SIZE];
+        buf[0] = 2; // TableLeaf, not freelist
+        let err = decode_trunk(&buf).unwrap_err();
+        assert!(format!("{err}").contains("expected freelist trunk page"));
+    }
+}

--- a/src/sql/pager/header.rs
+++ b/src/sql/pager/header.rs
@@ -33,11 +33,18 @@ pub const MAGIC: &[u8; 16] = b"SQLRiteFormat\0\0\0";
 ///   least one FTS index attached writes v5 instead. Decoders accept
 ///   both v4 and v5; v5 reading a v4-shaped DB just sees zero FTS
 ///   indexes in `sqlrite_master`. See [Phase 8 plan Q10].
+/// - Version 6 (SQLR-6): adds a persisted free-page list at header
+///   bytes [28..32] (`freelist_head`) plus the `PAGE_TYPE_FREELIST_TRUNK`
+///   page tag. Bumped **on demand** — a save that produces no freed
+///   pages keeps writing the file's existing version. The first save
+///   that yields a non-empty freelist promotes the file to v6.
 pub const FORMAT_VERSION_V4: u16 = 4;
 pub const FORMAT_VERSION_V5: u16 = 5;
+pub const FORMAT_VERSION_V6: u16 = 6;
 /// The version a brand-new write defaults to when no FTS index forces
 /// a bump. Existing databases keep their on-disk version unchanged
-/// across reads + non-FTS writes; FTS-bearing saves switch to V5.
+/// across reads + non-FTS writes; FTS-bearing saves switch to V5,
+/// freelist-bearing saves switch to V6.
 pub const FORMAT_VERSION_BASELINE: u16 = FORMAT_VERSION_V4;
 
 /// Parsed header. `page_count` includes page 0 itself.
@@ -46,9 +53,15 @@ pub struct DbHeader {
     pub page_count: u32,
     pub schema_root_page: u32,
     /// On-disk format version this header carries. Tracked explicitly
-    /// so save can preserve a v4 file as v4 (no FTS) or bump it to v5
-    /// (FTS present), per Phase 8c's on-demand bump strategy.
+    /// so save can preserve a v4 file as v4 (no FTS, no freelist),
+    /// bump it to v5 (FTS), or bump it to v6 (freelist), per the
+    /// on-demand promotion rules.
     pub format_version: u16,
+    /// First page of the persisted free-page list, or `0` if the list
+    /// is empty. The freelist is a chain of trunk pages; each trunk
+    /// records up to ~1018 free leaf-page numbers. v4/v5 files don't
+    /// carry a freelist on disk — `decode_header` returns `0` for them.
+    pub freelist_head: u32,
 }
 
 /// Encodes the header into a `PAGE_SIZE`-sized buffer.
@@ -59,13 +72,16 @@ pub fn encode_header(h: &DbHeader) -> [u8; PAGE_SIZE] {
     buf[18..20].copy_from_slice(&(PAGE_SIZE as u16).to_le_bytes());
     buf[20..24].copy_from_slice(&h.page_count.to_le_bytes());
     buf[24..28].copy_from_slice(&h.schema_root_page.to_le_bytes());
+    buf[28..32].copy_from_slice(&h.freelist_head.to_le_bytes());
     buf
 }
 
 /// Decodes the header from a `PAGE_SIZE`-sized buffer. Returns an error if
 /// magic bytes, format version, or page size don't match what we wrote.
-/// Both V4 and V5 are accepted; the result's `format_version` echoes
-/// what was on disk so a no-op resave preserves it.
+/// V4, V5, and V6 are accepted; the result's `format_version` echoes
+/// what was on disk so a no-op resave preserves it. `freelist_head` is
+/// read from bytes [28..32] for V6 files; V4/V5 files have a zero
+/// reserved region there, so the field decodes as `0` either way.
 pub fn decode_header(buf: &[u8]) -> Result<DbHeader> {
     if buf.len() != PAGE_SIZE {
         return Err(SQLRiteError::Internal(format!(
@@ -79,10 +95,11 @@ pub fn decode_header(buf: &[u8]) -> Result<DbHeader> {
         ));
     }
     let version = u16::from_le_bytes(buf[16..18].try_into().unwrap());
-    if version != FORMAT_VERSION_V4 && version != FORMAT_VERSION_V5 {
+    if version != FORMAT_VERSION_V4 && version != FORMAT_VERSION_V5 && version != FORMAT_VERSION_V6
+    {
         return Err(SQLRiteError::General(format!(
             "unsupported SQLRite format version {version}; this build understands \
-             {FORMAT_VERSION_V4} and {FORMAT_VERSION_V5}"
+             {FORMAT_VERSION_V4}, {FORMAT_VERSION_V5}, and {FORMAT_VERSION_V6}"
         )));
     }
     let page_size = u16::from_le_bytes(buf[18..20].try_into().unwrap()) as usize;
@@ -93,9 +110,11 @@ pub fn decode_header(buf: &[u8]) -> Result<DbHeader> {
     }
     let page_count = u32::from_le_bytes(buf[20..24].try_into().unwrap());
     let schema_root_page = u32::from_le_bytes(buf[24..28].try_into().unwrap());
+    let freelist_head = u32::from_le_bytes(buf[28..32].try_into().unwrap());
     Ok(DbHeader {
         page_count,
         schema_root_page,
         format_version: version,
+        freelist_head,
     })
 }

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -30,8 +30,12 @@
 // Module-level #[allow(dead_code)] keeps the build quiet without dotting
 // the modules with per-item attributes.
 #[allow(dead_code)]
+pub mod allocator;
+#[allow(dead_code)]
 pub mod cell;
 pub mod file;
+#[allow(dead_code)]
+pub mod freelist;
 #[allow(dead_code)]
 pub mod fts_cell;
 pub mod header;
@@ -187,9 +191,38 @@ struct IndexCatalogRow {
     rootpage: u32,
 }
 
-/// Persists `db` to disk. Same diff-commit behavior as before: only pages
-/// whose bytes actually changed get written.
+/// Persists `db` to disk. Diff-pager skips writing pages whose bytes
+/// haven't changed; the [`PageAllocator`] preserves per-table page
+/// numbers across saves so unchanged tables produce zero dirty frames.
+///
+/// Pages that were live before this save but aren't restaged this round
+/// (e.g., the leaves of a dropped table) move onto a persisted free
+/// list rooted at `header.freelist_head`; subsequent saves draw from
+/// the freelist before extending the file. `VACUUM` (see
+/// [`vacuum_database`]) compacts the file by ignoring the freelist and
+/// allocating linearly from page 1.
+///
+/// [`PageAllocator`]: crate::sql::pager::allocator::PageAllocator
 pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
+    save_database_with_mode(db, path, /*compact=*/ false)
+}
+
+/// Reclaims space by rewriting every live B-Tree contiguously from
+/// page 1, with no freelist. Equivalent to `save_database` but ignores
+/// the existing freelist and per-table preferred pools — every page is
+/// allocated by extending the high-water mark — so the resulting file
+/// is tightly packed and the freelist is empty.
+///
+/// Used by the SQL-level `VACUUM;` statement.
+pub fn vacuum_database(db: &mut Database, path: &Path) -> Result<()> {
+    save_database_with_mode(db, path, /*compact=*/ true)
+}
+
+/// Shared save core. `compact = false` is the normal save path (uses
+/// the existing freelist + per-table preferred pools). `compact = true`
+/// is the VACUUM path (empty freelist, empty preferred pools, linear
+/// allocation from page 1).
+fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Result<()> {
     // Phase 7d.3 — rebuild any HNSW index that DELETE / UPDATE-on-vector
     // marked dirty. Done up front under the &mut Database borrow we
     // already hold, before the immutable iteration loops below need
@@ -211,10 +244,40 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
         Pager::create(path)?
     };
 
+    // Snapshot what was live BEFORE we reset staged. Used to compute the
+    // newly-freed set after staging completes. Page 0 (the header) is
+    // never on the freelist — it's always live.
+    let old_header = pager.header();
+    let old_live: std::collections::HashSet<u32> = (1..old_header.page_count).collect();
+
+    // Read the previously-persisted freelist so its leaf pages can be
+    // reused as preferred allocations and its trunk pages don't leak.
+    let (old_free_leaves, old_free_trunks) = if compact || old_header.freelist_head == 0 {
+        (Vec::new(), Vec::new())
+    } else {
+        crate::sql::pager::freelist::read_freelist(&pager, old_header.freelist_head)?
+    };
+
+    // Snapshot the previous rootpages of each table/index so we can
+    // seed per-table preferred pools (the unchanged-table case stages
+    // byte-identical pages → diff pager skips every write for it).
+    let old_rootpages = if compact {
+        HashMap::new()
+    } else {
+        read_old_rootpages(&pager, old_header.schema_root_page)?
+    };
+
     pager.clear_staged();
 
-    // Page 0 is the header; payload pages start at 1.
-    let mut next_free_page: u32 = 1;
+    // Allocator: in normal mode, seed with the old freelist; in compact
+    // mode, start empty so allocation extends linearly from page 1.
+    use std::collections::VecDeque;
+    let initial_freelist: VecDeque<u32> = if compact {
+        VecDeque::new()
+    } else {
+        crate::sql::pager::freelist::freelist_to_deque(old_free_leaves.clone())
+    };
+    let mut alloc = crate::sql::pager::allocator::PageAllocator::new(initial_freelist, 1);
 
     // 1. Stage each user table's B-Tree, collecting master-row info.
     //    `kind` is "table" or "index" — master has one row per each.
@@ -228,9 +291,16 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
                 "user table cannot be named '{MASTER_TABLE_NAME}' (reserved)"
             )));
         }
+        if !compact {
+            if let Some(&prev_root) = old_rootpages.get(&("table".to_string(), name.to_string())) {
+                let prev =
+                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ true)?;
+                alloc.set_preferred(prev);
+            }
+        }
         let table = &db.tables[name];
-        let (rootpage, new_next) = stage_table_btree(&mut pager, table, next_free_page)?;
-        next_free_page = new_next;
+        let rootpage = stage_table_btree(&mut pager, table, &mut alloc)?;
+        alloc.finish_preferred();
         master_rows.push(CatalogEntry {
             kind: "table".into(),
             name: name.clone(),
@@ -251,8 +321,17 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
     index_entries
         .sort_by(|(ta, ia), (tb, ib)| ta.tb_name.cmp(&tb.tb_name).then(ia.name.cmp(&ib.name)));
     for (_table, idx) in index_entries {
-        let (rootpage, new_next) = stage_index_btree(&mut pager, idx, next_free_page)?;
-        next_free_page = new_next;
+        if !compact {
+            if let Some(&prev_root) =
+                old_rootpages.get(&("index".to_string(), idx.name.to_string()))
+            {
+                let prev =
+                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ false)?;
+                alloc.set_preferred(prev);
+            }
+        }
+        let rootpage = stage_index_btree(&mut pager, idx, &mut alloc)?;
+        alloc.finish_preferred();
         master_rows.push(CatalogEntry {
             kind: "index".into(),
             name: idx.name.clone(),
@@ -279,8 +358,17 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
     hnsw_entries
         .sort_by(|(ta, ea), (tb, eb)| ta.tb_name.cmp(&tb.tb_name).then(ea.name.cmp(&eb.name)));
     for (table, entry) in hnsw_entries {
-        let (rootpage, new_next) = stage_hnsw_btree(&mut pager, &entry.index, next_free_page)?;
-        next_free_page = new_next;
+        if !compact {
+            if let Some(&prev_root) =
+                old_rootpages.get(&("index".to_string(), entry.name.to_string()))
+            {
+                let prev =
+                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ false)?;
+                alloc.set_preferred(prev);
+            }
+        }
+        let rootpage = stage_hnsw_btree(&mut pager, &entry.index, &mut alloc)?;
+        alloc.finish_preferred();
         master_rows.push(CatalogEntry {
             kind: "index".into(),
             name: entry.name.clone(),
@@ -312,8 +400,17 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
         .sort_by(|(ta, ea), (tb, eb)| ta.tb_name.cmp(&tb.tb_name).then(ea.name.cmp(&eb.name)));
     let any_fts = !fts_entries.is_empty();
     for (table, entry) in fts_entries {
-        let (rootpage, new_next) = stage_fts_btree(&mut pager, &entry.index, next_free_page)?;
-        next_free_page = new_next;
+        if !compact {
+            if let Some(&prev_root) =
+                old_rootpages.get(&("index".to_string(), entry.name.to_string()))
+            {
+                let prev =
+                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ false)?;
+                alloc.set_preferred(prev);
+            }
+        }
+        let rootpage = stage_fts_btree(&mut pager, &entry.index, &mut alloc)?;
+        alloc.finish_preferred();
         master_rows.push(CatalogEntry {
             kind: "index".into(),
             name: entry.name.clone(),
@@ -327,7 +424,10 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
     }
 
     // 3. Build an in-memory sqlrite_master with one row per table or index,
-    //    then stage it via the same tree-build path.
+    //    then stage it via the same tree-build path. Seed master's
+    //    preferred pool with the previous master tree's pages so the
+    //    catalog page numbers stay stable across saves whenever the
+    //    catalog content didn't change.
     let mut master = build_empty_master_table();
     for (i, entry) in master_rows.into_iter().enumerate() {
         let rowid = (i as i64) + 1;
@@ -342,23 +442,67 @@ pub fn save_database(db: &mut Database, path: &Path) -> Result<()> {
             ],
         )?;
     }
-    let (master_root, master_next) = stage_table_btree(&mut pager, &master, next_free_page)?;
-    next_free_page = master_next;
+    if !compact && old_header.schema_root_page != 0 {
+        let prev = collect_pages_for_btree(
+            &pager,
+            old_header.schema_root_page,
+            /*follow_overflow=*/ true,
+        )?;
+        alloc.set_preferred(prev);
+    }
+    let master_root = stage_table_btree(&mut pager, &master, &mut alloc)?;
+    alloc.finish_preferred();
 
-    // Phase 8c — on-demand v4→v5 file-format bump per Q10. If any FTS
-    // index attached to the database, write v5; otherwise preserve the
-    // pre-existing version (v4 for files born before this build, or
-    // a previously-promoted v5 file). Reads accept both.
-    let format_version = if any_fts {
-        crate::sql::pager::header::FORMAT_VERSION_V5
+    // 4. Compute newly-freed pages: the previously-live set minus what
+    //    we just restaged. The previous freelist's trunk pages get
+    //    re-encoded too — they're in `old_live`, weren't restaged, so
+    //    the filter naturally moves them to the new freelist.
+    //
+    // In `compact` mode (VACUUM), we *discard* newly_freed instead of
+    // routing it onto the new freelist. The whole point of VACUUM is
+    // to let the file truncate to the new high-water mark, so any page
+    // past it gets dropped at the next checkpoint.
+    if !compact {
+        let used = alloc.used().clone();
+        let mut newly_freed: Vec<u32> = old_live
+            .iter()
+            .copied()
+            .filter(|p| !used.contains(p))
+            .collect();
+        let _ = &old_free_trunks; // silenced — handled by the old_live filter
+        alloc.add_to_freelist(newly_freed.drain(..));
+    }
+
+    // 5. Encode the new freelist into trunk pages. `stage_freelist`
+    //    consumes some of the free pages AS the trunk pages themselves —
+    //    a trunk is just a free page borrowed for metadata. Pages that
+    //    were on the freelist but become trunks no longer need to be
+    //    "extension" pages; the high-water mark from the staging loop
+    //    above is already correct.
+    let new_free_pages = alloc.drain_freelist();
+    let new_freelist_head =
+        crate::sql::pager::freelist::stage_freelist(&mut pager, new_free_pages)?;
+
+    // 6. Pick the format version. v6 is on demand: only bumps when the
+    //    new freelist is non-empty. FTS-bearing files keep their v5
+    //    promotion; v6 is a strict superset (v6 readers handle v4/v5/v6).
+    use crate::sql::pager::header::{FORMAT_VERSION_V5, FORMAT_VERSION_V6};
+    let format_version = if new_freelist_head != 0 {
+        FORMAT_VERSION_V6
+    } else if any_fts {
+        // Preserve a v6 file at v6 (don't downgrade) but otherwise
+        // bump v4 → v5 for FTS like Phase 8c does.
+        std::cmp::max(FORMAT_VERSION_V5, old_header.format_version)
     } else {
-        pager.header().format_version
+        // Preserve whatever the file already was.
+        old_header.format_version
     };
 
     pager.commit(DbHeader {
-        page_count: next_free_page,
+        page_count: alloc.high_water(),
         schema_root_page: master_root,
         format_version,
+        freelist_head: new_freelist_head,
     })?;
 
     if same_path {
@@ -1121,20 +1265,18 @@ fn clone_datatype(dt: &DataType) -> DataType {
 fn stage_index_btree(
     pager: &mut Pager,
     idx: &SecondaryIndex,
-    start_page: u32,
-) -> Result<(u32, u32)> {
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<u32> {
     // Build the leaves.
-    let (leaves, mut next_free_page) = stage_index_leaves(pager, idx, start_page)?;
+    let leaves = stage_index_leaves(pager, idx, alloc)?;
     if leaves.len() == 1 {
-        return Ok((leaves[0].0, next_free_page));
+        return Ok(leaves[0].0);
     }
     let mut level: Vec<(u32, i64)> = leaves;
     while level.len() > 1 {
-        let (next_level, new_next_free) = stage_interior_level(pager, &level, next_free_page)?;
-        next_free_page = new_next_free;
-        level = next_level;
+        level = stage_interior_level(pager, &level, alloc)?;
     }
-    Ok((level[0].0, next_free_page))
+    Ok(level[0].0)
 }
 
 /// Packs the index's (value, rowid) entries into a sibling-chained run
@@ -1146,13 +1288,12 @@ fn stage_index_btree(
 fn stage_index_leaves(
     pager: &mut Pager,
     idx: &SecondaryIndex,
-    start_page: u32,
-) -> Result<(Vec<(u32, i64)>, u32)> {
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<Vec<(u32, i64)>> {
     let mut leaves: Vec<(u32, i64)> = Vec::new();
     let mut current_leaf = TablePage::empty();
-    let mut current_leaf_page = start_page;
+    let mut current_leaf_page = alloc.allocate();
     let mut current_max_rowid: Option<i64> = None;
-    let mut next_free_page = start_page + 1;
 
     // Sort the entries by original rowid so the in-page slot directory,
     // which binary-searches by rowid, stays valid. (iter_entries orders by
@@ -1165,12 +1306,11 @@ fn stage_index_leaves(
         let entry_bytes = cell.encode()?;
 
         if !current_leaf.would_fit(entry_bytes.len()) {
-            let next_leaf_page_num = next_free_page;
+            let next_leaf_page_num = alloc.allocate();
             emit_leaf(pager, current_leaf_page, &current_leaf, next_leaf_page_num);
             leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
             current_leaf = TablePage::empty();
             current_leaf_page = next_leaf_page_num;
-            next_free_page += 1;
 
             if !current_leaf.would_fit(entry_bytes.len()) {
                 return Err(SQLRiteError::Internal(format!(
@@ -1186,7 +1326,7 @@ fn stage_index_leaves(
 
     emit_leaf(pager, current_leaf_page, &current_leaf, 0);
     leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
-    Ok((leaves, next_free_page))
+    Ok(leaves)
 }
 
 /// Phase 7d.3 — stages an HNSW index's page tree at `start_page`.
@@ -1202,19 +1342,17 @@ fn stage_index_leaves(
 fn stage_hnsw_btree(
     pager: &mut Pager,
     idx: &crate::sql::hnsw::HnswIndex,
-    start_page: u32,
-) -> Result<(u32, u32)> {
-    let (leaves, mut next_free_page) = stage_hnsw_leaves(pager, idx, start_page)?;
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<u32> {
+    let leaves = stage_hnsw_leaves(pager, idx, alloc)?;
     if leaves.len() == 1 {
-        return Ok((leaves[0].0, next_free_page));
+        return Ok(leaves[0].0);
     }
     let mut level: Vec<(u32, i64)> = leaves;
     while level.len() > 1 {
-        let (next_level, new_next_free) = stage_interior_level(pager, &level, next_free_page)?;
-        next_free_page = new_next_free;
-        level = next_level;
+        level = stage_interior_level(pager, &level, alloc)?;
     }
-    Ok((level[0].0, next_free_page))
+    Ok(level[0].0)
 }
 
 /// Phase 8c — stage one FTS index as a `TableLeaf`-shaped B-Tree.
@@ -1225,19 +1363,17 @@ fn stage_hnsw_btree(
 fn stage_fts_btree(
     pager: &mut Pager,
     idx: &crate::sql::fts::PostingList,
-    start_page: u32,
-) -> Result<(u32, u32)> {
-    let (leaves, mut next_free_page) = stage_fts_leaves(pager, idx, start_page)?;
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<u32> {
+    let leaves = stage_fts_leaves(pager, idx, alloc)?;
     if leaves.len() == 1 {
-        return Ok((leaves[0].0, next_free_page));
+        return Ok(leaves[0].0);
     }
     let mut level: Vec<(u32, i64)> = leaves;
     while level.len() > 1 {
-        let (next_level, new_next_free) = stage_interior_level(pager, &level, next_free_page)?;
-        next_free_page = new_next_free;
-        level = next_level;
+        level = stage_interior_level(pager, &level, alloc)?;
     }
-    Ok((level[0].0, next_free_page))
+    Ok(level[0].0)
 }
 
 /// Packs FTS posting cells into a sibling-chained run of `TableLeaf`
@@ -1249,15 +1385,14 @@ fn stage_fts_btree(
 fn stage_fts_leaves(
     pager: &mut Pager,
     idx: &crate::sql::fts::PostingList,
-    start_page: u32,
-) -> Result<(Vec<(u32, i64)>, u32)> {
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<Vec<(u32, i64)>> {
     use crate::sql::pager::fts_cell::FtsPostingCell;
 
     let mut leaves: Vec<(u32, i64)> = Vec::new();
     let mut current_leaf = TablePage::empty();
-    let mut current_leaf_page = start_page;
+    let mut current_leaf_page = alloc.allocate();
     let mut current_max_rowid: Option<i64> = None;
-    let mut next_free_page = start_page + 1;
 
     // Build the cell sequence: sidecar first, then per-term cells. The
     // sidecar always exists (even on an empty index) so reload sees a
@@ -1277,12 +1412,11 @@ fn stage_fts_leaves(
         let entry_bytes = cell.encode()?;
 
         if !current_leaf.would_fit(entry_bytes.len()) {
-            let next_leaf_page_num = next_free_page;
+            let next_leaf_page_num = alloc.allocate();
             emit_leaf(pager, current_leaf_page, &current_leaf, next_leaf_page_num);
             leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
             current_leaf = TablePage::empty();
             current_leaf_page = next_leaf_page_num;
-            next_free_page += 1;
 
             if !current_leaf.would_fit(entry_bytes.len()) {
                 // A single posting cell exceeds page capacity. Phase
@@ -1304,7 +1438,7 @@ fn stage_fts_leaves(
 
     emit_leaf(pager, current_leaf_page, &current_leaf, 0);
     leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
-    Ok((leaves, next_free_page))
+    Ok(leaves)
 }
 
 /// (rowid, value) pairs as decoded from a single FTS cell — value is
@@ -1373,15 +1507,14 @@ fn load_fts_postings(pager: &Pager, root_page: u32) -> Result<(FtsEntries, FtsPo
 fn stage_hnsw_leaves(
     pager: &mut Pager,
     idx: &crate::sql::hnsw::HnswIndex,
-    start_page: u32,
-) -> Result<(Vec<(u32, i64)>, u32)> {
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<Vec<(u32, i64)>> {
     use crate::sql::pager::hnsw_cell::HnswNodeCell;
 
     let mut leaves: Vec<(u32, i64)> = Vec::new();
     let mut current_leaf = TablePage::empty();
-    let mut current_leaf_page = start_page;
+    let mut current_leaf_page = alloc.allocate();
     let mut current_max_rowid: Option<i64> = None;
-    let mut next_free_page = start_page + 1;
 
     let serialized = idx.serialize_nodes();
 
@@ -1394,12 +1527,11 @@ fn stage_hnsw_leaves(
         let entry_bytes = cell.encode()?;
 
         if !current_leaf.would_fit(entry_bytes.len()) {
-            let next_leaf_page_num = next_free_page;
+            let next_leaf_page_num = alloc.allocate();
             emit_leaf(pager, current_leaf_page, &current_leaf, next_leaf_page_num);
             leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
             current_leaf = TablePage::empty();
             current_leaf_page = next_leaf_page_num;
-            next_free_page += 1;
 
             if !current_leaf.would_fit(entry_bytes.len()) {
                 return Err(SQLRiteError::Internal(format!(
@@ -1415,7 +1547,7 @@ fn stage_hnsw_leaves(
 
     emit_leaf(pager, current_leaf_page, &current_leaf, 0);
     leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
-    Ok((leaves, next_free_page))
+    Ok(leaves)
 }
 
 fn load_table_rows(pager: &Pager, table: &mut Table, root_page: u32) -> Result<()> {
@@ -1455,6 +1587,115 @@ fn load_table_rows(pager: &Pager, table: &mut Table, root_page: u32) -> Result<(
     Ok(())
 }
 
+/// Walks every page reachable from `root_page` and returns their page
+/// numbers. Includes `root_page`, every interior page, every leaf, and
+/// — when `follow_overflow` is true — every overflow page chained off
+/// table-leaf cells. Used by `save_database` to seed each table's
+/// per-table preferred pool and to compute the newly-freed set.
+///
+/// `follow_overflow = true` for table B-Trees (cells may carry
+/// `OverflowRef`s pointing at chained overflow pages); `false` for
+/// secondary-index, HNSW, and FTS B-Trees, which never overflow in the
+/// current encoding.
+fn collect_pages_for_btree(
+    pager: &Pager,
+    root_page: u32,
+    follow_overflow: bool,
+) -> Result<Vec<u32>> {
+    if root_page == 0 {
+        return Ok(Vec::new());
+    }
+    let mut pages: Vec<u32> = Vec::new();
+    let mut stack: Vec<u32> = vec![root_page];
+
+    while let Some(p) = stack.pop() {
+        let buf = pager.read_page(p).ok_or_else(|| {
+            SQLRiteError::Internal(format!(
+                "collect_pages: missing page {p} (rooted at {root_page})"
+            ))
+        })?;
+        pages.push(p);
+        match buf[0] {
+            t if t == PageType::InteriorNode as u8 => {
+                let payload: &[u8; PAYLOAD_PER_PAGE] =
+                    (&buf[PAGE_HEADER_SIZE..]).try_into().map_err(|_| {
+                        SQLRiteError::Internal("interior payload slice size".to_string())
+                    })?;
+                let interior = InteriorPage::from_bytes(payload);
+                // Push every divider's child + the rightmost child.
+                for slot in 0..interior.slot_count() {
+                    let cell = interior.cell_at(slot)?;
+                    stack.push(cell.child_page);
+                }
+                stack.push(interior.rightmost_child());
+            }
+            t if t == PageType::TableLeaf as u8 => {
+                if follow_overflow {
+                    let payload: &[u8; PAYLOAD_PER_PAGE] =
+                        (&buf[PAGE_HEADER_SIZE..]).try_into().map_err(|_| {
+                            SQLRiteError::Internal("leaf payload slice size".to_string())
+                        })?;
+                    let leaf = TablePage::from_bytes(payload);
+                    for slot in 0..leaf.slot_count() {
+                        match leaf.entry_at(slot)? {
+                            PagedEntry::Local(_) => {}
+                            PagedEntry::Overflow(r) => {
+                                let mut cur = r.first_overflow_page;
+                                while cur != 0 {
+                                    pages.push(cur);
+                                    let ob = pager.read_page(cur).ok_or_else(|| {
+                                        SQLRiteError::Internal(format!(
+                                            "collect_pages: missing overflow page {cur}"
+                                        ))
+                                    })?;
+                                    if ob[0] != PageType::Overflow as u8 {
+                                        return Err(SQLRiteError::Internal(format!(
+                                            "collect_pages: page {cur} expected Overflow, got tag {}",
+                                            ob[0]
+                                        )));
+                                    }
+                                    cur = u32::from_le_bytes(ob[1..5].try_into().unwrap());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            other => {
+                return Err(SQLRiteError::Internal(format!(
+                    "collect_pages: unexpected page type {other} at page {p}"
+                )));
+            }
+        }
+    }
+    Ok(pages)
+}
+
+/// Reads the previously-persisted `sqlrite_master` and returns a map from
+/// `(kind, name)` to that object's rootpage. Used by `save_database` to
+/// seed each table/index's per-table preferred pool with the pages it
+/// occupied last time round.
+///
+/// `kind` is `"table"` or `"index"` (the catalog already disambiguates
+/// the three index families via the SQL string, but for page-collection
+/// purposes a "table" tree must follow overflow refs while an "index"
+/// tree never does — that's the only distinction we need here).
+fn read_old_rootpages(pager: &Pager, schema_root: u32) -> Result<HashMap<(String, String), u32>> {
+    let mut out: HashMap<(String, String), u32> = HashMap::new();
+    if schema_root == 0 {
+        return Ok(out);
+    }
+    let mut master = build_empty_master_table();
+    load_table_rows(pager, &mut master, schema_root)?;
+    for rowid in master.rowids() {
+        let kind = take_text(&master, "type", rowid)?;
+        let name = take_text(&master, "name", rowid)?;
+        let rootpage = take_integer(&master, "rootpage", rowid)? as u32;
+        out.insert((kind, name), rootpage);
+    }
+    Ok(out)
+}
+
 /// Descends from `root_page` through `InteriorNode` pages, always taking
 /// the leftmost child, until a `TableLeaf` is reached. Returns that leaf's
 /// page number. A root that's already a leaf is returned as-is.
@@ -1483,60 +1724,57 @@ fn find_leftmost_leaf(pager: &Pager, root_page: u32) -> Result<u32> {
     }
 }
 
-/// Stages a table's B-Tree starting at `start_page`. Returns
-/// `(root_page, next_free_page)`. Builds bottom-up:
+/// Stages a table's B-Tree, drawing every page number from `alloc`.
+/// Returns the root page (the topmost interior page, or the single leaf
+/// when the table fits in one page).
 ///
-/// 1. Pack all row cells into `TableLeaf` pages, chaining them via each
-///    leaf's `next_page` sibling pointer (for fast sequential scans).
-/// 2. If the table fits in a single leaf, that leaf is the root.
-/// 3. Otherwise, group leaves into `InteriorNode` pages; recurse up the
-///    tree until one root remains.
+/// Builds bottom-up: pack rows into `TableLeaf` pages chained via
+/// `next_page`, then if more than one leaf, recursively wrap them in
+/// `InteriorNode` levels until one root remains.
 ///
-/// Deterministic: same in-memory rows → same pages at same offsets, so
-/// the Pager's diff commit still skips unchanged tables.
-fn stage_table_btree(pager: &mut Pager, table: &Table, start_page: u32) -> Result<(u32, u32)> {
-    let (leaves, mut next_free_page) = stage_leaves(pager, table, start_page)?;
+/// Deterministic: same rows + same allocator handouts → byte-identical
+/// pages at the same numbers, so the diff pager skips unchanged tables.
+fn stage_table_btree(
+    pager: &mut Pager,
+    table: &Table,
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<u32> {
+    let leaves = stage_leaves(pager, table, alloc)?;
     if leaves.len() == 1 {
-        return Ok((leaves[0].0, next_free_page));
+        return Ok(leaves[0].0);
     }
     let mut level: Vec<(u32, i64)> = leaves;
     while level.len() > 1 {
-        let (next_level, new_next_free) = stage_interior_level(pager, &level, next_free_page)?;
-        next_free_page = new_next_free;
-        level = next_level;
+        level = stage_interior_level(pager, &level, alloc)?;
     }
-    Ok((level[0].0, next_free_page))
+    Ok(level[0].0)
 }
 
 /// Packs the table's rows into a sibling-linked chain of `TableLeaf` pages.
-/// Returns each leaf's `(page_number, max_rowid)` (used by the next level
-/// up to build divider cells) and the first free page after the chain
-/// including any overflow pages allocated for oversized cells.
+/// Returns each leaf's `(page_number, max_rowid)` for use by the next
+/// interior level. Allocates leaf and overflow pages from `alloc`.
 fn stage_leaves(
     pager: &mut Pager,
     table: &Table,
-    start_page: u32,
-) -> Result<(Vec<(u32, i64)>, u32)> {
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<Vec<(u32, i64)>> {
     let mut leaves: Vec<(u32, i64)> = Vec::new();
     let mut current_leaf = TablePage::empty();
-    let mut current_leaf_page = start_page;
+    let mut current_leaf_page = alloc.allocate();
     let mut current_max_rowid: Option<i64> = None;
-    let mut next_free_page = start_page + 1;
 
     for rowid in table.rowids() {
-        let entry_bytes = build_row_entry(pager, table, rowid, &mut next_free_page)?;
+        let entry_bytes = build_row_entry(pager, table, rowid, alloc)?;
 
         if !current_leaf.would_fit(entry_bytes.len()) {
-            // Commit the current leaf. Its sibling next_page is the page
-            // number where the new leaf will go — which is next_free_page
-            // right now (no overflow pages have been allocated between
-            // this decision and the new leaf's allocation below).
-            let next_leaf_page_num = next_free_page;
+            // The new leaf goes at whatever the allocator hands out
+            // next. Commit the current leaf with that as its sibling
+            // pointer.
+            let next_leaf_page_num = alloc.allocate();
             emit_leaf(pager, current_leaf_page, &current_leaf, next_leaf_page_num);
             leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
             current_leaf = TablePage::empty();
             current_leaf_page = next_leaf_page_num;
-            next_free_page += 1;
             // current_max_rowid is reassigned by the insert below; no need
             // to zero it out here.
 
@@ -1555,25 +1793,24 @@ fn stage_leaves(
     // Final leaf: sibling next_page = 0 (end of chain).
     emit_leaf(pager, current_leaf_page, &current_leaf, 0);
     leaves.push((current_leaf_page, current_max_rowid.unwrap_or(i64::MIN)));
-    Ok((leaves, next_free_page))
+    Ok(leaves)
 }
 
 /// Encodes a single row's on-leaf entry — either the local cell bytes, or
 /// an `OverflowRef` pointing at a freshly-allocated overflow chain if the
-/// encoded cell exceeded the inline threshold. Advances `next_free_page`
-/// past any overflow pages used.
+/// encoded cell exceeded the inline threshold. Allocates any overflow
+/// pages from `alloc`.
 fn build_row_entry(
     pager: &mut Pager,
     table: &Table,
     rowid: i64,
-    next_free_page: &mut u32,
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
 ) -> Result<Vec<u8>> {
     let values = table.extract_row(rowid);
     let local_cell = Cell::new(rowid, values);
     let local_bytes = local_cell.encode()?;
     if local_bytes.len() > OVERFLOW_THRESHOLD {
-        let overflow_start = *next_free_page;
-        *next_free_page = write_overflow_chain(pager, &local_bytes, overflow_start)?;
+        let overflow_start = write_overflow_chain(pager, &local_bytes, alloc)?;
         Ok(OverflowRef {
             rowid,
             total_body_len: local_bytes.len() as u64,
@@ -1588,20 +1825,17 @@ fn build_row_entry(
 /// Builds one level of `InteriorNode` pages above the given children.
 /// Each interior packs as many dividers as will fit; the last child
 /// assigned to an interior becomes its `rightmost_child`. Returns the
-/// emitted interior pages as `(page_number, max_rowid_in_subtree)` so the
-/// next level can build on top of them.
+/// emitted interior pages as `(page_number, max_rowid_in_subtree)`.
 fn stage_interior_level(
     pager: &mut Pager,
     children: &[(u32, i64)],
-    start_page: u32,
-) -> Result<(Vec<(u32, i64)>, u32)> {
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<Vec<(u32, i64)>> {
     let mut next_level: Vec<(u32, i64)> = Vec::new();
-    let mut next_free_page = start_page;
     let mut idx = 0usize;
 
     while idx < children.len() {
-        let interior_page_num = next_free_page;
-        next_free_page += 1;
+        let interior_page_num = alloc.allocate();
 
         // Seed the interior with the first unassigned child as its
         // rightmost. As we add more children, the previous rightmost
@@ -1632,7 +1866,7 @@ fn stage_interior_level(
         next_level.push((interior_page_num, rightmost_child_max));
     }
 
-    Ok((next_level, next_free_page))
+    Ok(next_level)
 }
 
 /// Wraps a `TablePage` in the 7-byte page header and hands it to the pager.
@@ -2771,6 +3005,324 @@ mod tests {
         );
         assert_eq!(users.get_value("score", 1), Some(Value::Integer(0)));
 
+        cleanup(&path);
+    }
+
+    // ---------------------------------------------------------------------
+    // SQLR-6 — free-list + VACUUM tests
+    // ---------------------------------------------------------------------
+
+    /// Drop a table; subsequent CREATE TABLE should reuse the freed pages
+    /// rather than extending the file. The page_count after drop+create
+    /// should be at most what it was after the original two tables —
+    /// proving the new table landed on freelist pages.
+    #[test]
+    fn drop_table_freelist_persists_pages_for_reuse() {
+        let path = tmp_path("freelist_reuse");
+        let mut db = seed_db();
+        db.source_path = Some(path.clone());
+        save_database(&mut db, &path).expect("save");
+        let pages_two_tables = db.pager.as_ref().unwrap().header().page_count;
+
+        // Drop one table; its pages go on the freelist.
+        process_command("DROP TABLE users;", &mut db).expect("drop users");
+        let pages_after_drop = db.pager.as_ref().unwrap().header().page_count;
+        assert_eq!(
+            pages_after_drop, pages_two_tables,
+            "page_count should not shrink on drop — the freed pages persist on the freelist"
+        );
+        let head_after_drop = db.pager.as_ref().unwrap().header().freelist_head;
+        assert!(
+            head_after_drop != 0,
+            "freelist_head must be non-zero after drop"
+        );
+
+        // Re-create a similar-shaped table; should reuse freelist pages.
+        process_command(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, label TEXT NOT NULL UNIQUE);",
+            &mut db,
+        )
+        .expect("create accounts");
+        process_command("INSERT INTO accounts (label) VALUES ('a');", &mut db).unwrap();
+        process_command("INSERT INTO accounts (label) VALUES ('b');", &mut db).unwrap();
+        let pages_after_create = db.pager.as_ref().unwrap().header().page_count;
+        assert!(
+            pages_after_create <= pages_two_tables + 2,
+            "creating a similar-sized table after a drop should mostly draw from the \
+             freelist, not extend the file (got {pages_after_create} > {pages_two_tables} + 2)"
+        );
+
+        cleanup(&path);
+    }
+
+    /// `VACUUM;` after a drop must shrink the file and clear the freelist.
+    #[test]
+    fn drop_then_vacuum_shrinks_file() {
+        let path = tmp_path("vacuum_shrinks");
+        let mut db = seed_db();
+        db.source_path = Some(path.clone());
+        // Add a few more rows to make the dropped table bigger.
+        for i in 0..20 {
+            process_command(
+                &format!("INSERT INTO users (name, age) VALUES ('user{i}', {i});"),
+                &mut db,
+            )
+            .unwrap();
+        }
+        save_database(&mut db, &path).expect("save");
+
+        process_command("DROP TABLE users;", &mut db).expect("drop");
+        let size_before_vacuum = std::fs::metadata(&path).unwrap().len();
+        let pages_before_vacuum = db.pager.as_ref().unwrap().header().page_count;
+        let head_before = db.pager.as_ref().unwrap().header().freelist_head;
+        assert!(head_before != 0, "drop should populate the freelist");
+
+        // VACUUM (via process_command) checkpoints internally so the
+        // file actually shrinks on disk before we observe its size.
+        process_command("VACUUM;", &mut db).expect("vacuum");
+
+        let size_after = std::fs::metadata(&path).unwrap().len();
+        let pages_after = db.pager.as_ref().unwrap().header().page_count;
+        let head_after = db.pager.as_ref().unwrap().header().freelist_head;
+        assert!(
+            pages_after < pages_before_vacuum,
+            "VACUUM must reduce page_count: was {pages_before_vacuum}, now {pages_after}"
+        );
+        assert_eq!(head_after, 0, "VACUUM must clear the freelist");
+        assert!(
+            size_after < size_before_vacuum,
+            "VACUUM must shrink the file on disk: was {size_before_vacuum} bytes, now {size_after}"
+        );
+
+        cleanup(&path);
+    }
+
+    /// VACUUM on a non-empty multi-table DB must not lose any rows.
+    #[test]
+    fn vacuum_round_trips_data() {
+        let path = tmp_path("vacuum_round_trip");
+        let mut db = seed_db();
+        db.source_path = Some(path.clone());
+        save_database(&mut db, &path).expect("save");
+        process_command("VACUUM;", &mut db).expect("vacuum");
+
+        // Re-open from disk to make sure the on-disk catalog round-trips.
+        drop(db);
+        let loaded = open_database(&path, "t".to_string()).expect("reopen after vacuum");
+        assert!(loaded.contains_table("users".to_string()));
+        assert!(loaded.contains_table("notes".to_string()));
+        let users = loaded.get_table("users".to_string()).unwrap();
+        // seed_db inserts two users.
+        assert_eq!(users.rowids().len(), 2);
+
+        cleanup(&path);
+    }
+
+    /// Format version is bumped to v6 only after a save that creates a
+    /// non-empty freelist. VACUUM clears the freelist but doesn't
+    /// downgrade — v6 is a strict superset, so once at v6 we stay.
+    #[test]
+    fn freelist_format_version_promotion() {
+        use crate::sql::pager::header::{FORMAT_VERSION_BASELINE, FORMAT_VERSION_V6};
+        let path = tmp_path("v6_promotion");
+        let mut db = seed_db();
+        db.source_path = Some(path.clone());
+        save_database(&mut db, &path).expect("save");
+        let v_after_save = db.pager.as_ref().unwrap().header().format_version;
+        assert_eq!(
+            v_after_save, FORMAT_VERSION_BASELINE,
+            "fresh DB without drops should stay at the baseline version"
+        );
+
+        process_command("DROP TABLE users;", &mut db).expect("drop");
+        let v_after_drop = db.pager.as_ref().unwrap().header().format_version;
+        assert_eq!(
+            v_after_drop, FORMAT_VERSION_V6,
+            "first save with a non-empty freelist must promote to V6"
+        );
+
+        process_command("VACUUM;", &mut db).expect("vacuum");
+        let v_after_vacuum = db.pager.as_ref().unwrap().header().format_version;
+        assert_eq!(
+            v_after_vacuum, FORMAT_VERSION_V6,
+            "VACUUM must not downgrade — V6 is a strict superset"
+        );
+
+        cleanup(&path);
+    }
+
+    /// Freelist persists across reopen: drop, save, close, reopen,
+    /// confirm the next CREATE TABLE re-uses pages from the persisted
+    /// freelist (rather than extending the file).
+    #[test]
+    fn freelist_round_trip_through_reopen() {
+        let path = tmp_path("freelist_reopen");
+        let pages_two_tables;
+        {
+            let mut db = seed_db();
+            db.source_path = Some(path.clone());
+            save_database(&mut db, &path).expect("save");
+            pages_two_tables = db.pager.as_ref().unwrap().header().page_count;
+            process_command("DROP TABLE users;", &mut db).expect("drop");
+            let head = db.pager.as_ref().unwrap().header().freelist_head;
+            assert!(head != 0, "drop must populate the freelist");
+        }
+
+        // Reopen from disk — the freelist must come back.
+        let mut db = open_database(&path, "t".to_string()).expect("reopen");
+        assert!(
+            db.pager.as_ref().unwrap().header().freelist_head != 0,
+            "freelist_head must survive close/reopen"
+        );
+
+        process_command(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, label TEXT NOT NULL UNIQUE);",
+            &mut db,
+        )
+        .expect("create accounts");
+        process_command("INSERT INTO accounts (label) VALUES ('reopened');", &mut db).unwrap();
+        let pages_after_create = db.pager.as_ref().unwrap().header().page_count;
+        assert!(
+            pages_after_create <= pages_two_tables + 2,
+            "post-reopen create should reuse freelist (got {pages_after_create} > \
+             {pages_two_tables} + 2 — file extended instead of reusing)"
+        );
+
+        cleanup(&path);
+    }
+
+    /// VACUUM inside an explicit transaction must error before touching the
+    /// disk. `BEGIN; VACUUM;` is the documented rejection path.
+    #[test]
+    fn vacuum_inside_transaction_is_rejected() {
+        let path = tmp_path("vacuum_txn");
+        let mut db = seed_db();
+        db.source_path = Some(path.clone());
+        save_database(&mut db, &path).expect("save");
+
+        process_command("BEGIN;", &mut db).expect("begin");
+        let err = process_command("VACUUM;", &mut db).unwrap_err();
+        assert!(
+            format!("{err}").contains("VACUUM cannot run inside a transaction"),
+            "expected in-transaction rejection, got: {err}"
+        );
+        // Roll back to leave the DB in a clean state.
+        process_command("ROLLBACK;", &mut db).unwrap();
+        cleanup(&path);
+    }
+
+    /// VACUUM on an in-memory database is a documented no-op.
+    #[test]
+    fn vacuum_on_in_memory_database_is_noop() {
+        let mut db = Database::new("mem".to_string());
+        process_command("CREATE TABLE t (id INTEGER PRIMARY KEY);", &mut db).unwrap();
+        let out = process_command("VACUUM;", &mut db).expect("vacuum no-op");
+        assert!(
+            out.to_lowercase().contains("no-op") || out.to_lowercase().contains("in-memory"),
+            "expected no-op message for in-memory VACUUM, got: {out}"
+        );
+    }
+
+    /// Untouched tables shouldn't write any pages on the save that
+    /// follows a DROP of an unrelated table. Confirms the per-table
+    /// preferred pool keeps page numbers stable so the diff pager skips
+    /// every byte-identical leaf.
+    #[test]
+    fn unchanged_table_pages_skip_diff_after_unrelated_drop() {
+        // Need three tables so dropping one in the middle still leaves
+        // an "unrelated" alphabetical neighbour. Layout pre-drop (sorted):
+        //   accounts, notes, users
+        // Drop `notes`. `accounts` and `users` should keep their pages.
+        let path = tmp_path("diff_after_drop");
+        let mut db = Database::new("t".to_string());
+        db.source_path = Some(path.clone());
+        process_command(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, label TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        process_command(
+            "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        process_command(
+            "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        for i in 0..5 {
+            process_command(
+                &format!("INSERT INTO accounts (label) VALUES ('a{i}');"),
+                &mut db,
+            )
+            .unwrap();
+            process_command(
+                &format!("INSERT INTO notes (body) VALUES ('n{i}');"),
+                &mut db,
+            )
+            .unwrap();
+            process_command(
+                &format!("INSERT INTO users (name) VALUES ('u{i}');"),
+                &mut db,
+            )
+            .unwrap();
+        }
+        save_database(&mut db, &path).expect("baseline save");
+
+        // Capture page bytes for `accounts` and `users` so we can
+        // verify they don't change.
+        let pager = db.pager.as_ref().unwrap();
+        let acc_root = read_old_rootpages(pager, pager.header().schema_root_page)
+            .unwrap()
+            .get(&("table".to_string(), "accounts".to_string()))
+            .copied()
+            .unwrap();
+        let users_root = read_old_rootpages(pager, pager.header().schema_root_page)
+            .unwrap()
+            .get(&("table".to_string(), "users".to_string()))
+            .copied()
+            .unwrap();
+        let acc_bytes_before: Vec<u8> = pager.read_page(acc_root).unwrap().to_vec();
+        let users_bytes_before: Vec<u8> = pager.read_page(users_root).unwrap().to_vec();
+
+        // Drop the middle table.
+        process_command("DROP TABLE notes;", &mut db).expect("drop notes");
+
+        let pager = db.pager.as_ref().unwrap();
+        // `accounts` and `users` should still live at the same pages
+        // with byte-identical content.
+        let acc_after = pager.read_page(acc_root).unwrap();
+        let users_after = pager.read_page(users_root).unwrap();
+        assert_eq!(
+            &acc_after[..],
+            &acc_bytes_before[..],
+            "accounts root page must not be rewritten when an unrelated table is dropped"
+        );
+        assert_eq!(
+            &users_after[..],
+            &users_bytes_before[..],
+            "users root page must not be rewritten when an unrelated table is dropped"
+        );
+
+        cleanup(&path);
+    }
+
+    /// VACUUM modifiers (FULL, REINDEX, table targets, …) are rejected
+    /// with NotImplemented — only bare `VACUUM;` is supported.
+    #[test]
+    fn vacuum_modifiers_are_rejected() {
+        let path = tmp_path("vacuum_modifiers");
+        let mut db = seed_db();
+        db.source_path = Some(path.clone());
+        save_database(&mut db, &path).expect("save");
+        for stmt in ["VACUUM FULL;", "VACUUM users;"] {
+            let err = process_command(stmt, &mut db).unwrap_err();
+            assert!(
+                format!("{err}").contains("VACUUM modifiers"),
+                "expected modifier rejection for `{stmt}`, got: {err}"
+            );
+        }
         cleanup(&path);
     }
 }

--- a/src/sql/pager/overflow.rs
+++ b/src/sql/pager/overflow.rs
@@ -156,26 +156,33 @@ impl PagedEntry {
     }
 }
 
-/// Writes `bytes` into a chain of Overflow-typed pages starting at
-/// `start_page`, using consecutive page numbers. Returns the first page
-/// number *after* the chain (i.e., the next free page to hand out).
-pub fn write_overflow_chain(pager: &mut Pager, bytes: &[u8], start_page: u32) -> Result<u32> {
+/// Writes `bytes` into a chain of Overflow-typed pages, drawing each
+/// page number from the supplied [`PageAllocator`]. Returns the page
+/// number of the first link in the chain (the value to record in the
+/// `OverflowRef` cell on the owning leaf).
+///
+/// Pages no longer have to be consecutive — the chain is followed by
+/// `next_page` pointers, and the allocator may hand out pages from a
+/// freelist or preferred pool that aren't sequential.
+pub fn write_overflow_chain(
+    pager: &mut Pager,
+    bytes: &[u8],
+    alloc: &mut crate::sql::pager::allocator::PageAllocator,
+) -> Result<u32> {
     if bytes.is_empty() {
         return Err(SQLRiteError::Internal(
             "refusing to write an empty overflow chain — caller should inline instead".to_string(),
         ));
     }
-    let mut current_page = start_page;
-    let mut remaining = bytes;
-    while !remaining.is_empty() {
-        let chunk_len = remaining.len().min(PAYLOAD_PER_PAGE);
-        let (chunk, rest) = remaining.split_at(chunk_len);
-        let next = if rest.is_empty() { 0 } else { current_page + 1 };
-        pager.stage_page(current_page, encode_overflow_page(next, chunk)?);
-        current_page += 1;
-        remaining = rest;
+    // Allocate every page in the chain up front so each stage_page call
+    // already knows the successor's page number.
+    let chunks: Vec<&[u8]> = bytes.chunks(PAYLOAD_PER_PAGE).collect();
+    let pages: Vec<u32> = (0..chunks.len()).map(|_| alloc.allocate()).collect();
+    for (i, chunk) in chunks.iter().enumerate() {
+        let next = if i + 1 < pages.len() { pages[i + 1] } else { 0 };
+        pager.stage_page(pages[i], encode_overflow_page(next, chunk)?);
     }
-    Ok(current_page)
+    Ok(pages[0])
 }
 
 /// Walks an overflow chain starting at `first_page` and concatenates its
@@ -300,15 +307,19 @@ mod tests {
         // A blob that definitely spans multiple pages.
         let blob: Vec<u8> = (0..10_000).map(|i| (i % 251) as u8).collect();
         let pages_needed = blob.len().div_ceil(PAYLOAD_PER_PAGE) as u32;
-        let start = 10u32;
-        let next_free = write_overflow_chain(&mut pager, &blob, start).unwrap();
-        assert_eq!(next_free, start + pages_needed);
+        let mut alloc =
+            crate::sql::pager::allocator::PageAllocator::new(std::collections::VecDeque::new(), 10);
+        let start = write_overflow_chain(&mut pager, &blob, &mut alloc).unwrap();
+        assert_eq!(start, 10);
+        // Linear allocation from page 10 → high water = 10 + pages_needed.
+        assert_eq!(alloc.high_water(), 10 + pages_needed);
 
         pager
             .commit(crate::sql::pager::header::DbHeader {
-                page_count: next_free,
+                page_count: alloc.high_water(),
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
 
@@ -326,17 +337,21 @@ mod tests {
         let path = tmp_path("mismatch");
         let mut pager = Pager::create(&path).unwrap();
         let blob = vec![1u8; 500];
-        let next = write_overflow_chain(&mut pager, &blob, 10).unwrap();
+        let mut alloc =
+            crate::sql::pager::allocator::PageAllocator::new(std::collections::VecDeque::new(), 10);
+        let start = write_overflow_chain(&mut pager, &blob, &mut alloc).unwrap();
+        assert_eq!(start, 10);
         pager
             .commit(crate::sql::pager::header::DbHeader {
-                page_count: next,
+                page_count: alloc.high_water(),
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
 
         // Claim more bytes than the chain actually carries.
-        let err = read_overflow_chain(&pager, 10, 999).unwrap_err();
+        let err = read_overflow_chain(&pager, start, 999).unwrap_err();
         assert!(format!("{err}").contains("overflow chain produced"));
 
         let _ = std::fs::remove_file(&path);
@@ -346,7 +361,9 @@ mod tests {
     fn empty_chain_is_rejected() {
         let path = tmp_path("empty");
         let mut pager = Pager::create(&path).unwrap();
-        let err = write_overflow_chain(&mut pager, &[], 10).unwrap_err();
+        let mut alloc =
+            crate::sql::pager::allocator::PageAllocator::new(std::collections::VecDeque::new(), 10);
+        let err = write_overflow_chain(&mut pager, &[], &mut alloc).unwrap_err();
         assert!(format!("{err}").contains("empty overflow chain"));
         let _ = std::fs::remove_file(&path);
     }

--- a/src/sql/pager/pager.rs
+++ b/src/sql/pager/pager.rs
@@ -306,6 +306,7 @@ impl Pager {
             page_count: 2,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         };
 
         // Write the file synchronously so the initial create is durable and
@@ -664,6 +665,7 @@ mod tests {
                 page_count: 5,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         // 3 dirty data pages (pages 2, 3, 4). The page-0 commit frame is
@@ -679,6 +681,7 @@ mod tests {
                 page_count: 5,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         assert_eq!(writes, 1, "only the changed page should have been written");
@@ -739,6 +742,7 @@ mod tests {
             page_count: 5,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
 
@@ -760,6 +764,7 @@ mod tests {
             page_count: 3,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
 
@@ -792,6 +797,7 @@ mod tests {
                 page_count: 4,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         }
@@ -817,6 +823,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         }
@@ -853,6 +860,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         assert_eq!(first, 1);
@@ -864,6 +872,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         assert_eq!(second, 0, "no data frames should be re-appended");
@@ -887,6 +896,7 @@ mod tests {
             page_count: 4,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
 
@@ -928,6 +938,7 @@ mod tests {
             page_count: 3,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
 
@@ -953,6 +964,7 @@ mod tests {
             page_count: 5,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
         p.checkpoint().unwrap();
@@ -966,6 +978,7 @@ mod tests {
             page_count: 3,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
         p.checkpoint().unwrap();
@@ -1000,6 +1013,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         }
@@ -1034,6 +1048,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         }
@@ -1091,6 +1106,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         }
@@ -1101,6 +1117,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap_err();
         assert!(
@@ -1133,6 +1150,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
             // Force the WAL into the main file before we nuke it.
@@ -1166,6 +1184,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
             // Manually write the committed page 2 into the main file at
@@ -1210,6 +1229,7 @@ mod tests {
                 page_count: 3,
                 schema_root_page: 1,
                 format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+                freelist_head: 0,
             })
             .unwrap();
         }
@@ -1226,6 +1246,7 @@ mod tests {
             page_count: 3,
             schema_root_page: 1,
             format_version: crate::sql::pager::header::FORMAT_VERSION_BASELINE,
+            freelist_head: 0,
         })
         .unwrap();
         let post = std::fs::metadata(wal_path_for(&path)).unwrap().len();


### PR DESCRIPTION
## Summary

- Adds a SQLite-style persisted free-page list at `header.freelist_head` (bytes [28..32], format version v6 on demand) plus a new `FreelistTrunk` page type. After `DROP TABLE` / `DROP INDEX` / `ALTER TABLE DROP COLUMN`, the dropped object's pages move onto the freelist instead of triggering a global page-number renumber.
- Replaces `save_database`'s linear `next_free_page` counter with a [`PageAllocator`](src/sql/pager/allocator.rs) that draws from per-table preferred pools → global freelist → file extension. Unrelated tables keep their page numbers across drops, so the diff pager skips writing their byte-identical leaves.
- New `VACUUM;` SQL statement ([executor.rs](src/sql/executor.rs:720), [mod.rs dispatch](src/sql/mod.rs)) compacts the file by ignoring both pools and allocating linearly from page 1, then double-checkpoints so the on-disk shrink is visible immediately. Bare `VACUUM;` only — modifiers rejected.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` — no new errors
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` — 441 tests pass (9 new SQLR-6 tests + 11 unit tests for allocator/freelist)
- [x] `cargo doc --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --no-deps` builds clean
- [x] REPL smoke test: create 2 tables, populate, `DROP TABLE accounts; VACUUM;` → reports `2 pages reclaimed (8192 bytes)`, file shrinks on disk, reopen confirms remaining table's rows intact

## Out of scope (follow-up tickets to be filed)

- Auto-VACUUM after every drop (the task explicitly defers this — wait for usage data).
- Cross-session freelist reconciliation beyond fs2 advisory locks.
- Bounded `on_disk` cache (pre-existing pager limitation, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)