### PR TITLE
feat(bench): harness scaffolding + W1 read-by-PK (sub-phase 9.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,20 @@ jobs:
       #   rlib targets (unresolved Python/Node symbols). The per-SDK
       #   `python-sdk` + `nodejs-sdk` jobs below exercise these
       #   crates through their native tooling (maturin / napi-rs).
+      #
+      # - `sqlrite-benchmarks` is the SQLR-4 / SQLR-16 bench harness.
+      #   Excluded from CI for two reasons: criterion benches are
+      #   noisy on shared GitHub runners (the published numbers come
+      #   from a pinned local host per Q1), and the bundled rusqlite
+      #   build pulls in a heavy C toolchain that we don't want to
+      #   pay on every PR. Run locally with `make bench`.
       - name: cargo build
         run: |
           cargo build --workspace \
             --exclude sqlrite-desktop \
             --exclude sqlrite-python \
             --exclude sqlrite-nodejs \
+            --exclude sqlrite-benchmarks \
             --all-targets
 
       - name: cargo test
@@ -104,7 +112,8 @@ jobs:
           cargo test --workspace \
             --exclude sqlrite-desktop \
             --exclude sqlrite-python \
-            --exclude sqlrite-nodejs
+            --exclude sqlrite-nodejs \
+            --exclude sqlrite-benchmarks
 
   # ---------------------------------------------------------------------------
   # Rust: lint — fmt + clippy + doc. One cell (ubuntu) because these
@@ -140,6 +149,7 @@ jobs:
             --exclude sqlrite-desktop \
             --exclude sqlrite-python \
             --exclude sqlrite-nodejs \
+            --exclude sqlrite-benchmarks \
             --all-targets
 
       - name: cargo doc
@@ -150,6 +160,7 @@ jobs:
             --exclude sqlrite-desktop \
             --exclude sqlrite-python \
             --exclude sqlrite-nodejs \
+            --exclude sqlrite-benchmarks \
             --no-deps
 
   # ---------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,14 @@ SQLRite is a from-scratch SQLite-style embedded database written in Rust. It's p
 
 ## Workspace layout
 
-`Cargo.toml` is a workspace whose members are: `.` (the engine, package `sqlrite-engine`, lib `sqlrite`), `desktop/src-tauri`, `sqlrite-ffi`, `sqlrite-ask`, `sqlrite-mcp`, `sdk/python`, `sdk/nodejs`. `sdk/wasm` and `sdk/go` are deliberately **not** workspace members (wasm32 target / cgo separation).
+`Cargo.toml` is a workspace whose members are: `.` (the engine, package `sqlrite-engine`, lib `sqlrite`), `desktop/src-tauri`, `sqlrite-ffi`, `sqlrite-ask`, `sqlrite-mcp`, `sdk/python`, `sdk/nodejs`, `benchmarks`. `sdk/wasm` and `sdk/go` are deliberately **not** workspace members (wasm32 target / cgo separation).
 
 - `src/` — engine. Public API is `Connection`/`Statement`/`Rows`/`Row`/`Value` from [src/connection.rs](src/connection.rs), re-exported via [src/lib.rs](src/lib.rs). Any new SDK should bind only to this surface.
 - `sqlrite-ask/` — pure-Rust LLM adapter (Anthropic/OpenAI/Ollama) for natural-language → SQL. The engine's `ask` feature provides the thin `ConnectionAskExt::ask` glue.
 - `sqlrite-mcp/` — MCP stdio server. Seven tools: `list_tables`, `describe_table`, `query`, `execute`, `schema_dump`, `vector_search`, `ask`. `--read-only` opens with a shared lock and hides `execute`.
 - `sqlrite-ffi/` — C ABI cdylib + generated `sqlrite.h` header. Backs the Go SDK and any C consumer.
 - `desktop/` — Tauri 2 + Svelte 5 GUI. Embeds the engine directly (no FFI hop).
+- `benchmarks/` — SQLR-4 / SQLR-16 bench harness. `Driver` trait + SQLRite + SQLite (rusqlite-bundled) drivers + criterion-driven workloads. Excluded from the default CI build/test/clippy/doc commands; run locally with `make bench` (or `make bench-duckdb`). See [docs/benchmarks-plan.md](docs/benchmarks-plan.md).
 
 Architecture deep-dive: [docs/architecture.md](docs/architecture.md). The full doc index is [docs/_index.md](docs/_index.md).
 
@@ -24,20 +25,20 @@ SQL string → [src/sql/mod.rs](src/sql/mod.rs) `process_command` parses with th
 
 ## Commands
 
-CI is the source of truth — the workspace excludes that follow are required because the desktop crate needs a Svelte build first and the PyO3/napi-rs cdylibs can't link standalone test binaries.
+CI is the source of truth — the workspace excludes that follow are required because the desktop crate needs a Svelte build first, the PyO3/napi-rs cdylibs can't link standalone test binaries, and the `benchmarks/` harness deliberately stays out of CI (criterion is noisy on shared runners; the rusqlite-bundled build is heavy).
 
 ```sh
 # Build / test the Rust workspace (matches CI)
-cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets
-cargo test  --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs
+cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --all-targets
+cargo test  --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks
 
 # Single test (exact name; --nocapture to see println!)
 cargo test <test_name> -- --nocapture
 
 # Lint (CI runs all three)
 cargo fmt --all -- --check
-cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --all-targets
-cargo doc    --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --no-deps
+cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --all-targets
+cargo doc    --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --no-deps
 
 # Run the REPL (default features include cli + ask + file-locks)
 cargo run                                  # in-memory
@@ -48,6 +49,10 @@ cargo run -- --readonly path/to/db.sqlrite # shared-lock open
 cargo build --release -p sqlrite-ffi       # C cdylib + sqlrite.h
 cd desktop && npm install && npm run tauri dev   # desktop app dev mode
 cargo run -p sqlrite-mcp -- /path/to.sqlrite     # MCP server (stdio)
+
+# Benchmarks (SQLR-4 / SQLR-16) — local-only, never CI
+make bench                                 # SQLRite + SQLite (lean)
+# make bench-duckdb                        # adds DuckDB driver (Group B only) — lands in 9.5
 
 # Release plumbing
 scripts/bump-version.sh 0.2.0              # bumps version across 11 manifests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbindgen"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +419,33 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -557,6 +596,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +644,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -881,6 +961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1053,18 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1468,6 +1566,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1596,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -1854,6 +1972,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2203,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91632f3b4fb6bd1d72aa3d78f41ffecfcf2b1a6648d8c241dbe7dbfaf4875e15"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2519,6 +2657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2788,6 +2932,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -3313,6 +3485,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,6 +4010,22 @@ dependencies = [
  "thiserror 2.0.18",
  "tiny_http",
  "ureq",
+]
+
+[[package]]
+name = "sqlrite-benchmarks"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "criterion",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sqlrite-engine",
+ "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -4507,6 +4709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4897,6 +5109,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@
 # wasm32-unknown-unknown. `cargo build --workspace` on a native host
 # would fail on a wasm-only crate; wasm-pack drives that build
 # separately.
-members = [".", "desktop/src-tauri", "sqlrite-ffi", "sqlrite-ask", "sqlrite-mcp", "sdk/python", "sdk/nodejs"]
+members = [".", "desktop/src-tauri", "sqlrite-ffi", "sqlrite-ask", "sqlrite-mcp", "sdk/python", "sdk/nodejs", "benchmarks"]
 resolver = "3"
 
 [package]

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,13 @@ code-lines:
 generate-docs:
 	@echo '${GREEN}Generating${RESET} ${YELLOW}documentation ${RESET} for SQLRite'
 	@cargo doc --open
+
+.PHONY: bench
+## Run the benchmark suite (SQLR-4 / SQLR-16) — SQLRite vs SQLite (lean)
+bench:
+	@echo '${GREEN}Running${RESET} ${YELLOW}benchmark suite${RESET} (SQLRite vs SQLite, lean profile)'
+	@./benchmarks/scripts/run.sh
+
+# `make bench-duckdb` lands alongside the DuckDB driver in sub-phase 9.5
+# (Group B only). Until then, the `duckdb` feature isn't declared on
+# the bench crate so invoking it would be a build error.

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,83 @@
+[package]
+# SQLR-4 / SQLR-16 — benchmark suite for SQLRite vs SQLite (and friends).
+# See `docs/benchmarks-plan.md` for the canonical design + decisions.
+#
+# Not published to crates.io. Not built by default in CI — the engine's
+# `rust-build-and-test` job carries an `--exclude sqlrite-benchmarks`
+# alongside `sqlrite-desktop` because criterion benches don't make sense
+# in CI (noisy on shared runners) and the heavy `rusqlite[bundled]`
+# build is also undesirable on every PR.
+#
+# Run locally with `make bench` (lean: SQLRite + SQLite only) or
+# `make bench-duckdb` (adds the optional DuckDB driver for Group B).
+name = "sqlrite-benchmarks"
+version = "0.0.0"
+authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
+edition = "2024"
+rust-version = "1.85"
+publish = false
+description = "Benchmark suite — SQLRite vs SQLite (and friends). Not for crates.io."
+license = "MIT"
+
+[lib]
+name = "sqlrite_benchmarks"
+path = "src/lib.rs"
+
+# Aggregator binary — walks `target/criterion/` after `cargo bench` and
+# emits a single results JSON file under `benchmarks/results/`. Run via
+# `scripts/run.sh` (which `make bench` invokes); not for direct use.
+[[bin]]
+name = "aggregate"
+path = "src/bin/aggregate.rs"
+
+# Single criterion entry point. Fans out (workload × driver) pairs via
+# the `Driver` trait. Adding a workload = one file in `src/workloads/`
+# + one register-call in this entry point.
+[[bench]]
+name = "suite"
+path = "benches/suite.rs"
+harness = false
+
+[features]
+default = []
+
+# `duckdb` feature lands alongside the driver in sub-phase 9.5
+# (Group B only). Heavy dep — keeping it out of the dep graph until
+# the driver is actually wired up.
+
+[dependencies]
+# The engine. Default features off (no rustyline / clap / `ask`), but
+# `file-locks` is on so the comparison runs the same lock-acquisition
+# path that any real SQLRite consumer pays.
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.8.0", default-features = false, features = ["file-locks"] }
+
+# SQLite via rusqlite, with `bundled` so the comparison is against a
+# known SQLite version (not whatever happens to be on the host).
+# `extra_check` and `column_decltype` would be nice-to-have but cost
+# binary size; skipping until a workload needs them.
+rusqlite = { version = "0.36", features = ["bundled"] }
+
+# Criterion for the actual measurement loop. v0.5 ships HDR-style
+# sampling, statistical confidence intervals, and JSON output to
+# `target/criterion/` that the `aggregate` binary harvests.
+criterion = { version = "0.5", default-features = false, features = ["plotters", "cargo_bench_support"] }
+
+# Deterministic data generation (Q8: workloads versioned; the seed is
+# part of the workload's contract so v1 inputs reproduce byte-for-byte).
+rand = "0.8"
+rand_chacha = "0.3"
+
+# JSON envelope for `benchmarks/results/*.json`.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Per-run temp dirs so each iteration starts from a clean DB file.
+# Prevents page-cache / WAL-state bleed across runs.
+tempfile = "3"
+
+# Anyhow for driver-level error reporting. The bench harness is
+# end-user code; we don't need to surface a typed error ladder.
+anyhow = "1"
+
+# Walk `target/criterion/` for the aggregator binary.
+walkdir = "2"

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,117 @@
+# SQLRite benchmarks
+
+Benchmark suite for SQLRite vs SQLite (and friends). Tracks task **SQLR-4** / **SQLR-16**.
+
+> **Status (2026-05-06):** sub-phase 9.1 landed — harness + W1. W2–W12 land in 9.2–9.4. The first official pinned-host JSON gets committed in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
+
+## Quick start
+
+```sh
+# From repo root.
+make bench                  # SQLRite + SQLite (lean, ~4 min)
+# make bench-duckdb         # adds DuckDB driver (Group B only) — lands in 9.5
+```
+
+Each invocation runs the criterion suite, then aggregates the per-bench JSON criterion writes under `target/criterion/` into a single envelope under [`results/`](results/), keyed by date + host fingerprint + commit short-SHA. The shape is locked in [`src/envelope.rs`](src/envelope.rs).
+
+## Why this exists
+
+Three drivers, in plan order:
+
+1. **Decision support for the engine roadmap.** Concrete numbers for "is the bottom-up B-tree rebuild the bottleneck or is the executor's row reassembly?", informing whether LSM/SSTable engine work or executor refactors come first.
+2. **Differentiator validation.** Phase 7d's HNSW, Phase 8's BM25, and Phase 8d's hybrid retrieval shipped without comparable numbers. W10–W12 publish absolute latencies for the "SQLRite for RAG" pitch.
+3. **Regression detection.** JSON output is shaped so a future per-PR regression detector can mechanically diff `main` vs branch (parked as a post-9.6 follow-up — needs ~3 baseline runs first).
+
+## Workloads
+
+Three groups (full descriptions in [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md#workloads)):
+
+- **Group A — OLTP baseline.** W1 read-by-PK, W2 range scan, W3 bulk insert, W4 single-row insert, W5 mixed OLTP, W6 index lookup. Lands in 9.1 (W1) + 9.2.
+- **Group B — SQL-feature scaling.** W7 aggregate, W8 GROUP BY, W9 INNER JOIN. Lands in 9.3.
+- **Group C — Differentiators.** W10 vector top-10, W11 BM25 top-10, W12 hybrid retrieval. Lands in 9.4.
+
+Workloads are versioned (`W1.v1`, `W1.v2`, …) per Q8 — bumping the version is the explicit "I changed the benchmark" gesture.
+
+## Drivers
+
+| Engine | Crate | Profile | Status |
+|---|---|---|---|
+| SQLRite | `sqlrite-engine` (path dep, `default-features = false` + `file-locks`) | Default | ✅ 9.1 |
+| SQLite | `rusqlite` v0.36 (bundled libsqlite3) | `WAL` + `synchronous=NORMAL` + 64 MB cache + `temp_store=MEMORY` (Q3 — tuned headline) | ✅ 9.1 |
+| DuckDB | `duckdb-rs` | Defaults | 🟡 9.5, opt-in via `--features duckdb` |
+| libSQL | — | — | 🟡 deferred (post-9.6) |
+
+The SQLite driver runs the **tuned profile** as the headline (Q3). A SQLite-default column is opt-in, post-9.6.
+
+## Results
+
+Each `make bench` invocation drops a JSON file under `results/`. The `.gitignore` keeps casual local runs out of git; the first "official" pinned-host run gets committed in sub-phase 9.6.
+
+The table below is updated as new workloads land. Numbers are placeholders until 9.6 commits an official pinned-host run; ratios shown here are illustrative output from the sub-phase 9.1 development run on the project owner's M-series MBP.
+
+### W1 — read-by-PK (`SELECT name, payload FROM kv WHERE id = ?`)
+
+100k-row table, 10k random keys, in-process, prepared statement on the SQLite side / per-call parse on the SQLRite side (no parameter binding yet — see [`src/drivers/sqlrite.rs`](src/drivers/sqlrite.rs)).
+
+| Engine | Median latency | Throughput (ops/s) | Notes |
+|---|---|---|---|
+| SQLRite (this branch) | ~12 µs | ~84k | Per-iter parse + plan; no prepared params yet |
+| SQLite (rusqlite, WAL+NORMAL) | ~2.5 µs | ~395k | `prepare_cached` + bound `?` params |
+
+**Read this as:** SQLRite is ~5× slower than SQLite on the hottest-path SELECT-by-PK on a sub-µs-per-op workload. Most of that gap is per-iteration parsing — SQLRite has no prepared-plan cache, so every iteration walks the `sqlparser` AST again. A future "prepared statement support" follow-up will tighten this; the W1 number is the baseline that work needs to move.
+
+> Replace these numbers with the official pinned-host run that lands in 9.6. The sample command above also writes raw criterion HTML reports to `target/criterion/` for the curious — open `target/criterion/report/index.html`.
+
+## Adding a workload
+
+Per the [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md#sub-phases) sequencing:
+
+1. New file `src/workloads/<name>.rs` — `pub const W*: WorkloadId`, `setup`, `bench_iter`, `correctness_check`.
+2. Register in `src/workloads/mod.rs` (`pub mod <name>;`).
+3. One `register_*` function in `benches/suite.rs` that builds the (workload × driver) bench groups.
+4. Add a row to the table above with the new measured numbers.
+
+If the workload's shape changes between releases (added column, different query plan target), bump the `version` in the `WorkloadId`. Old JSON results stay readable; the comparison script (`scripts/compare.py`, lands in 9.6) only diffs same-version pairs.
+
+## Adding a driver
+
+1. New file `src/drivers/<name>.rs` implementing the `Driver` trait.
+2. Add to `src/drivers/mod.rs`.
+3. Register on each workload in `benches/suite.rs`.
+
+Driver-bias is a known risk (see `docs/benchmarks-plan.md` "Risks + things to watch") — review every implementation against the question "is this how a perf-conscious user of `<engine>` would write it?"
+
+## Layout
+
+```
+benchmarks/
+├── Cargo.toml             — workspace member, not published, excluded from CI
+├── README.md              — this file
+├── src/
+│   ├── lib.rs             — Driver trait, Value type, BenchSample
+│   ├── envelope.rs        — JSON output schema (locked in 9.1)
+│   ├── data.rs            — deterministic dataset generators (seeded ChaCha8)
+│   ├── drivers/
+│   │   ├── mod.rs
+│   │   ├── sqlrite.rs     — engine-side driver (inlines params)
+│   │   ├── sqlite.rs      — rusqlite + Q3 tuned profile
+│   │   └── duckdb.rs      — feature-gated; lands in 9.5
+│   ├── workloads/
+│   │   ├── mod.rs
+│   │   └── kv.rs          — W1 read-by-PK (this PR)
+│   └── bin/
+│       └── aggregate.rs   — walks target/criterion/ → results/*.json
+├── benches/
+│   └── suite.rs           — single criterion entry point
+├── scripts/
+│   └── run.sh             — make bench → cargo bench + aggregator
+└── results/
+    ├── .gitkeep
+    └── .gitignore         — keeps local runs out of git until 9.6
+```
+
+## See also
+
+- [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) — canonical design + decisions.
+- [`docs/architecture.md`](../docs/architecture.md) — engine layer map; benchmarks bind to the public `Connection` surface only.
+- [`docs/roadmap.md`](../docs/roadmap.md) — broader project roadmap; SQLR-4 lives under "Possible extras."

--- a/benchmarks/benches/suite.rs
+++ b/benchmarks/benches/suite.rs
@@ -1,0 +1,65 @@
+//! Single criterion entry point — fans out (workload × driver) pairs.
+//!
+//! Adding a workload = one file under `src/workloads/` + one
+//! `register_w*` call below. Adding a driver = one file under
+//! `src/drivers/` + adding it to the per-workload register call.
+//!
+//! Each bench:
+//! 1. Creates a fresh `TempDir` (per-run isolation — no page-cache /
+//!    WAL-state bleed across iterations).
+//! 2. Calls the workload's `setup` once **outside** `b.iter` —
+//!    setup cost (CREATE TABLE, INSERT 100k rows) shouldn't pollute
+//!    the per-iter measurement.
+//! 3. Runs the workload's `correctness_check` once. If the engine
+//!    returns the wrong shape, we fail fast rather than publish a
+//!    "speedup" that's just a bug.
+//! 4. Times `bench_iter` via `b.iter` over a pre-shuffled key slice.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use sqlrite_benchmarks::Driver;
+use sqlrite_benchmarks::drivers::sqlite::SQLiteDriver;
+use sqlrite_benchmarks::drivers::sqlrite::SQLRiteDriver;
+use sqlrite_benchmarks::workloads::kv as w1;
+
+fn register_w1<D: Driver>(c: &mut Criterion, driver: D, suffix: &str) {
+    let tmp = tempfile::Builder::new()
+        .prefix(&format!("sqlrite-bench-w1-{suffix}-"))
+        .tempdir()
+        .expect("tempdir");
+    let db_path = tmp.path().join(match driver.name() {
+        // Use the engine's native extension so a half-debugged DB is
+        // recognizable on disk.
+        "sqlite" => "w1.sqlite",
+        "duckdb" => "w1.duckdb",
+        _ => "w1.sqlrite",
+    });
+    let (mut conn, keys) = w1::setup(&driver, &db_path).expect("W1 setup");
+    w1::correctness_check(&driver, &mut conn).expect("W1 correctness check");
+
+    let mut group = c.benchmark_group(w1::W1.full());
+    let bench_id = format!("{}/{}", driver.name(), suffix);
+    let mut idx = 0usize;
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let key = keys[idx % keys.len()];
+            idx = idx.wrapping_add(1);
+            let row = w1::bench_iter(&driver, &mut conn, key).expect("W1 query");
+            black_box(row)
+        });
+    });
+    group.finish();
+
+    // Keep tempdir alive until all benches finished — drop here.
+    drop(conn);
+    drop(tmp);
+}
+
+fn benches(c: &mut Criterion) {
+    register_w1(c, SQLRiteDriver, "default");
+    register_w1(c, SQLiteDriver, "default");
+}
+
+criterion_group!(suite, benches);
+criterion_main!(suite);

--- a/benchmarks/results/.gitignore
+++ b/benchmarks/results/.gitignore
@@ -1,0 +1,7 @@
+# Local bench runs land here. Only the "official" pinned-host runs
+# get committed (lands in 9.6 — see `docs/benchmarks-plan.md`). Until
+# 9.6, ignore everything except this rule + .gitkeep so the directory
+# stays in git.
+*
+!.gitkeep
+!.gitignore

--- a/benchmarks/scripts/run.sh
+++ b/benchmarks/scripts/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Run the SQLRite benchmark suite + aggregate criterion's per-bench
+# JSON into one results envelope under benchmarks/results/.
+#
+# Invoked by `make bench` (lean: SQLRite + SQLite). The DuckDB-extended
+# variant is `make bench-duckdb`; same script with FEATURES=duckdb.
+#
+# Usage:
+#   scripts/run.sh                 # default: lean profile
+#   FEATURES=duckdb scripts/run.sh # adds the DuckDB driver
+#   OUTPUT=path/to.json scripts/run.sh
+#
+# Exits non-zero on failure; prints the path to the emitted results JSON.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FEATURES="${FEATURES:-}"
+OUTPUT="${OUTPUT:-}"
+RUN_STARTED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+START_EPOCH="$(date -u '+%s')"
+
+echo "==> running cargo bench (-p sqlrite-benchmarks${FEATURES:+ --features $FEATURES})"
+if [ -n "$FEATURES" ]; then
+  cargo bench -p sqlrite-benchmarks --features "$FEATURES"
+else
+  cargo bench -p sqlrite-benchmarks
+fi
+
+END_EPOCH="$(date -u '+%s')"
+DURATION_SECS="$((END_EPOCH - START_EPOCH))"
+
+echo "==> aggregating criterion output → results JSON"
+AGG_ARGS=(
+  --criterion-dir "target/criterion"
+  --run-started-at "$RUN_STARTED_AT"
+  --run-duration-secs "$DURATION_SECS"
+)
+if [ -n "$OUTPUT" ]; then
+  AGG_ARGS+=(--output "$OUTPUT")
+fi
+
+cargo run -p sqlrite-benchmarks --bin aggregate --quiet -- "${AGG_ARGS[@]}"

--- a/benchmarks/src/bin/aggregate.rs
+++ b/benchmarks/src/bin/aggregate.rs
@@ -1,0 +1,381 @@
+//! Aggregator binary — walks `target/criterion/` after `cargo bench`
+//! and emits a single results JSON file under `benchmarks/results/`.
+//!
+//! Run via `scripts/run.sh` (which `make bench` invokes), not directly.
+//! Usage:
+//!
+//! ```text
+//! aggregate --criterion-dir <path> --output <path> --run-started-at <RFC3339>
+//! ```
+//!
+//! `criterion-dir` defaults to `target/criterion`. `output` defaults
+//! to a date-host-commit file under `benchmarks/results/`.
+//!
+//! Criterion writes per-bench `estimates.json` files at
+//! `<group>/<bench_id>/new/estimates.json`. We harvest each one,
+//! reconstruct the (workload, driver) pair from the directory name,
+//! and emit one [`BenchSample`] per pair into a [`ResultsEnvelope`].
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::SystemTime;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use sqlrite_benchmarks::BenchSample;
+use sqlrite_benchmarks::envelope::{CommitInfo, HostInfo, ResultsEnvelope, SCHEMA_VERSION};
+use walkdir::WalkDir;
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let mut criterion_dir = PathBuf::from("target/criterion");
+    let mut output: Option<PathBuf> = None;
+    let mut run_started_at: Option<String> = None;
+    let mut run_duration_secs: Option<f64> = None;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--criterion-dir" => {
+                criterion_dir = PathBuf::from(args.next().context("--criterion-dir <path>")?);
+            }
+            "--output" => {
+                output = Some(PathBuf::from(args.next().context("--output <path>")?));
+            }
+            "--run-started-at" => {
+                run_started_at = Some(args.next().context("--run-started-at <rfc3339>")?);
+            }
+            "--run-duration-secs" => {
+                run_duration_secs = Some(
+                    args.next()
+                        .context("--run-duration-secs <secs>")?
+                        .parse()
+                        .context("--run-duration-secs parse")?,
+                );
+            }
+            "--help" | "-h" => {
+                println!(
+                    "usage: aggregate [--criterion-dir <path>] [--output <path>] \
+                     [--run-started-at <rfc3339>] [--run-duration-secs <secs>]"
+                );
+                return Ok(());
+            }
+            other => anyhow::bail!("unknown argument: {other}"),
+        }
+    }
+
+    if !criterion_dir.exists() {
+        anyhow::bail!(
+            "criterion output dir {} does not exist — did `cargo bench` run?",
+            criterion_dir.display()
+        );
+    }
+
+    let host = host_info();
+    let commit = commit_info();
+    let samples = collect_samples(&criterion_dir)?;
+    let envelope = ResultsEnvelope {
+        schema_version: SCHEMA_VERSION,
+        run_started_at: run_started_at.unwrap_or_else(now_rfc3339),
+        run_duration_secs: run_duration_secs.unwrap_or(0.0),
+        host: host.clone(),
+        commit: commit.clone(),
+        samples,
+    };
+
+    let output = output.unwrap_or_else(|| default_output_path(&host, &commit));
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("mkdir -p {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(&envelope)?;
+    fs::write(&output, json).with_context(|| format!("write {}", output.display()))?;
+    println!(
+        "wrote {} ({} samples)",
+        output.display(),
+        envelope.samples.len()
+    );
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct CriterionEstimates {
+    mean: PointEstimate,
+    median: PointEstimate,
+    std_dev: PointEstimate,
+}
+
+#[derive(Debug, Deserialize)]
+struct PointEstimate {
+    confidence_interval: ConfidenceInterval,
+    point_estimate: f64,
+    #[allow(dead_code)]
+    standard_error: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfidenceInterval {
+    #[allow(dead_code)]
+    confidence_level: f64,
+    lower_bound: f64,
+    upper_bound: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct BenchmarkInfo {
+    /// Bench id within the group. Format: `{driver}/{suffix}` (see
+    /// `benches/suite.rs::register_w1`).
+    function_id: Option<String>,
+    /// Group name. Format: `W{n}.v{v}` (see `WorkloadId::full`).
+    group_id: String,
+}
+
+/// Just the array lengths from `sample.json` — enough to recover
+/// criterion's per-bench sample count without parsing every f64.
+#[derive(Debug, Deserialize)]
+struct SampleInfo {
+    times: Vec<f64>,
+}
+
+fn collect_samples(criterion_dir: &Path) -> Result<Vec<BenchSample>> {
+    let mut out = Vec::new();
+    for entry in WalkDir::new(criterion_dir)
+        .into_iter()
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.file_name() != "estimates.json" {
+            continue;
+        }
+        // We only want the `new/estimates.json` files — criterion also
+        // keeps `base/` snapshots from prior runs, and we don't want
+        // to double-count those.
+        let parent = match entry.path().parent() {
+            Some(p) => p,
+            None => continue,
+        };
+        if parent.file_name().and_then(|s| s.to_str()) != Some("new") {
+            continue;
+        }
+        // benchmark.json sits next to estimates.json (same `new/`
+        // directory). It carries the human-readable group + function
+        // ids — much friendlier than parsing the path.
+        let info_path = parent.join("benchmark.json");
+        if !info_path.exists() {
+            continue;
+        }
+        let info: BenchmarkInfo = serde_json::from_str(
+            &fs::read_to_string(&info_path)
+                .with_context(|| format!("read {}", info_path.display()))?,
+        )
+        .with_context(|| format!("parse {}", info_path.display()))?;
+        let estimates: CriterionEstimates = serde_json::from_str(
+            &fs::read_to_string(entry.path())
+                .with_context(|| format!("read {}", entry.path().display()))?,
+        )
+        .with_context(|| format!("parse {}", entry.path().display()))?;
+        let sample_path = parent.join("sample.json");
+        let sample_count: u64 = if sample_path.exists() {
+            let s: SampleInfo = serde_json::from_str(
+                &fs::read_to_string(&sample_path)
+                    .with_context(|| format!("read {}", sample_path.display()))?,
+            )
+            .with_context(|| format!("parse {}", sample_path.display()))?;
+            s.times.len() as u64
+        } else {
+            0
+        };
+
+        // Bench id format: `{driver}/{suffix}` — split on the first
+        // `/`. If it doesn't have one, treat the whole thing as the
+        // driver and leave suffix empty.
+        let function_id = info.function_id.clone().unwrap_or_default();
+        let driver = function_id
+            .split_once('/')
+            .map(|(d, _)| d.to_string())
+            .unwrap_or(function_id);
+
+        let median_ns = estimates.median.point_estimate;
+        let ops_per_s = if median_ns > 0.0 {
+            1e9 / median_ns
+        } else {
+            0.0
+        };
+        out.push(BenchSample {
+            workload: info.group_id,
+            driver,
+            median_ns,
+            median_ci_lower_ns: estimates.median.confidence_interval.lower_bound,
+            median_ci_upper_ns: estimates.median.confidence_interval.upper_bound,
+            mean_ns: estimates.mean.point_estimate,
+            std_dev_ns: estimates.std_dev.point_estimate,
+            samples: sample_count,
+            ops_per_s,
+        });
+    }
+    out.sort_by(|a, b| a.workload.cmp(&b.workload).then(a.driver.cmp(&b.driver)));
+    Ok(out)
+}
+
+fn host_info() -> HostInfo {
+    let cpu = read_cpu_brand().unwrap_or_else(|| "unknown".to_string());
+    let cpus = std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(0);
+    let ram_mib = read_ram_mib().unwrap_or(0);
+    HostInfo {
+        cpu,
+        cpus,
+        ram_mib,
+        os_kind: std::env::consts::OS.to_string(),
+        os_release: read_os_release().unwrap_or_else(|| "unknown".to_string()),
+        arch: std::env::consts::ARCH.to_string(),
+    }
+}
+
+fn read_cpu_brand() -> Option<String> {
+    if cfg!(target_os = "macos") {
+        let out = Command::new("sysctl")
+            .args(["-n", "machdep.cpu.brand_string"])
+            .output()
+            .ok()?;
+        Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else if cfg!(target_os = "linux") {
+        let s = fs::read_to_string("/proc/cpuinfo").ok()?;
+        for line in s.lines() {
+            if let Some(rest) = line.strip_prefix("model name") {
+                if let Some(after_colon) = rest.split_once(':') {
+                    return Some(after_colon.1.trim().to_string());
+                }
+            }
+        }
+        None
+    } else {
+        None
+    }
+}
+
+fn read_ram_mib() -> Option<u64> {
+    if cfg!(target_os = "macos") {
+        let out = Command::new("sysctl")
+            .args(["-n", "hw.memsize"])
+            .output()
+            .ok()?;
+        let bytes: u64 = String::from_utf8_lossy(&out.stdout).trim().parse().ok()?;
+        Some(bytes / (1024 * 1024))
+    } else if cfg!(target_os = "linux") {
+        let s = fs::read_to_string("/proc/meminfo").ok()?;
+        for line in s.lines() {
+            if let Some(rest) = line.strip_prefix("MemTotal:") {
+                let kib: u64 = rest.split_whitespace().next()?.parse().ok()?;
+                return Some(kib / 1024);
+            }
+        }
+        None
+    } else {
+        None
+    }
+}
+
+fn read_os_release() -> Option<String> {
+    let out = Command::new("uname").arg("-r").output().ok()?;
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn commit_info() -> CommitInfo {
+    let sha = git("rev-parse", &["HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let branch =
+        git("rev-parse", &["--abbrev-ref", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    let dirty = !git("status", &["--porcelain"])
+        .unwrap_or_default()
+        .trim()
+        .is_empty();
+    CommitInfo { sha, branch, dirty }
+}
+
+fn git(cmd: &str, args: &[&str]) -> Option<String> {
+    let mut full = vec![cmd];
+    full.extend_from_slice(args);
+    let out = Command::new("git").args(&full).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+fn now_rfc3339() -> String {
+    let dur = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    // Manual RFC 3339 (UTC) — avoids a chrono dep for one timestamp.
+    let secs = dur.as_secs() as i64;
+    let days_since_epoch = secs / 86_400;
+    let secs_today = secs % 86_400;
+    let (y, mo, d) = ymd_from_days(days_since_epoch);
+    let h = secs_today / 3600;
+    let mi = (secs_today / 60) % 60;
+    let s = secs_today % 60;
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+/// Convert "days since 1970-01-01" to (year, month, day). Standard
+/// civil-from-days algorithm (Howard Hinnant's date library).
+fn ymd_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+fn default_output_path(host: &HostInfo, commit: &CommitInfo) -> PathBuf {
+    // benchmarks/results/YYYY-MM-DD-<host_token>-<short_sha>.json
+    let now = now_rfc3339();
+    let date = &now[..10];
+    let host_token = host
+        .cpu
+        .split_whitespace()
+        .next()
+        .unwrap_or("host")
+        .to_lowercase();
+    let host_token = host_token.replace(|c: char| !c.is_ascii_alphanumeric(), "");
+    let short_sha = if commit.sha == "unknown" {
+        "unknown".to_string()
+    } else {
+        commit.sha.chars().take(8).collect()
+    };
+    PathBuf::from(format!(
+        "benchmarks/results/{date}-{host_token}-{short_sha}.json"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ymd_from_days_known_dates() {
+        // 1970-01-01
+        assert_eq!(ymd_from_days(0), (1970, 1, 1));
+        // 2026-05-06 — today's date per the project memory.
+        let target = days_from_ymd(2026, 5, 6);
+        assert_eq!(ymd_from_days(target), (2026, 5, 6));
+    }
+
+    /// Inverse of [`ymd_from_days`] — only used for round-trip in
+    /// tests; the production code only goes one way (days → ymd).
+    fn days_from_ymd(y: i64, m: i64, d: i64) -> i64 {
+        let y = if m <= 2 { y - 1 } else { y };
+        let era = y.div_euclid(400);
+        let yoe = y - era * 400;
+        let doy = (153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5 + d - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146_097 + doe - 719_468
+    }
+}

--- a/benchmarks/src/data.rs
+++ b/benchmarks/src/data.rs
@@ -1,0 +1,91 @@
+//! Deterministic dataset generators.
+//!
+//! Every workload pulls its inputs from this module. The seed is part
+//! of the workload's contract — a `W1.v1` run reproduces byte-for-byte
+//! across hosts. Bumping a workload's version (`v1` → `v2`) is the
+//! explicit gesture for "I changed the dataset shape" (see Q8 in
+//! `benchmarks-plan.md`).
+//!
+//! Why not generate into `benchmarks/data/`? — small datasets like W1's
+//! 100k rows regenerate in milliseconds, so we re-build them per-run
+//! from the seed. Larger workloads (W7's 1M-row aggregate) might need
+//! the on-disk cache; that lands alongside W7 in 9.3.
+
+use rand::SeedableRng;
+use rand::seq::SliceRandom;
+use rand_chacha::ChaCha8Rng;
+
+/// W1 dataset: 100k rows of `(id INTEGER PRIMARY KEY, name TEXT, payload TEXT)`.
+///
+/// `name` is `"user_<id>"`. `payload` is a deterministic 64-char string
+/// — enough to push each row out of "fits in the i64 PK" territory and
+/// exercise the row reassembly path, but not large enough to dominate
+/// the comparison with disk I/O.
+///
+/// The `keys` slice is a shuffled permutation of `1..=100_000` —
+/// criterion's hot loop picks `keys[i % keys.len()]` per iteration so
+/// every probe is to a present row but lookup order is unpredictable
+/// (no monotone B-tree leaf walk gaming the cache).
+pub struct W1Dataset {
+    pub rows: Vec<W1Row>,
+    pub keys: Vec<i64>,
+}
+
+pub struct W1Row {
+    pub id: i64,
+    pub name: String,
+    pub payload: String,
+}
+
+/// Total rows in the W1 dataset. Public so the workload + the README's
+/// table can reference the same number without drift.
+pub const W1_ROW_COUNT: usize = 100_000;
+
+/// Per-iteration probe count. The bench loop reads one row per iter,
+/// then criterion estimates per-iter latency from many iters; this
+/// constant is just the size of the prebuilt random-key slice the
+/// loop indexes into — picking it large enough to avoid cache games
+/// without bloating memory.
+pub const W1_KEY_COUNT: usize = 10_000;
+
+const W1_SEED: u64 = 42;
+
+/// Build the W1 dataset deterministically. Cheap (~30 ms for 100k
+/// rows on an M-series MBP); regenerated per bench-process so we
+/// don't carry a `benchmarks/data/` cache in v1.
+pub fn w1_dataset() -> W1Dataset {
+    let mut rng = ChaCha8Rng::seed_from_u64(W1_SEED);
+
+    let mut rows = Vec::with_capacity(W1_ROW_COUNT);
+    for i in 1..=W1_ROW_COUNT as i64 {
+        rows.push(W1Row {
+            id: i,
+            name: format!("user_{i}"),
+            payload: payload_for(i),
+        });
+    }
+
+    let mut keys: Vec<i64> = (1..=W1_ROW_COUNT as i64).collect();
+    keys.shuffle(&mut rng);
+    keys.truncate(W1_KEY_COUNT);
+
+    W1Dataset { rows, keys }
+}
+
+fn payload_for(id: i64) -> String {
+    // 64 chars, content stable per id. Hex-encoded mix-of-bits so two
+    // consecutive ids don't share a prefix (matters for any future
+    // index-prefix-compressed engine — not SQLite or SQLRite today,
+    // but a cheap correctness gesture).
+    let mut s = String::with_capacity(64);
+    let mut x = (id as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    for _ in 0..8 {
+        s.push_str(&format!("{x:016x}"));
+        x = x.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+        if s.len() >= 64 {
+            s.truncate(64);
+            break;
+        }
+    }
+    s
+}

--- a/benchmarks/src/drivers/mod.rs
+++ b/benchmarks/src/drivers/mod.rs
@@ -1,0 +1,18 @@
+//! Driver implementations.
+//!
+//! One file per engine; each implements [`crate::Driver`]. See
+//! `docs/benchmarks-plan.md` "Driver bias" risk: every implementation
+//! is reviewed against the question "is this how a perf-conscious user
+//! of <engine> would write it?" — `prepare_cached`, transaction
+//! batching, etc.
+//!
+//! Adding a comparator is one file here + one register-call in
+//! `benches/suite.rs`.
+
+pub mod sqlite;
+pub mod sqlrite;
+
+// DuckDB driver lands in sub-phase 9.5 (Group B only). Feature-gated
+// then; the module file gets created alongside the implementation.
+// #[cfg(feature = "duckdb")]
+// pub mod duckdb;

--- a/benchmarks/src/drivers/sqlite.rs
+++ b/benchmarks/src/drivers/sqlite.rs
@@ -1,0 +1,154 @@
+//! SQLite driver via [`rusqlite`] (bundled libsqlite3).
+//!
+//! Per Q3, the driver applies the **headline tuned profile** at open
+//! time:
+//!
+//! ```sql
+//! PRAGMA journal_mode = WAL;
+//! PRAGMA synchronous  = NORMAL;
+//! PRAGMA temp_store   = MEMORY;
+//! PRAGMA cache_size   = -65536;  -- 64 MB
+//! ```
+//!
+//! Rationale: SQLRite's WAL is mandatory + always-on, so SQLite-default
+//! (`journal_mode=DELETE`, `synchronous=FULL`) is *not* apples-to-apples.
+//! `synchronous=NORMAL` matches SQLRite's commit fsync semantics. A
+//! "SQLite-default" comparator column is a future opt-in (post-9.6).
+//!
+//! Driver-bias mitigation (Q3 risk in the plan): every hot SELECT path
+//! goes through `prepare_cached` so we measure the engine's execution
+//! cost, not per-iter parse cost. That's how a perf-conscious rusqlite
+//! user would write this.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::{Driver, Value};
+
+pub struct SQLiteDriver;
+
+impl Driver for SQLiteDriver {
+    type Conn = rusqlite::Connection;
+
+    fn name(&self) -> &'static str {
+        "sqlite"
+    }
+
+    fn open(&self, path: &Path) -> Result<Self::Conn> {
+        let conn = rusqlite::Connection::open(path)
+            .with_context(|| format!("rusqlite open({})", path.display()))?;
+        // Tuned profile (Q3). Each PRAGMA returns one row of feedback
+        // we discard; query_row is the right shape (`pragma_update`
+        // doesn't accept the negative-value cache_size form).
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .context("PRAGMA journal_mode=WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")
+            .context("PRAGMA synchronous=NORMAL")?;
+        conn.pragma_update(None, "temp_store", "MEMORY")
+            .context("PRAGMA temp_store=MEMORY")?;
+        conn.pragma_update(None, "cache_size", -65536i64)
+            .context("PRAGMA cache_size=-65536")?;
+        Ok(conn)
+    }
+
+    fn execute(&self, conn: &mut Self::Conn, sql: &str) -> Result<()> {
+        conn.execute_batch(sql)
+            .with_context(|| format!("rusqlite execute_batch: {sql}"))?;
+        Ok(())
+    }
+
+    fn execute_with_params(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<()> {
+        let bound: Vec<rusqlite::types::Value> = params.iter().map(to_rusqlite).collect();
+        conn.execute(sql, rusqlite::params_from_iter(bound.iter()))
+            .with_context(|| format!("rusqlite execute: {sql}"))?;
+        Ok(())
+    }
+
+    fn query_one(&self, conn: &mut Self::Conn, sql: &str, params: &[Value]) -> Result<Vec<Value>> {
+        // prepare_cached is the standard rusqlite hot-path idiom — it
+        // hits the connection's per-statement LRU cache, so the same
+        // SQL string only pays the parse cost once across all bench
+        // iterations (cache size defaults to 16, plenty for our
+        // workloads).
+        let mut stmt = conn
+            .prepare_cached(sql)
+            .with_context(|| format!("rusqlite prepare_cached: {sql}"))?;
+        let bound: Vec<rusqlite::types::Value> = params.iter().map(to_rusqlite).collect();
+        let cols = stmt.column_count();
+        let mut rows = stmt
+            .query(rusqlite::params_from_iter(bound.iter()))
+            .with_context(|| format!("rusqlite query: {sql}"))?;
+        let row = rows
+            .next()
+            .with_context(|| format!("rusqlite row read: {sql}"))?
+            .context("rusqlite query_one: zero rows returned")?;
+        let mut out = Vec::with_capacity(cols);
+        for i in 0..cols {
+            out.push(extract_column(row, i)?);
+        }
+        if rows
+            .next()
+            .with_context(|| format!("rusqlite row read: {sql}"))?
+            .is_some()
+        {
+            anyhow::bail!("rusqlite query_one: >1 rows returned");
+        }
+        Ok(out)
+    }
+
+    fn query_all(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<Vec<Vec<Value>>> {
+        let mut stmt = conn
+            .prepare_cached(sql)
+            .with_context(|| format!("rusqlite prepare_cached: {sql}"))?;
+        let bound: Vec<rusqlite::types::Value> = params.iter().map(to_rusqlite).collect();
+        let cols = stmt.column_count();
+        let mut rows = stmt
+            .query(rusqlite::params_from_iter(bound.iter()))
+            .with_context(|| format!("rusqlite query: {sql}"))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .with_context(|| format!("rusqlite row read: {sql}"))?
+        {
+            let mut buf = Vec::with_capacity(cols);
+            for i in 0..cols {
+                buf.push(extract_column(row, i)?);
+            }
+            out.push(buf);
+        }
+        Ok(out)
+    }
+}
+
+fn to_rusqlite(v: &Value) -> rusqlite::types::Value {
+    match v {
+        Value::Null => rusqlite::types::Value::Null,
+        Value::Integer(i) => rusqlite::types::Value::Integer(*i),
+        Value::Real(f) => rusqlite::types::Value::Real(*f),
+        Value::Text(s) => rusqlite::types::Value::Text(s.clone()),
+    }
+}
+
+fn extract_column(row: &rusqlite::Row<'_>, idx: usize) -> Result<Value> {
+    let raw: rusqlite::types::Value = row.get(idx)?;
+    Ok(match raw {
+        rusqlite::types::Value::Null => Value::Null,
+        rusqlite::types::Value::Integer(i) => Value::Integer(i),
+        rusqlite::types::Value::Real(f) => Value::Real(f),
+        rusqlite::types::Value::Text(s) => Value::Text(s),
+        rusqlite::types::Value::Blob(_) => {
+            anyhow::bail!("rusqlite extract_column: BLOB not yet supported by bench harness")
+        }
+    })
+}

--- a/benchmarks/src/drivers/sqlrite.rs
+++ b/benchmarks/src/drivers/sqlrite.rs
@@ -1,0 +1,205 @@
+//! SQLRite driver.
+//!
+//! Binds against the engine's public [`sqlrite::Connection`] surface —
+//! the same API the language SDKs use. SQLRite has no parameter
+//! binding yet (see `connection.rs:145` — "parameter binding and
+//! prepared-plan caching are future work"), so the driver formats
+//! `[Value]` into the SQL string at call time. That's an honest cost
+//! to include in the comparison: a SQLRite user calling a hot SELECT
+//! today pays the same per-call parse + format overhead.
+//!
+//! Once SQLRite gains parameter binding (post-9.6 follow-up), this
+//! driver will switch to the bound path and a workload `v` bump will
+//! capture the methodology change.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::{Driver, Value};
+
+pub struct SQLRiteDriver;
+
+impl Driver for SQLRiteDriver {
+    type Conn = sqlrite::Connection;
+
+    fn name(&self) -> &'static str {
+        "sqlrite"
+    }
+
+    fn open(&self, path: &Path) -> Result<Self::Conn> {
+        sqlrite::Connection::open(path)
+            .map_err(|e| anyhow::anyhow!("sqlrite open({}): {e}", path.display()))
+    }
+
+    fn execute(&self, conn: &mut Self::Conn, sql: &str) -> Result<()> {
+        conn.execute(sql)
+            .map_err(|e| anyhow::anyhow!("sqlrite execute: {e}\n  sql: {sql}"))?;
+        Ok(())
+    }
+
+    fn execute_with_params(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<()> {
+        let inlined = inline_params(sql, params)?;
+        conn.execute(&inlined)
+            .map_err(|e| anyhow::anyhow!("sqlrite execute_with_params: {e}\n  sql: {inlined}"))?;
+        Ok(())
+    }
+
+    fn query_one(&self, conn: &mut Self::Conn, sql: &str, params: &[Value]) -> Result<Vec<Value>> {
+        let inlined = inline_params(sql, params)?;
+        let stmt = conn
+            .prepare(&inlined)
+            .map_err(|e| anyhow::anyhow!("sqlrite prepare: {e}\n  sql: {inlined}"))?;
+        let mut rows = stmt
+            .query()
+            .map_err(|e| anyhow::anyhow!("sqlrite query: {e}\n  sql: {inlined}"))?;
+        let row = rows
+            .next()
+            .map_err(|e| anyhow::anyhow!("sqlrite row read: {e}"))?
+            .context("sqlrite query_one: zero rows returned")?;
+        let cols = row.columns().len();
+        let mut out = Vec::with_capacity(cols);
+        for i in 0..cols {
+            let v: sqlrite::Value = row.get(i)?;
+            out.push(from_engine_value(v));
+        }
+        if rows
+            .next()
+            .map_err(|e| anyhow::anyhow!("sqlrite row read: {e}"))?
+            .is_some()
+        {
+            anyhow::bail!("sqlrite query_one: >1 rows returned");
+        }
+        Ok(out)
+    }
+
+    fn query_all(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<Vec<Vec<Value>>> {
+        let inlined = inline_params(sql, params)?;
+        let stmt = conn
+            .prepare(&inlined)
+            .map_err(|e| anyhow::anyhow!("sqlrite prepare: {e}\n  sql: {inlined}"))?;
+        let mut rows = stmt
+            .query()
+            .map_err(|e| anyhow::anyhow!("sqlrite query: {e}\n  sql: {inlined}"))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .map_err(|e| anyhow::anyhow!("sqlrite row read: {e}"))?
+        {
+            let cols = row.columns().len();
+            let mut buf = Vec::with_capacity(cols);
+            for i in 0..cols {
+                let v: sqlrite::Value = row.get(i)?;
+                buf.push(from_engine_value(v));
+            }
+            out.push(buf);
+        }
+        Ok(out)
+    }
+}
+
+/// Inline `?`-positional placeholders with literal values. Replaces the
+/// first `?` with `params[0]`, the second with `params[1]`, etc. Errors
+/// if the count doesn't match. Strings are SQL-escaped.
+fn inline_params(sql: &str, params: &[Value]) -> Result<String> {
+    let mut out = String::with_capacity(sql.len() + params.len() * 16);
+    let mut iter = params.iter();
+    let mut in_string = false;
+    for ch in sql.chars() {
+        if ch == '\'' {
+            in_string = !in_string;
+            out.push(ch);
+            continue;
+        }
+        if ch == '?' && !in_string {
+            let p = iter
+                .next()
+                .context("inline_params: more `?` placeholders than params")?;
+            push_literal(&mut out, p);
+        } else {
+            out.push(ch);
+        }
+    }
+    if iter.next().is_some() {
+        anyhow::bail!("inline_params: more params than `?` placeholders");
+    }
+    Ok(out)
+}
+
+fn push_literal(out: &mut String, v: &Value) {
+    match v {
+        Value::Null => out.push_str("NULL"),
+        Value::Integer(i) => out.push_str(&i.to_string()),
+        Value::Real(f) => out.push_str(&format!("{f}")),
+        Value::Text(s) => {
+            out.push('\'');
+            for ch in s.chars() {
+                if ch == '\'' {
+                    out.push('\'');
+                }
+                out.push(ch);
+            }
+            out.push('\'');
+        }
+    }
+}
+
+fn from_engine_value(v: sqlrite::Value) -> Value {
+    match v {
+        sqlrite::Value::Null => Value::Null,
+        sqlrite::Value::Integer(i) => Value::Integer(i),
+        sqlrite::Value::Real(f) => Value::Real(f),
+        sqlrite::Value::Text(s) => Value::Text(s),
+        // Bench inputs don't include booleans / vectors / JSON yet —
+        // when a workload starts using them, this match grows.
+        other => Value::Text(format!("{other:?}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_params_replaces_in_order() {
+        let s = inline_params(
+            "SELECT * FROM t WHERE a = ? AND b = ? AND c = ?",
+            &[Value::Integer(1), Value::Text("x".into()), Value::Null],
+        )
+        .unwrap();
+        assert_eq!(s, "SELECT * FROM t WHERE a = 1 AND b = 'x' AND c = NULL");
+    }
+
+    #[test]
+    fn inline_params_preserves_question_marks_in_strings() {
+        let s =
+            inline_params("SELECT 'what?', * FROM t WHERE a = ?", &[Value::Integer(7)]).unwrap();
+        assert_eq!(s, "SELECT 'what?', * FROM t WHERE a = 7");
+    }
+
+    #[test]
+    fn inline_params_escapes_quotes() {
+        let s = inline_params(
+            "SELECT * FROM t WHERE name = ?",
+            &[Value::Text("O'Hara".into())],
+        )
+        .unwrap();
+        assert_eq!(s, "SELECT * FROM t WHERE name = 'O''Hara'");
+    }
+
+    #[test]
+    fn inline_params_arity_mismatch_errors() {
+        assert!(inline_params("SELECT ?", &[]).is_err());
+        assert!(inline_params("SELECT 1", &[Value::Integer(1)]).is_err());
+    }
+}

--- a/benchmarks/src/envelope.rs
+++ b/benchmarks/src/envelope.rs
@@ -1,0 +1,72 @@
+//! JSON output envelope for `benchmarks/results/*.json`.
+//!
+//! The shape is locked in 9.1 (Q8 — workload version + host fingerprint
+//! together let same-version, same-host runs be diffed mechanically).
+//! The aggregator binary (`src/bin/aggregate.rs`) walks
+//! `target/criterion/**/new/estimates.json` after `cargo bench` and
+//! emits one [`ResultsEnvelope`] per `make bench` invocation.
+//!
+//! Schema rationale:
+//! - `host` carries enough to know "is this run comparable to that
+//!   one?" — CPU model, RAM, OS family, kernel rev. The plan's "macOS
+//!   vs Linux skew" risk is addressed by including `os_kind` so the
+//!   comparison script can refuse cross-OS diffs.
+//! - `commit` (full SHA + dirty bit) lets us recover what was tested.
+//! - `samples` is the per-(workload, driver) row, carrying every
+//!   number criterion produced. `compare.py` (lands in 9.6) reads
+//!   this directly.
+
+use serde::{Deserialize, Serialize};
+
+use crate::BenchSample;
+
+/// Top-level results envelope. One file = one `make bench` run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResultsEnvelope {
+    /// Schema version. Bump when the envelope shape changes; allows
+    /// `compare.py` to refuse to diff incompatible files.
+    pub schema_version: u32,
+    /// Run timestamp in RFC 3339 (UTC). Captured at run start.
+    pub run_started_at: String,
+    /// Run duration, seconds wall-clock. Captured by the aggregator.
+    pub run_duration_secs: f64,
+    /// Host fingerprint (CPU / RAM / OS).
+    pub host: HostInfo,
+    /// Repo state at run time.
+    pub commit: CommitInfo,
+    /// One row per (workload-version, driver) pair.
+    pub samples: Vec<BenchSample>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HostInfo {
+    /// CPU model string. On macOS read from `sysctl machdep.cpu.brand_string`;
+    /// on Linux the first `model name` line in `/proc/cpuinfo`.
+    pub cpu: String,
+    /// Logical CPU count.
+    pub cpus: u32,
+    /// Total RAM in MiB.
+    pub ram_mib: u64,
+    /// `linux`, `macos`, `windows`, …
+    pub os_kind: String,
+    /// Kernel / OS version string (`uname -r`).
+    pub os_release: String,
+    /// CPU arch (`aarch64`, `x86_64`, …).
+    pub arch: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitInfo {
+    /// Full git SHA at run time. `"unknown"` if the run was outside a
+    /// git checkout.
+    pub sha: String,
+    /// Branch name at run time.
+    pub branch: String,
+    /// Working tree dirty? (uncommitted changes present)
+    pub dirty: bool,
+}
+
+/// Schema version. Bump whenever any field in [`ResultsEnvelope`] or
+/// [`BenchSample`] changes shape; `compare.py` reads this and refuses
+/// cross-version diffs.
+pub const SCHEMA_VERSION: u32 = 1;

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,0 +1,160 @@
+//! Benchmark harness — SQLRite vs SQLite (and friends).
+//!
+//! See [`docs/benchmarks-plan.md`](../../docs/benchmarks-plan.md) for the
+//! canonical design + decisions. Sub-phase 9.1 (this PR) lands the
+//! scaffolding, the `Driver` trait, the SQLRite + SQLite drivers, and
+//! one workload end-to-end (W1 — read-by-PK). Workloads W2–W12 land in
+//! 9.2–9.4 by adding one file under `src/workloads/` and one register
+//! call in `benches/suite.rs`.
+//!
+//! ## Driver model
+//!
+//! Workloads are generic over [`Driver`] — engine-agnostic Rust. Each
+//! engine implements the trait once; adding a new comparator (libSQL,
+//! DuckDB, …) is one file under `src/drivers/` and a register-call in
+//! [`benches/suite.rs`](../../benchmarks/benches/suite.rs).
+//!
+//! [`Value`] is a small four-variant enum that's enough to express
+//! every workload's data shape (the engine's full `Value` type has
+//! booleans, vectors, JSON, etc., but bench inputs only need int /
+//! real / text / null).
+//!
+//! ## JSON output schema (Q8 — workload versioning)
+//!
+//! Every bench iteration is reported in a per-row [`BenchSample`] that
+//! carries an explicit `workload_version` (e.g. `"W1.v1"`). The
+//! `aggregate` binary collects these into a [`ResultsEnvelope`] under
+//! `benchmarks/results/`. Q8's commitment is enforced here: changing
+//! a workload's shape requires bumping the version, so historical
+//! comparisons can be filtered to same-version runs.
+
+#![allow(clippy::missing_errors_doc)]
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+pub mod data;
+pub mod drivers;
+pub mod envelope;
+pub mod workloads;
+
+/// Driver-side value type. Tight enough that any of the engines under
+/// test can map it onto their native bind types — rusqlite has
+/// [`rusqlite::ToSql`], DuckDB has its own; SQLRite has no parameter
+/// binding yet so the SQLRite driver inlines via SQL formatting.
+///
+/// Deliberately doesn't carry every type the engines support
+/// (booleans, vectors, JSON, blobs); workload inputs only need these
+/// four. New variants land alongside the workload that needs them.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+}
+
+/// Engine-agnostic surface every workload binds to.
+///
+/// Implementations live in `src/drivers/`. The trait is intentionally
+/// small: workloads use `execute` for setup (CREATE / INSERT inside a
+/// transaction), `query_one` for hot SELECT-by-PK paths, and
+/// `query_all` when they need every row (range scans, aggregates).
+///
+/// The `&self` receiver makes drivers cheap to clone into criterion
+/// closures; per-connection mutable state lives in [`Driver::Conn`].
+pub trait Driver: Send + Sync {
+    /// Connection handle type. Owned per workload run; closed on drop.
+    type Conn;
+
+    /// Stable engine label that lands in the JSON envelope and the
+    /// criterion bench id (e.g. `"sqlrite"`, `"sqlite"`).
+    fn name(&self) -> &'static str;
+
+    /// Open or create a database at `path`. The harness always passes
+    /// a fresh path under a per-run [`tempfile::TempDir`].
+    fn open(&self, path: &Path) -> anyhow::Result<Self::Conn>;
+
+    /// Run a non-query statement (DDL, INSERT, BEGIN/COMMIT, PRAGMA,
+    /// …). No-op return; errors propagate.
+    fn execute(&self, conn: &mut Self::Conn, sql: &str) -> anyhow::Result<()>;
+
+    /// Run a non-query statement with positional parameters.
+    fn execute_with_params(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> anyhow::Result<()>;
+
+    /// Run a query expected to return a single row. Returns the row's
+    /// values in projection order. Errors if zero or >1 rows come
+    /// back — the caller is asserting one row by shape.
+    fn query_one(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> anyhow::Result<Vec<Value>>;
+
+    /// Run a query and materialize every row. Used for range scans /
+    /// aggregates / GROUP BY where the result set is the answer.
+    #[allow(dead_code)]
+    fn query_all(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> anyhow::Result<Vec<Vec<Value>>>;
+}
+
+/// Workload-version tag. Mirrors Q8 in `benchmarks-plan.md`: every
+/// workload carries an explicit version (`W1.v1`, `W1.v2`, …). The
+/// comparison script (lands in 9.6) only diffs same-version pairs and
+/// warns on cross-version compares.
+///
+/// Bumping a workload's version is the explicit "we changed the
+/// benchmark" gesture. Old JSON files keep their old version key and
+/// stay readable forever.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkloadId {
+    /// Stable id like `"W1"`. Used as the criterion group prefix.
+    pub id: &'static str,
+    /// Human-readable name, e.g. `"read-by-pk"`.
+    pub name: &'static str,
+    /// Version tag — increment when the workload's shape changes.
+    pub version: &'static str,
+}
+
+impl WorkloadId {
+    /// `id.vversion`, e.g. `"W1.v1"`. Used as the criterion bench-group
+    /// id and the JSON envelope's `workload` key.
+    pub fn full(&self) -> String {
+        format!("{}.{}", self.id, self.version)
+    }
+}
+
+/// One sample row in the JSON envelope. Matches criterion's
+/// `estimates.json` shape closely so `aggregate` is mostly a copy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchSample {
+    /// Full workload id with version, e.g. `"W1.v1"`.
+    pub workload: String,
+    /// Engine label from [`Driver::name`].
+    pub driver: String,
+    /// criterion's median estimate, in nanoseconds per iteration.
+    pub median_ns: f64,
+    /// 95% confidence interval lower bound on the median, in ns.
+    pub median_ci_lower_ns: f64,
+    /// 95% confidence interval upper bound on the median, in ns.
+    pub median_ci_upper_ns: f64,
+    /// criterion's mean estimate, in ns/iter.
+    pub mean_ns: f64,
+    /// Standard deviation, in ns/iter.
+    pub std_dev_ns: f64,
+    /// Number of samples criterion took (default 100).
+    pub samples: u64,
+    /// Throughput, ops/s — derived from `1e9 / median_ns`.
+    pub ops_per_s: f64,
+}

--- a/benchmarks/src/workloads/kv.rs
+++ b/benchmarks/src/workloads/kv.rs
@@ -1,0 +1,119 @@
+//! W1 — read-by-PK.
+//!
+//! Schema:
+//!
+//! ```sql
+//! CREATE TABLE kv (
+//!   id      INTEGER PRIMARY KEY,
+//!   name    TEXT,
+//!   payload TEXT
+//! );
+//! -- 100k rows inserted in one transaction.
+//! -- Hot loop: SELECT name, payload FROM kv WHERE id = ?, 10k random keys.
+//! ```
+//!
+//! The hot loop is the reference latency for the engine's hottest
+//! path. Both engines have an auto-PK index, so this exercises:
+//!
+//! - parse + plan (every iter for SQLRite; cached for SQLite)
+//! - PK index probe + leaf B-tree fetch
+//! - row reassembly (3 cells: int + text + text)
+//! - return + iterator setup/teardown
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{W1_KEY_COUNT, W1_ROW_COUNT, W1Dataset, w1_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W1: WorkloadId = WorkloadId {
+    id: "W1",
+    name: "read-by-pk",
+    version: "v1",
+};
+
+/// SELECT used by the hot loop. Both engines support `?`-positional
+/// binds; the SQLRite driver inlines, the SQLite driver binds via
+/// `prepare_cached`.
+pub const SELECT_SQL: &str = "SELECT name, payload FROM kv WHERE id = ?";
+
+/// Build the W1 table + populate 100k rows. Returns the open connection
+/// + the prebuilt random-key slice the hot loop will iterate.
+///
+/// Inserts go through one transaction so we don't pay the per-row
+/// COMMIT cost — the bulk insert path lands as its own workload (W3)
+/// in 9.2 and that's where COMMIT is the unit under measurement.
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, Vec<i64>)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE kv (id INTEGER PRIMARY KEY, name TEXT, payload TEXT)",
+    )?;
+
+    let dataset = w1_dataset();
+    insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset.keys))
+}
+
+/// One iteration of the hot loop. Looks up `key`, asserts that exactly
+/// one row came back. Returns the row so criterion's `black_box` can
+/// see a real result and the optimizer doesn't shortcut the call.
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn, key: i64) -> Result<Vec<Value>> {
+    driver.query_one(conn, SELECT_SQL, &[Value::Integer(key)])
+}
+
+/// Correctness gate (Q3 mitigation). Run once before the timed loop
+/// to verify the engine returns the expected row shape. Comparing the
+/// full payload across the whole dataset would dwarf the bench
+/// runtime; we sample a handful of fixed keys.
+pub fn correctness_check<D: Driver>(driver: &D, conn: &mut D::Conn) -> Result<()> {
+    for &key in &[1i64, 50_001, 100_000] {
+        let row = driver.query_one(conn, SELECT_SQL, &[Value::Integer(key)])?;
+        if row.len() != 2 {
+            anyhow::bail!(
+                "W1 correctness: expected 2 columns (name, payload), got {}",
+                row.len()
+            );
+        }
+        match (&row[0], &row[1]) {
+            (Value::Text(name), Value::Text(payload)) => {
+                let expected_name = format!("user_{key}");
+                if name != &expected_name {
+                    anyhow::bail!(
+                        "W1 correctness: key {key} → name = {name:?}, expected {expected_name:?}"
+                    );
+                }
+                if payload.len() != 64 {
+                    anyhow::bail!(
+                        "W1 correctness: key {key} → payload len = {}, expected 64",
+                        payload.len()
+                    );
+                }
+            }
+            other => anyhow::bail!("W1 correctness: key {key} → unexpected row shape {other:?}"),
+        }
+    }
+    Ok(())
+}
+
+fn insert_rows<D: Driver>(driver: &D, conn: &mut D::Conn, dataset: &W1Dataset) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W1 BEGIN")?;
+    for row in &dataset.rows {
+        driver
+            .execute_with_params(
+                conn,
+                "INSERT INTO kv (id, name, payload) VALUES (?, ?, ?)",
+                &[
+                    Value::Integer(row.id),
+                    Value::Text(row.name.clone()),
+                    Value::Text(row.payload.clone()),
+                ],
+            )
+            .with_context(|| format!("W1 INSERT id={}", row.id))?;
+    }
+    driver.execute(conn, "COMMIT").context("W1 COMMIT")?;
+    debug_assert_eq!(dataset.rows.len(), W1_ROW_COUNT);
+    debug_assert_eq!(dataset.keys.len(), W1_KEY_COUNT);
+    Ok(())
+}

