### PR TITLE
fix(storage): pre-collect preferred-pool pages before staging (SQLR-1)

### DIFF
--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -139,6 +139,8 @@ body           variable        depends on kind_tag
 
 The shared prefix means `Cell::peek_rowid` works uniformly across all kinds — useful for binary search over a page's slot directory without decoding full bodies.
 
+**Decoder dispatch is per-B-tree, not per-cell.** Each B-Tree owns one cell kind on its leaves: table B-Trees carry `Local`/`Overflow` cells (decoded via `PagedEntry::decode`), secondary-index B-Trees carry `Index` cells (`IndexCell::decode`), HNSW carries `HNSW` cells (`HnswNodeCell::decode`), FTS carries `FTS Posting` cells (`FtsPostingCell::decode`), and every interior node — regardless of the leaf kind below it — carries `Interior` divider cells (`InteriorCell::decode`). Callers must dispatch on the *page's owning B-Tree*, not on the kind tag they happen to see; pointing the wrong decoder at a leaf yields an `Internal` error that names both the offending kind and the B-Tree it belongs to (SQLR-1).
+
 ### Local cell body
 
 ```

--- a/src/sql/pager/mod.rs
+++ b/src/sql/pager/mod.rs
@@ -267,6 +267,43 @@ fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Res
         read_old_rootpages(&pager, old_header.schema_root_page)?
     };
 
+    // SQLR-1 — snapshot every prior B-Tree's page set NOW, before any
+    // staging starts. `Pager::read_page` shadows on-disk bytes with the
+    // current `staged` buffer, so if we deferred these walks until each
+    // object's turn in the staging loop, a *new* index added in this
+    // save would extend past the old high-water and overwrite the
+    // pages of any later-staged object whose old root sits in that
+    // range — including `sqlrite_master`, which is always staged last.
+    // The follow-up walk would then read the wrong B-Tree's bytes and
+    // either hand the allocator a bogus preferred pool or panic
+    // dispatching cells (a table-cell decoder vs. an index leaf, the
+    // shape of the original SQLR-1 panic). Walking up front pins each
+    // map to the committed bytes that were on disk before this save
+    // touched anything.
+    let old_preferred_pages: HashMap<(String, String), Vec<u32>> = if compact {
+        HashMap::new()
+    } else {
+        let mut map: HashMap<(String, String), Vec<u32>> = HashMap::new();
+        for ((kind, name), &root) in &old_rootpages {
+            // Tables can carry overflow chains; index/HNSW/FTS leaves
+            // never overflow in the current encoding, so the cheaper
+            // walk suffices for them.
+            let follow = kind == "table";
+            let pages = collect_pages_for_btree(&pager, root, follow)?;
+            map.insert((kind.clone(), name.clone()), pages);
+        }
+        map
+    };
+    let old_master_pages: Vec<u32> = if compact || old_header.schema_root_page == 0 {
+        Vec::new()
+    } else {
+        collect_pages_for_btree(
+            &pager,
+            old_header.schema_root_page,
+            /*follow_overflow=*/ true,
+        )?
+    };
+
     pager.clear_staged();
 
     // Allocator: in normal mode, seed with the old freelist; in compact
@@ -292,10 +329,8 @@ fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Res
             )));
         }
         if !compact {
-            if let Some(&prev_root) = old_rootpages.get(&("table".to_string(), name.to_string())) {
-                let prev =
-                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ true)?;
-                alloc.set_preferred(prev);
+            if let Some(prev) = old_preferred_pages.get(&("table".to_string(), name.to_string())) {
+                alloc.set_preferred(prev.clone());
             }
         }
         let table = &db.tables[name];
@@ -322,12 +357,10 @@ fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Res
         .sort_by(|(ta, ia), (tb, ib)| ta.tb_name.cmp(&tb.tb_name).then(ia.name.cmp(&ib.name)));
     for (_table, idx) in index_entries {
         if !compact {
-            if let Some(&prev_root) =
-                old_rootpages.get(&("index".to_string(), idx.name.to_string()))
+            if let Some(prev) =
+                old_preferred_pages.get(&("index".to_string(), idx.name.to_string()))
             {
-                let prev =
-                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ false)?;
-                alloc.set_preferred(prev);
+                alloc.set_preferred(prev.clone());
             }
         }
         let rootpage = stage_index_btree(&mut pager, idx, &mut alloc)?;
@@ -359,12 +392,10 @@ fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Res
         .sort_by(|(ta, ea), (tb, eb)| ta.tb_name.cmp(&tb.tb_name).then(ea.name.cmp(&eb.name)));
     for (table, entry) in hnsw_entries {
         if !compact {
-            if let Some(&prev_root) =
-                old_rootpages.get(&("index".to_string(), entry.name.to_string()))
+            if let Some(prev) =
+                old_preferred_pages.get(&("index".to_string(), entry.name.to_string()))
             {
-                let prev =
-                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ false)?;
-                alloc.set_preferred(prev);
+                alloc.set_preferred(prev.clone());
             }
         }
         let rootpage = stage_hnsw_btree(&mut pager, &entry.index, &mut alloc)?;
@@ -401,12 +432,10 @@ fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Res
     let any_fts = !fts_entries.is_empty();
     for (table, entry) in fts_entries {
         if !compact {
-            if let Some(&prev_root) =
-                old_rootpages.get(&("index".to_string(), entry.name.to_string()))
+            if let Some(prev) =
+                old_preferred_pages.get(&("index".to_string(), entry.name.to_string()))
             {
-                let prev =
-                    collect_pages_for_btree(&pager, prev_root, /*follow_overflow=*/ false)?;
-                alloc.set_preferred(prev);
+                alloc.set_preferred(prev.clone());
             }
         }
         let rootpage = stage_fts_btree(&mut pager, &entry.index, &mut alloc)?;
@@ -442,13 +471,11 @@ fn save_database_with_mode(db: &mut Database, path: &Path, compact: bool) -> Res
             ],
         )?;
     }
-    if !compact && old_header.schema_root_page != 0 {
-        let prev = collect_pages_for_btree(
-            &pager,
-            old_header.schema_root_page,
-            /*follow_overflow=*/ true,
-        )?;
-        alloc.set_preferred(prev);
+    if !compact && !old_master_pages.is_empty() {
+        // Use the page list snapshotted before any staging touched
+        // disk; re-walking here would read whatever a new index
+        // already restaged on top of master's old root (SQLR-1).
+        alloc.set_preferred(old_master_pages.clone());
     }
     let master_root = stage_table_btree(&mut pager, &master, &mut alloc)?;
     alloc.finish_preferred();
@@ -2719,6 +2746,148 @@ mod tests {
         assert!(idx.is_unique);
         assert_eq!(idx.lookup(&Value::Text("a@x".into())).len(), 1);
         assert_eq!(idx.lookup(&Value::Text("b@x".into())).len(), 1);
+
+        cleanup(&path);
+    }
+
+    /// SQLR-1 — `CREATE INDEX` on a wide table must round-trip when the
+    /// index B-tree grows past one leaf and needs an interior level.
+    /// Before the fix, the post-DDL auto-save panicked with
+    /// `Internal("unknown paged-entry kind tag 0x4 …")` because a
+    /// table-cell decoder was being run against an index leaf
+    /// (`KIND_INDEX = 0x04`).
+    ///
+    /// 5 000 rows mirror the original repro from the issue and exceed
+    /// every leaf-fanout cliff for the small `(rowid, value)` cells in
+    /// a TEXT-keyed secondary index.
+    #[test]
+    fn secondary_index_with_interior_level_round_trips() {
+        let path = tmp_path("sqlr1_wide_index");
+        let mut db = Database::new("idx".to_string());
+        db.source_path = Some(path.clone());
+
+        process_command(
+            "CREATE TABLE bloat (id INTEGER PRIMARY KEY, payload TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        // BEGIN/COMMIT collapses 5 000 inserts into one save (matches
+        // `auto_vacuum_setup` and the issue's repro shape).
+        process_command("BEGIN;", &mut db).unwrap();
+        for i in 0..5000 {
+            process_command(
+                &format!("INSERT INTO bloat (payload) VALUES ('p-{i:08}');"),
+                &mut db,
+            )
+            .unwrap();
+        }
+        process_command("COMMIT;", &mut db).unwrap();
+
+        // The DDL that used to panic.
+        process_command("CREATE INDEX idx_p ON bloat (payload);", &mut db).unwrap();
+
+        // Reopen and verify lookups, plus that the index tree actually
+        // grew an interior layer (otherwise this test wouldn't cover the
+        // regression).
+        drop(db);
+        let loaded = open_database(&path, "idx".to_string()).unwrap();
+        let bloat = loaded.get_table("bloat".to_string()).unwrap();
+        let idx = bloat
+            .index_by_name("idx_p")
+            .expect("idx_p should survive close/reopen");
+        assert!(!idx.is_unique);
+
+        // Spot-check the keyspace: first, middle, last value each map
+        // back to exactly the row that carried them.
+        for &(probe_i, expected_rowid) in &[(0i64, 1i64), (2500, 2501), (4999, 5000)] {
+            let value = Value::Text(format!("p-{probe_i:08}"));
+            let hits = idx.lookup(&value);
+            assert_eq!(
+                hits,
+                vec![expected_rowid],
+                "lookup({value:?}) should yield rowid {expected_rowid}",
+            );
+        }
+
+        // Confirm the index tree is multi-level (the regression's
+        // necessary condition) — root must be an `InteriorNode` and
+        // `find_leftmost_leaf` must reach a `TableLeaf` through it.
+        let pager = loaded.pager.as_ref().unwrap();
+        let mut master = build_empty_master_table();
+        load_table_rows(pager, &mut master, pager.header().schema_root_page).unwrap();
+        let idx_root = master
+            .rowids()
+            .into_iter()
+            .find_map(
+                |r| match (master.get_value("name", r), master.get_value("type", r)) {
+                    (Some(Value::Text(name)), Some(Value::Text(kind)))
+                        if name == "idx_p" && kind == "index" =>
+                    {
+                        match master.get_value("rootpage", r) {
+                            Some(Value::Integer(p)) => Some(p as u32),
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                },
+            )
+            .expect("idx_p should appear in sqlrite_master");
+        let root_buf = pager.read_page(idx_root).unwrap();
+        assert_eq!(
+            root_buf[0],
+            PageType::InteriorNode as u8,
+            "5 000-entry index must have an interior root — without one this test wouldn't cover SQLR-1",
+        );
+        let leaf = find_leftmost_leaf(pager, idx_root).unwrap();
+        let leaf_buf = pager.read_page(leaf).unwrap();
+        assert_eq!(leaf_buf[0], PageType::TableLeaf as u8);
+
+        cleanup(&path);
+    }
+
+    /// SQLR-1 follow-on — the page-recycling path between two large
+    /// versions of the same index name must not corrupt cell decoding.
+    /// `DROP INDEX` returns its pages to the freelist; the next
+    /// `CREATE INDEX` is free to reuse them. If the allocator hands an
+    /// old index leaf to a *table* without zeroing it, an upstream
+    /// table walk would see KIND_INDEX cells and panic.
+    #[test]
+    fn drop_then_recreate_wide_index_does_not_panic() {
+        let path = tmp_path("sqlr1_drop_recreate");
+        let mut db = Database::new("idx".to_string());
+        db.source_path = Some(path.clone());
+
+        process_command(
+            "CREATE TABLE bloat (id INTEGER PRIMARY KEY, payload TEXT);",
+            &mut db,
+        )
+        .unwrap();
+        process_command("BEGIN;", &mut db).unwrap();
+        for i in 0..5000 {
+            process_command(
+                &format!("INSERT INTO bloat (payload) VALUES ('p-{i:08}');"),
+                &mut db,
+            )
+            .unwrap();
+        }
+        process_command("COMMIT;", &mut db).unwrap();
+
+        process_command("CREATE INDEX idx_p ON bloat (payload);", &mut db).unwrap();
+        process_command("DROP INDEX idx_p;", &mut db).unwrap();
+        // Recreate from scratch — exercises the recycle path.
+        process_command("CREATE INDEX idx_p ON bloat (payload);", &mut db).unwrap();
+
+        drop(db);
+        let loaded = open_database(&path, "idx".to_string()).unwrap();
+        let bloat = loaded.get_table("bloat".to_string()).unwrap();
+        let idx = bloat
+            .index_by_name("idx_p")
+            .expect("idx_p should survive drop+recreate+reopen");
+        assert_eq!(
+            idx.lookup(&Value::Text("p-00002500".into())),
+            vec![2501],
+            "post-recycle lookup must still resolve correctly",
+        );
 
         cleanup(&path);
     }

--- a/src/sql/pager/overflow.rs
+++ b/src/sql/pager/overflow.rs
@@ -139,8 +139,17 @@ impl PagedEntry {
     }
 
     /// Dispatches on the kind tag and returns the appropriate variant.
+    ///
+    /// Only `KIND_LOCAL` and `KIND_OVERFLOW` are valid here — `PagedEntry`
+    /// is the table-leaf-cell type, so any other kind means a caller
+    /// pointed the wrong decoder at this page (the slot directory layout
+    /// is shared across leaf B-Trees, but secondary-index, HNSW, and
+    /// FTS leaves carry kind-specific cells decoded by `IndexCell::decode`,
+    /// `HnswNodeCell::decode`, and `FtsPostingCell::decode` respectively).
+    /// The named-kind error makes that mistake obvious next time.
     pub fn decode(buf: &[u8], pos: usize) -> Result<(PagedEntry, usize)> {
-        match Cell::peek_kind(buf, pos)? {
+        let kind = Cell::peek_kind(buf, pos)?;
+        match kind {
             KIND_LOCAL => {
                 let (c, n) = Cell::decode(buf, pos)?;
                 Ok((PagedEntry::Local(c), n))
@@ -150,9 +159,38 @@ impl PagedEntry {
                 Ok((PagedEntry::Overflow(r), n))
             }
             other => Err(SQLRiteError::Internal(format!(
-                "unknown paged-entry kind tag {other:#x} at offset {pos}"
+                "PagedEntry::decode at offset {pos} got kind tag {other:#x} ({}); \
+                 expected KIND_LOCAL (0x01) or KIND_OVERFLOW (0x02). \
+                 The caller is reading a {} page with the table-leaf decoder.",
+                kind_name(other),
+                kind_btree_hint(other),
             ))),
         }
+    }
+}
+
+/// Human-readable label for a cell kind tag — used in error messages
+/// to make wrong-decoder mistakes self-explanatory.
+fn kind_name(tag: u8) -> &'static str {
+    match tag {
+        crate::sql::pager::cell::KIND_LOCAL => "KIND_LOCAL",
+        crate::sql::pager::cell::KIND_OVERFLOW => "KIND_OVERFLOW",
+        crate::sql::pager::cell::KIND_INTERIOR => "KIND_INTERIOR",
+        crate::sql::pager::cell::KIND_INDEX => "KIND_INDEX",
+        crate::sql::pager::cell::KIND_HNSW => "KIND_HNSW",
+        crate::sql::pager::cell::KIND_FTS_POSTING => "KIND_FTS_POSTING",
+        _ => "unknown kind",
+    }
+}
+
+/// Hint pointing at which B-Tree owns a cell of the given kind.
+fn kind_btree_hint(tag: u8) -> &'static str {
+    match tag {
+        crate::sql::pager::cell::KIND_INTERIOR => "B-Tree interior",
+        crate::sql::pager::cell::KIND_INDEX => "secondary-index",
+        crate::sql::pager::cell::KIND_HNSW => "HNSW",
+        crate::sql::pager::cell::KIND_FTS_POSTING => "FTS",
+        _ => "non-table",
     }
 }
 
@@ -282,6 +320,50 @@ mod tests {
         let overflow_bytes = overflow.encode();
         let (decoded, _) = PagedEntry::decode(&overflow_bytes, 0).unwrap();
         assert_eq!(decoded, PagedEntry::Overflow(overflow));
+    }
+
+    /// SQLR-1 — `PagedEntry::decode` is the table-leaf-cell decoder.
+    /// Pointing it at a secondary-index leaf used to surface as a
+    /// cryptic `unknown paged-entry kind tag 0x4`. The new error
+    /// message names the offending kind and the B-Tree the caller
+    /// is mistakenly walking.
+    #[test]
+    fn paged_entry_decode_rejects_index_kind_with_clear_error() {
+        use crate::sql::pager::index_cell::IndexCell;
+        let ic = IndexCell::new(42, Value::Text("alice".into()));
+        let bytes = ic.encode().unwrap();
+        let err = PagedEntry::decode(&bytes, 0).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("KIND_INDEX"),
+            "expected error to name KIND_INDEX, got: {msg}",
+        );
+        assert!(
+            msg.contains("secondary-index"),
+            "expected error to identify the secondary-index B-Tree, got: {msg}",
+        );
+    }
+
+    /// Symmetric coverage for HNSW and FTS — same wrong-decoder shape,
+    /// same diagnostic guarantee.
+    #[test]
+    fn paged_entry_decode_rejects_hnsw_and_fts_kinds() {
+        use crate::sql::pager::cell::{KIND_FTS_POSTING, KIND_HNSW};
+        // Build minimal byte sequences carrying the right kind tag at
+        // the right offset. Body content past the kind tag doesn't
+        // matter — we expect the dispatch to short-circuit on the tag.
+        for (tag, hint) in [(KIND_HNSW, "HNSW"), (KIND_FTS_POSTING, "FTS")] {
+            // body_len declared as 1 (the kind tag itself); body is the
+            // tag and nothing else. Honest about what's in the buffer
+            // so a future tightening of `peek_kind` doesn't bite us.
+            let bytes = vec![/*body_len varint=*/ 1u8, tag];
+            let err = PagedEntry::decode(&bytes, 0).unwrap_err();
+            let msg = format!("{err}");
+            assert!(
+                msg.contains(hint),
+                "expected error to identify the {hint} B-Tree, got: {msg}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes SQLR-1: `CREATE INDEX` on a wide table panicked during the post-DDL auto-save with `Internal("unknown paged-entry kind tag 0x4 …")`.
- Root cause: `save_database_with_mode` walked each B-Tree's previous root via `collect_pages_for_btree` *during* the staging loop. `Pager::read_page` shadows on-disk bytes with the in-flight `staged` buffer, so a new index extending past the old high-water would overwrite the pages of any later-staged object — `sqlrite_master` (always staged last) being the canonical victim. The master walk then read the new index's freshly-staged leaf and tripped on `KIND_INDEX = 0x04` going through `PagedEntry::decode`, which only knows `KIND_LOCAL`/`KIND_OVERFLOW`.
- Fix: snapshot every prior B-Tree's page set up front (right after `read_old_rootpages`, before `clear_staged()`), then look those snapshots up in the staging loop instead of re-walking. Master gets its own `old_master_pages` snapshot for the same reason. All five in-loop `collect_pages_for_btree` calls removed.
- Tightens `PagedEntry::decode`'s error to name the offending kind and the B-Tree the caller meant to walk, and documents the per-B-Tree decoder dispatch contract in `docs/file-format.md` so the bug-class doesn't recur.

## Test plan

- [x] New regression test `secondary_index_with_interior_level_round_trips` — 5000-row CREATE INDEX, reopen, lookup spot-checks, asserts root is `InteriorNode` (the regression's necessary condition).
- [x] New regression test `drop_then_recreate_wide_index_does_not_panic` — exercises page recycling between two large versions of the same index name.
- [x] New unit tests `paged_entry_decode_rejects_index_kind_with_clear_error` and `paged_entry_decode_rejects_hnsw_and_fts_kinds` — wrong-decoder error message coverage.
- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets`
- [x] `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` (384 engine + 19 MCP + 12 FFI + all doctests pass)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets` (no new warnings)
- [x] `cargo doc --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --no-deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)