### PR TITLE
Release v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ask"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-desktop"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "env_logger",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ffi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cbindgen",
  "serde",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "libc",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-nodejs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-python"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "pyo3",
  "sqlrite-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "3"
 # `package =` key so the import name stays `sqlrite` internally:
 #     sqlrite = { package = "sqlrite-engine", path = "…" }
 name = "sqlrite-engine"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -138,4 +138,4 @@ fs2 = { version = "0.4", optional = true }
 # crate publishes to crates.io, and a path-only dep without a
 # version field fails the manifest verification step. See PR #58
 # retrospective in docs/roadmap.md.
-sqlrite-ask = { version = "0.5.0", path = "sqlrite-ask", optional = true }
+sqlrite-ask = { version = "0.5.1", path = "sqlrite-ask", optional = true }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlrite-desktop-frontend",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-desktop"
-version = "0.5.0"
+version = "0.5.1"
 description = "SQLRite desktop app — Tauri 2 shell around the engine"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SQLRite",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.sqlrite.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/sdk/nodejs/Cargo.toml
+++ b/sdk/nodejs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-nodejs"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joaoh82/sqlrite",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Node.js bindings for SQLRite — a small, embeddable SQLite clone written in Rust.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-python"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sqlrite"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python bindings for SQLRite — a small, embeddable SQLite clone written in Rust."
 authors = [{ name = "Joao Henrique Machado Silva", email = "joaoh82@gmail.com" }]
 license = { text = "MIT" }

--- a/sdk/wasm/Cargo.toml
+++ b/sdk/wasm/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "sqlrite-wasm"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -46,7 +46,7 @@ sqlrite = { package = "sqlrite-engine", path = "../..", default-features = false
 # builds for wasm32). Per Q9, the WASM SDK never makes the HTTP call
 # itself — the JS caller does that. Browser → backend → LLM provider
 # → JS hands the raw response back to `db.askParse()`.
-sqlrite-ask = { version = "0.5.0", path = "../../sqlrite-ask", default-features = false }
+sqlrite-ask = { version = "0.5.1", path = "../../sqlrite-ask", default-features = false }
 
 # wasm-bindgen + friends. `serde-serialize` on wasm-bindgen gives
 # us `serde_wasm_bindgen` interop for structured row objects.

--- a/sqlrite-ask/Cargo.toml
+++ b/sqlrite-ask/Cargo.toml
@@ -10,7 +10,7 @@
 # Published to crates.io as `sqlrite-ask`. Joins the lockstep release
 # wave (`sqlrite-ask-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-ask"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-ffi/Cargo.toml
+++ b/sqlrite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-ffi"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-mcp/Cargo.toml
+++ b/sqlrite-mcp/Cargo.toml
@@ -18,7 +18,7 @@
 # Published to crates.io as `sqlrite-mcp`. Joins the lockstep
 # release wave (`sqlrite-mcp-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-mcp"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -52,7 +52,7 @@ ask = ["sqlrite/ask"]
 # off (which excludes the `cli` feature and its rustyline/clap pull
 # weight) and only enable `ask` when our own `ask` feature is on.
 # Keeps the MCP binary small + boot-fast.
-sqlrite = { package = "sqlrite-engine", path = "..", version = "0.5.0", default-features = false }
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.5.1", default-features = false }
 
 # JSON-RPC + tool I/O. The MCP wire format is JSON in / JSON out;
 # tool argument schemas are JSON; tool results are JSON. serde +


### PR DESCRIPTION
Bumps every product to `v0.5.1` (previously `v0.5.0`). Patch release covering the SQLR-1 fix.

## Included since v0.5.0

- [#93](https://github.com/joaoh82/rust_sqlite/pull/93) — fix(storage): pre-collect preferred-pool pages before staging (SQLR-1). Resolves the `unknown paged-entry kind tag 0x4` panic on `CREATE INDEX` against tables large enough to need a multi-page secondary-index B-Tree, plus a clearer wrong-decoder error message.

## Test plan

- [x] `scripts/bump-version.sh 0.5.1` (13 manifests touched, plus `Cargo.lock` refresh)
- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs` clean
- [ ] CI green on this PR

## What merging triggers

`release.yml` runs against the merge commit:
1. Tags `sqlrite-v0.5.1`, `sqlrite-ffi-v0.5.1`, and umbrella `v0.5.1`.
2. Publishes the Rust crates (`sqlrite-engine`, `sqlrite-ffi`, `sqlrite-ask`).
3. Publishes the Python (PyPI), Node (npm), and WASM (npm) SDKs.
4. Creates the umbrella `v0.5.1` GitHub Release with auto-generated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)