--- a/benchmarks/src/workloads/mod.rs
+++ b/benchmarks/src/workloads/mod.rs
@@ -1,0 +1,17 @@
+//! Workloads.
+//!
+//! Each workload is one file. Pattern:
+//!
+//! 1. Public `WORKLOAD_ID: WorkloadId` constant. Carries the
+//!    versioned id (Q8) so the JSON envelope and the criterion bench
+//!    group both pick it up consistently.
+//! 2. A `setup<D: Driver>(...)` that builds the dataset against the
+//!    driver and returns the connection — runs once per criterion
+//!    bench, **outside** the timed loop.
+//! 3. A `bench_iter<D: Driver>(...)` for the per-iteration body —
+//!    what criterion's `b.iter` measures.
+//! 4. An `expected_hash(...)` for the correctness gate (Q3 risk
+//!    mitigation: catch divergent semantics across engines before the
+//!    "winner" measurement is meaningful).
+
+pub mod kv;

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -62,7 +62,7 @@ See the [Roadmap](roadmap.md) for the full phase plan.
 
 - [Phase 7 plan](phase-7-plan.md) — AI-era extensions (vector column type + HNSW, JSON, NL→SQL `ask()` API across REPL/library/SDKs/desktop/MCP, MCP server). **Implementation complete except 7f, which deferred to Phase 8.**
 - [Phase 8 plan](phase-8-plan.md) — Full-text search (FTS5-style BM25) + hybrid retrieval. The deferred 7f scope. **All six sub-phases (8a–8f) shipped.** Canonical reference: [`docs/fts.md`](fts.md).
-- [Benchmarks plan](benchmarks-plan.md) — design proposal for an SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4. Tracks 10 curated workloads across OLTP, SQL-feature scaling, and AI-era differentiators (HNSW / BM25 / hybrid retrieval); proposes a `benchmarks/` workspace member with a small `Driver` trait that lets workloads run engine-agnostically.
+- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phase 9.1 (harness + W1) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench`. The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
 
 ## Conventions
 

--- a/docs/benchmarks-plan.md
+++ b/docs/benchmarks-plan.md
@@ -1,6 +1,6 @@
 # Benchmarks plan — SQLRite vs SQLite (and friends)
 
-**Status:** *draft 2026-05-06 — design proposal awaiting review (Q1–Q8 below).* No harness code lands until the open questions are answered. Tracks task **SQLR-4**.
+**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phase 9.1 in flight.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
 
 **TL;DR.** Stand up a small, focused benchmark suite that pits the engine against `SQLite` (mandatory) and `DuckDB` (optional, analytical-slice only) under a curated set of OLTP + analytical + AI-era workloads. Skip distributed and network-resident options (`Cloudflare D1`, `rqlite`) — they don't share SQLRite's deployment shape. Defer `libSQL` until we have a vector- or replication-flavored axis that justifies a third row-oriented embedded engine. Suite lives in a new top-level `benchmarks/` workspace member, not built by default, runs on demand on a pinned host, emits JSON for trend tracking.
 
@@ -165,7 +165,7 @@ Rationale: SQLRite's WAL is mandatory + checkpointer is always on; SQLRite's com
 
 ## Repository layout
 
-New top-level `benchmarks/` workspace member. **Not** added to the default `cargo build --workspace` exclude list (so CI's existing build/test still skips it via the existing `--exclude` pattern, mirroring how `sqlrite-desktop` is handled today).
+New top-level `benchmarks/` workspace member. CI skips it via an explicit `--exclude sqlrite-benchmarks` on every `cargo build` / `cargo test` / `cargo clippy` / `cargo doc` invocation (the same pattern that hides `sqlrite-desktop`, `sqlrite-python`, and `sqlrite-nodejs`). Run locally with `make bench`.
 
 ```
 benchmarks/
@@ -277,57 +277,73 @@ Add the `duckdb-rs` driver under a `--features duckdb` flag. Wire only into Grou
 
 ---
 
-## Decisions
+## Decisions (was: open questions)
 
-Same Q-list shape as the phase plans. Each one is "decide before sub-phase 9.1 starts."
+Q1–Q8 were resolved by the project owner on 2026-05-06. Each question keeps its original options + recommendation as a record of the rationale; the **Decided:** line at the top is the canonical answer the implementation should follow.
 
 ### Q1. Bench harness host
 
+> **Decided: pinned local M-series MBP for v1.** Bare-metal hosts (Hetzner / Equinix) revisited post-9.6 once we're publishing numbers externally and want stability across runs. The JSON envelope already captures CPU model / RAM / OS / kernel so a future host swap is documentable, not a silent break.
+
 Pinned local M-series MBP for v1, or rent a bare-metal box (Hetzner / Equinix) for stable numbers from day one?
 
-**Lean:** local laptop. Cheaper, faster iteration, "developer wall-clock" is the right unit at this stage. Switch to bare-metal when we want to publish numbers externally (post-9.6).
+**Recommendation:** local laptop. Cheaper, faster iteration, "developer wall-clock" is the right unit at this stage. Switch to bare-metal when we want to publish numbers externally (post-9.6).
 
 ### Q2. SLO thresholds
 
+> **Decided: no PR-gating in v1.** The harness publishes numbers; it does not fail PRs. Tracked as a post-9.6 follow-up — needs ~3+ same-host baseline runs before any threshold (e.g. "regress >20% on workload X") is anything but noise-fitting.
+
 Should the bench harness gate PRs ("fail if SQLRite regresses >X% on workload Y")?
 
-**Lean:** no for v1. Need ~3+ baseline runs to know what "noise" looks like before setting a threshold. Document as a Post-9.6 idea.
+**Recommendation:** no for v1. Need ~3+ baseline runs to know what "noise" looks like before setting a threshold. Document as a Post-9.6 idea.
 
 ### Q3. SQLite tuning
 
+> **Decided: tuned (WAL + `synchronous=NORMAL`) is the headline.** SQLite-default (`journal_mode=DELETE` + `synchronous=FULL`) is the *secondary* column — opt-in via the harness, not the default `make bench` axis. Rationale stays in `docs/benchmarks.md` so anyone reading "SQLite Y ms vs SQLRite Z ms" sees up front that both engines are durability-comparable, not "SQLRite vs SQLite's most paranoid mode."
+
 Compare against SQLite default settings (`journal_mode=DELETE`, `synchronous=FULL`) or tuned (`WAL` + `synchronous=NORMAL`)?
 
-**Lean:** tuned (WAL+NORMAL) as the headline number, with a note in `benchmarks.md` explaining why. Optionally publish a "SQLite-default" column too, since some users compare against the default. Apples-to-apples is the goal — SQLRite has no `synchronous=FULL` mode to opt into.
+**Recommendation:** tuned (WAL+NORMAL) as the headline number, with a note in `benchmarks.md` explaining why. Optionally publish a "SQLite-default" column too, since some users compare against the default. Apples-to-apples is the goal — SQLRite has no `synchronous=FULL` mode to opt into.
 
 ### Q4. DuckDB inclusion
 
+> **Decided: opt-in via `--features duckdb`** on the bench crate. `make bench` stays lean (rusqlite + sqlrite only); `make bench-duckdb` pulls the heavy dep and runs only Group B (W7–W9), per the viability section.
+
 Hard-out, opt-in feature, or default-on?
 
-**Lean:** opt-in via `--features duckdb`. Heavy dep, only useful on Group B. `make bench` stays lean.
+**Recommendation:** opt-in via `--features duckdb`. Heavy dep, only useful on Group B. `make bench` stays lean.
 
 ### Q5. libSQL
 
+> **Decided: punted to post-9.6.** Embedded libSQL tracks SQLite within a few percent on the OLTP path; not enough signal to justify a third row-oriented driver in v1. Revisit alongside any "vector-only" benchmark page (post-9.4) where a non-extension vector competitor would be informative.
+
 Add as a +1 driver in 9.5 alongside DuckDB, or punt to post-9.6?
 
-**Lean:** punt. The OLTP numbers will track SQLite within a few percent and add noise without insight. Worth adding when we want a non-extension vector competitor on W10.
+**Recommendation:** punt. The OLTP numbers will track SQLite within a few percent and add noise without insight. Worth adding when we want a non-extension vector competitor on W10.
 
 ### Q6. D1 / rqlite
 
+> **Decided: out of scope.** Both are network-resident; round-trip latency dominates every workload. Out-of-scope rationale already lives in the [viability section](#comparison-target-viability); no driver work, no follow-up. Revisit only if SQLRite ever ships a remote-server / distributed mode.
+
 Already proposed out-of-scope in the [viability section](#comparison-target-viability). Confirming by Q.
 
-**Lean:** out. Document the rationale, don't burn cycles.
+**Recommendation:** out. Document the rationale, don't burn cycles.
 
 ### Q7. Where to publish
 
+> **Decided: in-repo.** Canonical reference at `docs/benchmarks.md` (lands in 9.6); raw JSON committed under `benchmarks/results/` keyed by date + host + commit; cross-link from `README.md` and `docs/_index.md`. A standalone docs site can grow out of this if/when demand appears, but versioned-with-the-code is the right v1 default.
+
 In-repo Markdown (`docs/benchmarks.md` + raw JSON in `benchmarks/results/`), or a separate docs site?
 
-**Lean:** in-repo. Versioned with the code, no extra infra, clickable from the README. A separate site can grow out of this if there's demand.
+**Recommendation:** in-repo. Versioned with the code, no extra infra, clickable from the README. A separate site can grow out of this if there's demand.
 
 ### Q8. Workload shape changes mid-suite
 
+> **Decided: workloads carry an explicit version (`W1.v1`, `W1.v2`, …).** The JSON output schema includes `workload_version` per row; the comparison script only diffs same-version pairs and warns on cross-version compares. Bumping the version is the explicit "we changed the benchmark" gesture; old JSON files remain readable forever.
+
 If we add a column or change a query in a workload between releases, how do we keep historical comparison meaningful?
 
-**Lean:** workloads are versioned (`W1.v1`, `W1.v2`). Old JSON keeps the old workload-version key; results page only compares same-version runs. Cheap, opt-in, avoids "we silently changed the benchmark" mistakes.
+**Recommendation:** workloads are versioned (`W1.v1`, `W1.v2`). Old JSON keeps the old workload-version key; results page only compares same-version runs. Cheap, opt-in, avoids "we silently changed the benchmark" mistakes.
 
 ---
 


### PR DESCRIPTION
## Summary

First executable code for the SQLRite-vs-SQLite benchmark suite designed in #101 (SQLR-4). Sub-phase **9.1** of the plan.

- **Q1–Q8 resolved.** Plan-doc updated to mirror Phase 7's "Decisions (was: open questions)" shape — each question keeps its original options + a `> **Decided: …**` blockquote at the top. See [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.1-harness/docs/benchmarks-plan.md#decisions-was-open-questions).
- **`benchmarks/` workspace member** with a small `Driver` trait, two engine impls (SQLRite via `Connection`, SQLite via `rusqlite`-bundled), one workload (W1 read-by-PK), a criterion entry point, and an aggregator that walks `target/criterion/**/estimates.json` into a single results envelope under `benchmarks/results/`.
- **CI excludes** `sqlrite-benchmarks` alongside `sqlrite-desktop` + the SDK cdylibs; runs locally via `make bench`.

## Plan-doc decisions (Q1–Q8)

| # | Decision |
|---|---|
| Q1 | Pinned local M-series MBP for v1; bare-metal post-9.6 |
| Q2 | No PR-gating; needs ~3 baselines first |
| Q3 | Headline = SQLite WAL+`synchronous=NORMAL`+64 MB cache; default-mode is opt-in secondary |
| Q4 | DuckDB opt-in (`--features duckdb`); Group B only |
| Q5 | libSQL deferred to post-9.6 |
| Q6 | D1 / rqlite out of scope |
| Q7 | In-repo: `docs/benchmarks.md` + raw JSON in `benchmarks/results/` |
| Q8 | Workloads carry an explicit `version` (`W1.v1`, `W1.v2`, …) |

## Harness shape

- **`Driver` trait** is small enough to express every planned workload (open / execute / execute_with_params / query_one / query_all). `&self` receiver so drivers are cheap to clone into criterion closures.
- **SQLRite driver** inlines `?` params via SQL formatting — the engine has no parameter binding yet; the inliner is unit-tested for arity, escaping, and `?`-in-strings. Once the engine grows real binds, this driver flips to the bound path and a workload `v` bump captures the methodology change.
- **SQLite driver** runs the Q3-tuned profile at open time (WAL + `synchronous=NORMAL` + 64 MB cache + `temp_store=MEMORY`) and `prepare_cached` on every hot-path SELECT — so we measure execution cost, not per-iter parse cost.
- **Per-run `TempDir`** — no page-cache / WAL bleed across iterations.
- **Correctness gate** — every workload runs `correctness_check` against sample keys before timing, so a divergent-result "speedup" can't silently land.
- **Q8 versioning baked in** — workloads carry `WorkloadId { id, name, version }` and the JSON envelope tags every sample with `W{n}.v{v}`.

## JSON output (locked in this PR)

`BenchSample` per (workload, driver) pair: median + 95% CI + mean + std dev + sample count + ops/s.

`ResultsEnvelope` carries `schema_version`, `run_started_at` (RFC 3339), `run_duration_secs`, host fingerprint (CPU brand, RAM, OS kind + release, arch), and commit info (sha, branch, dirty bit). `aggregate.rs` reads `sysctl` / `/proc` / `git` directly — no `chrono` / `sysinfo` deps.

`benchmarks/results/.gitignore` keeps casual local runs out of git until 9.6 commits the first official pinned-host run.

## End-to-end smoke run (illustrative — not the official 9.6 publication)

```
W1.v1/sqlrite/default   ~12 µs/op   ~84k ops/s
W1.v1/sqlite/default    ~2.5 µs/op  ~395k ops/s
```

About a 5× gap on the read-by-PK hot path, driven by SQLRite re-parsing the SQL on every iteration. That's the baseline a future "prepared-statement support" follow-up needs to move.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p sqlrite-benchmarks --all-targets` clean (existing engine warnings unchanged from baseline)
- [x] Full CI-equivalent: `cargo build / test / doc --workspace --exclude {desktop,python,nodejs,benchmarks}` green
- [x] `cargo test -p sqlrite-benchmarks` — 5 tests pass (4 inliner + 1 ymd-from-days round-trip)
- [x] `cargo bench -p sqlrite-benchmarks --bench suite` runs end-to-end; aggregator wrote a 2-sample JSON envelope
- [x] `make bench` target wired through `scripts/run.sh`
- [x] CI excludes verified — `--exclude sqlrite-benchmarks` added to all four cargo commands in `.github/workflows/ci.yml`

## Follow-ups

- **9.2 (Group A)** — W2–W6. W4 (single-row INSERT) is the one most likely to expose the bottom-up-rebuild commit cost.
- **Prepared-statement support in SQLRite** — closing the per-iter parse gap is post-9.6, behind a `W1.v2` bump.
- **9.5 — DuckDB driver** — Cargo.toml feature + commented module placeholder ready to land.
- **9.6** — `docs/benchmarks.md` + first official pinned-host JSON committed + top-level README "Benchmarks" section.

## References

- Plan: [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.1-harness/docs/benchmarks-plan.md)
- Plan PR: #101
- Roadmap: [`docs/roadmap.md` "Possible extras"](https://github.com/joaoh82/rust_sqlite/blob/bench-9.1-harness/docs/roadmap.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)