### PR TITLE
feat(bench): Group A workloads — W2..W6 (sub-phase 9.2)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,7 +2,7 @@
 
 Benchmark suite for SQLRite vs SQLite (and friends). Tracks task **SQLR-4** / **SQLR-16**.
 
-> **Status (2026-05-06):** sub-phase 9.1 landed — harness + W1. W2–W12 land in 9.2–9.4. The first official pinned-host JSON gets committed in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
+> **Status (2026-05-06):** sub-phases 9.1 + 9.2 landed — harness + Group A (W1–W6). W7–W12 land in 9.3–9.4. The first official pinned-host JSON gets committed in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
 
 ## Quick start
 
@@ -26,7 +26,7 @@ Three drivers, in plan order:
 
 Three groups (full descriptions in [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md#workloads)):
 
-- **Group A — OLTP baseline.** W1 read-by-PK, W2 range scan, W3 bulk insert, W4 single-row insert, W5 mixed OLTP, W6 index lookup. Lands in 9.1 (W1) + 9.2.
+- **Group A — OLTP baseline.** W1 read-by-PK, W2 range scan, W3 bulk insert, W4 single-row insert, W5 mixed OLTP, W6 index lookup. ✅ shipped (9.1 + 9.2).
 - **Group B — SQL-feature scaling.** W7 aggregate, W8 GROUP BY, W9 INNER JOIN. Lands in 9.3.
 - **Group C — Differentiators.** W10 vector top-10, W11 BM25 top-10, W12 hybrid retrieval. Lands in 9.4.
 
@@ -49,18 +49,80 @@ Each `make bench` invocation drops a JSON file under `results/`. The `.gitignore
 
 The table below is updated as new workloads land. Numbers are placeholders until 9.6 commits an official pinned-host run; ratios shown here are illustrative output from the sub-phase 9.1 development run on the project owner's M-series MBP.
 
+> All numbers below come from a **smoke run** (criterion `--warm-up-time 1 --measurement-time 1-2 --sample-size 10`) on the project owner's M1 Pro / 32 GiB / macOS 23.5.0 host on `bench-9.2-group-a`. They're directionally honest but the official pinned-host publication is sub-phase 9.6's job. Open `target/criterion/report/index.html` after a local `make bench` for the full criterion HTML.
+
 ### W1 — read-by-PK (`SELECT name, payload FROM kv WHERE id = ?`)
 
 100k-row table, 10k random keys, in-process, prepared statement on the SQLite side / per-call parse on the SQLRite side (no parameter binding yet — see [`src/drivers/sqlrite.rs`](src/drivers/sqlrite.rs)).
 
 | Engine | Median latency | Throughput (ops/s) | Notes |
 |---|---|---|---|
-| SQLRite (this branch) | ~12 µs | ~84k | Per-iter parse + plan; no prepared params yet |
-| SQLite (rusqlite, WAL+NORMAL) | ~2.5 µs | ~395k | `prepare_cached` + bound `?` params |
+| SQLRite | ~19 µs | ~53k | Per-iter parse + plan; no prepared params yet |
+| SQLite (rusqlite, WAL+NORMAL) | ~2.4 µs | ~423k | `prepare_cached` + bound `?` params |
 
-**Read this as:** SQLRite is ~5× slower than SQLite on the hottest-path SELECT-by-PK on a sub-µs-per-op workload. Most of that gap is per-iteration parsing — SQLRite has no prepared-plan cache, so every iteration walks the `sqlparser` AST again. A future "prepared statement support" follow-up will tighten this; the W1 number is the baseline that work needs to move.
+**Read this as:** ~8× slower on the hottest-path SELECT-by-PK. Most of the gap is per-iteration parsing — SQLRite has no prepared-plan cache, so every iteration walks the `sqlparser` AST again. A future "prepared statement support" follow-up will tighten this.
 
-> Replace these numbers with the official pinned-host run that lands in 9.6. The sample command above also writes raw criterion HTML reports to `target/criterion/` for the curious — open `target/criterion/report/index.html`.
+### W2 — range scan (`WHERE secondary >= ? AND secondary <= ?`)
+
+100k-row table with a unique-index on `secondary` (a permutation of `1..=100_000`). Three width buckets, all measuring how the scan time scales with the number of matching rows.
+
+> SQLRite's tiny optimizer only probes the index on `<col> = <literal>` shape ([`docs/supported-sql.md:210`](../docs/supported-sql.md)) — range predicates fall back to full table scan, which is why all three width buckets land at ~the same SQLRite latency. SQLite uses the index for range scans.
+
+| Width | SQLRite | SQLite | Ratio |
+|---|---|---|---|
+| 100 rows | ~36.6 ms | ~60 µs | ~610× |
+| 1,000 rows | ~32.2 ms | ~594 µs | ~54× |
+| 10,000 rows | ~33.8 ms | ~6.5 ms | ~5× |
+
+**Read this as:** the ratio collapses as the matching set grows — SQLite's index range scan does its work, SQLRite's full-table scan does its (constant) work, and at 10k matching rows of a 100k table they converge. A future range-scan optimizer is the roadmap unlock here; the 100-row bucket gap is its yardstick.
+
+### W3 — bulk insert (100k rows in one transaction)
+
+`BEGIN; INSERT…×100k; COMMIT`. Per criterion sample is one full transaction; each sample starts from a fresh DB (`iter_batched(BatchSize::PerIteration)`). Only 10 samples requested per driver because each sample is expensive — re-run with `cargo bench -- --sample-size 30 --measurement-time 30 W3` to sharpen the estimate.
+
+| Engine | Median per 100k-row txn | Rows/s |
+|---|---|---|
+| SQLRite | ~1.35 s | ~74k |
+| SQLite (rusqlite, WAL+NORMAL) | ~206 ms | ~485k |
+| **Ratio** | **~6.6×** | |
+
+**Read this as:** in-transaction bulk paths are tractably close. The gap is mostly per-row parse + execute (no prepared cache on SQLRite), with one COMMIT amortized across all 100k rows. Same root cause as W1's per-iter parse, scaled up.
+
+### W4 — single-row insert (each in its own implicit transaction)
+
+`INSERT INTO kv_writes …` — auto-committed per row. Preloaded with 1,000 rows so the table size is stable across iterations (otherwise the bottom-up rebuild's O(N) commit cost would ramp through the bench window). See [`src/workloads/single_insert.rs`](src/workloads/single_insert.rs) for the preload rationale.
+
+| Engine | Median latency | Throughput (ops/s) |
+|---|---|---|
+| SQLRite | ~7.34 ms | ~136 |
+| SQLite (rusqlite, WAL+NORMAL) | ~10.9 µs | ~91k |
+| **Ratio** | **~673×** ⚠️ | |
+
+**Read this as:** every COMMIT triggers a full bottom-up B-tree rebuild on SQLRite. Even at a tiny 1k-row preload, the rebuild + WAL append + checkpoint per row dominates. **Investigation follow-up filed (SQLR-18)** per the plan's "if W4 shows >100× gap" heuristic — informational, not a release gate. The fix is a phase-level change (in-place B-tree splits, or LSM/SSTable swap), not a bench-suite tweak.
+
+### W5 — mixed OLTP (50/50 SELECT-by-PK + UPDATE-by-PK)
+
+YCSB-A flavor over the Group-A 100k-row table. Even iterations are SELECTs, odd iterations are UPDATEs. SELECTs are fast on both engines; UPDATEs hit the same per-row commit path as W4 — but on a 100k-row preload, so the rebuild cost is much larger.
+
+| Engine | Median per mixed op | Throughput (ops/s) |
+|---|---|---|
+| SQLRite | ~71.1 ms | ~14 |
+| SQLite (rusqlite, WAL+NORMAL) | ~12.3 µs | ~81k |
+| **Ratio** | **~5,800×** | |
+
+**Read this as:** same root cause as W4, amplified by 100× the preload (1k → 100k). The median sits in the bimodal "every other op is an O(100k) rebuild" zone. Tracked together with W4 under SQLR-18.
+
+### W6 — secondary-index lookup (`WHERE secondary = ?`)
+
+Unique-index probes — every probe matches exactly one row. SQLRite's optimizer fast-paths `<indexed_col> = <literal>`, so this exercises the same code path on both engines: B-tree probe + ROWID indirection + row reassembly.
+
+| Engine | Median latency | Throughput (ops/s) |
+|---|---|---|
+| SQLRite | ~14.6 µs | ~68k |
+| SQLite (rusqlite, WAL+NORMAL) | ~3.1 µs | ~323k |
+| **Ratio** | **~5×** | |
+
+**Read this as:** secondary-index path is healthy — same ~5–8× per-iter-parse-cost band as W1. The index probe itself is fine; what we're measuring is mostly `sqlparser` per call.
 
 ## Adding a workload
 
@@ -98,7 +160,12 @@ benchmarks/
 │   │   └── duckdb.rs      — feature-gated; lands in 9.5
 │   ├── workloads/
 │   │   ├── mod.rs
-│   │   └── kv.rs          — W1 read-by-PK (this PR)
+│   │   ├── kv.rs            — W1 read-by-PK
+│   │   ├── range_scan.rs    — W2 range scan (100/1k/10k)
+│   │   ├── bulk_insert.rs   — W3 bulk insert (100k/txn)
+│   │   ├── single_insert.rs — W4 single-row insert
+│   │   ├── mixed_oltp.rs    — W5 50/50 SELECT+UPDATE
+│   │   └── index_lookup.rs  — W6 secondary-index lookup
 │   └── bin/
 │       └── aggregate.rs   — walks target/criterion/ → results/*.json
 ├── benches/

--- a/benchmarks/benches/suite.rs
+++ b/benchmarks/benches/suite.rs
@@ -13,33 +13,58 @@
 //! 3. Runs the workload's `correctness_check` once. If the engine
 //!    returns the wrong shape, we fail fast rather than publish a
 //!    "speedup" that's just a bug.
-//! 4. Times `bench_iter` via `b.iter` over a pre-shuffled key slice.
+//! 4. Times `bench_iter` via `b.iter` over a pre-shuffled probe slice.
+//!
+//! W3 is the exception: each criterion sample needs to start from a
+//! fresh DB (otherwise samples after the first measure inserts into
+//! a table that's already been bulk-loaded), so it uses
+//! `iter_batched` with `BatchSize::PerIteration`.
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::measurement::WallTime;
+use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
+use std::path::{Path, PathBuf};
 
 use sqlrite_benchmarks::Driver;
 use sqlrite_benchmarks::drivers::sqlite::SQLiteDriver;
 use sqlrite_benchmarks::drivers::sqlrite::SQLRiteDriver;
-use sqlrite_benchmarks::workloads::kv as w1;
+use sqlrite_benchmarks::workloads::{
+    bulk_insert as w3, index_lookup as w6, kv as w1, mixed_oltp as w5, range_scan as w2,
+    single_insert as w4,
+};
 
-fn register_w1<D: Driver>(c: &mut Criterion, driver: D, suffix: &str) {
-    let tmp = tempfile::Builder::new()
-        .prefix(&format!("sqlrite-bench-w1-{suffix}-"))
+/// Pick a DB filename inside `dir` based on the driver — keeps a
+/// half-debugged file recognizable on disk.
+fn db_path(dir: &Path, driver_name: &str, stem: &str) -> PathBuf {
+    let ext = match driver_name {
+        "sqlite" => "sqlite",
+        "duckdb" => "duckdb",
+        _ => "sqlrite",
+    };
+    dir.join(format!("{stem}.{ext}"))
+}
+
+/// Make a tempdir keyed to a workload + driver pair so a half-finished
+/// run leaves a recognizable trail under `$TMPDIR`.
+fn tempdir_for(workload: &str, driver_name: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("sqlrite-bench-{workload}-{driver_name}-"))
         .tempdir()
-        .expect("tempdir");
-    let db_path = tmp.path().join(match driver.name() {
-        // Use the engine's native extension so a half-debugged DB is
-        // recognizable on disk.
-        "sqlite" => "w1.sqlite",
-        "duckdb" => "w1.duckdb",
-        _ => "w1.sqlrite",
-    });
-    let (mut conn, keys) = w1::setup(&driver, &db_path).expect("W1 setup");
+        .expect("tempdir")
+}
+
+// ---------------------------------------------------------------------------
+// W1 — read-by-PK
+// ---------------------------------------------------------------------------
+
+fn register_w1<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w1", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w1");
+    let (mut conn, keys) = w1::setup(&driver, &path).expect("W1 setup");
     w1::correctness_check(&driver, &mut conn).expect("W1 correctness check");
 
     let mut group = c.benchmark_group(w1::W1.full());
-    let bench_id = format!("{}/{}", driver.name(), suffix);
+    let bench_id = format!("{}/default", driver.name());
     let mut idx = 0usize;
     group.bench_function(&bench_id, |b| {
         b.iter(|| {
@@ -50,15 +75,224 @@ fn register_w1<D: Driver>(c: &mut Criterion, driver: D, suffix: &str) {
         });
     });
     group.finish();
-
-    // Keep tempdir alive until all benches finished — drop here.
     drop(conn);
     drop(tmp);
 }
 
+// ---------------------------------------------------------------------------
+// W2 — range scan (three width buckets: 100 / 1k / 10k)
+// ---------------------------------------------------------------------------
+
+fn register_w2<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w2", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w2");
+    let (mut conn, dataset) = w2::setup(&driver, &path).expect("W2 setup");
+    // Run correctness across all three widths so the gate proves the
+    // engine returns the right count for each.
+    for &(_, width) in &w2::RANGE_SIZES {
+        w2::correctness_check(&driver, &mut conn, width).expect("W2 correctness check");
+    }
+
+    for &(label, _width) in &w2::RANGE_SIZES {
+        // One criterion group per width — keeps the JSON envelope
+        // tidy (each range size becomes its own (workload, driver)
+        // sample row in `benchmarks/results/*.json`).
+        let group_name = format!("{}/range-{}", w2::W2.full(), label);
+        let mut group = c.benchmark_group(&group_name);
+        bench_w2_width(&mut group, &driver, &mut conn, label, &dataset);
+        group.finish();
+    }
+    drop(conn);
+    drop(tmp);
+}
+
+fn bench_w2_width<D: Driver>(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    driver: &D,
+    conn: &mut D::Conn,
+    label: &str,
+    dataset: &sqlrite_benchmarks::data::GroupADataset,
+) {
+    let probes: &[(i64, i64)] = match label {
+        "100" => &dataset.range_probes_100,
+        "1k" => &dataset.range_probes_1k,
+        "10k" => &dataset.range_probes_10k,
+        _ => panic!("unknown W2 width label: {label}"),
+    };
+    let bench_id = format!("{}/default", driver.name());
+    let mut idx = 0usize;
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let (lo, hi) = probes[idx % probes.len()];
+            idx = idx.wrapping_add(1);
+            let count = w2::bench_iter(driver, conn, lo, hi).expect("W2 query");
+            black_box(count)
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// W3 — bulk insert (100k rows in one transaction)
+// ---------------------------------------------------------------------------
+
+fn register_w3<D: Driver + 'static>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w3", driver.name());
+    let dataset = w3::dataset();
+
+    // Sanity-check correctness on a one-shot insert against a probe
+    // file before the timed loop — same DB lifecycle a real iter
+    // sees.
+    {
+        let probe_path = db_path(tmp.path(), driver.name(), "w3-probe");
+        let mut probe_conn = w3::setup_iter(&driver, &probe_path).expect("W3 probe setup");
+        w3::bench_iter(&driver, &mut probe_conn, &dataset).expect("W3 probe insert");
+        w3::correctness_check(&driver, &mut probe_conn, dataset.rows.len())
+            .expect("W3 correctness check");
+        drop(probe_conn);
+        std::fs::remove_file(&probe_path).ok();
+        // Also clean up the WAL sidecar SQLRite leaves behind so
+        // criterion doesn't reopen a stale half-checkpointed file
+        // when it picks the same path on a subsequent run.
+        std::fs::remove_file(probe_path.with_extension(format!(
+            "{}-wal",
+            probe_path
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+        )))
+        .ok();
+    }
+
+    let mut group = c.benchmark_group(w3::W3.full());
+    // 100k inserts per sample = expensive; cap the sample count and
+    // measurement-time so a single-driver run finishes in a couple
+    // of minutes instead of a quarter-hour. Override at the CLI with
+    // `cargo bench -- --measurement-time 30 --sample-size 30` to
+    // sharpen the estimate.
+    group.sample_size(10);
+    let bench_id = format!("{}/default", driver.name());
+    // Each sample needs its own DB. `iter_batched` runs the setup
+    // closure outside timing; the routine closure is what criterion
+    // measures.
+    let tmp_path = tmp.path().to_path_buf();
+    let driver_name = driver.name().to_string();
+    group.bench_function(&bench_id, |b| {
+        b.iter_batched(
+            || {
+                // Per-sample fresh DB. Stamp the path with a counter
+                // so SQLRite's WAL sidecar from one sample doesn't
+                // collide with the next.
+                static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+                let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                let stem = format!("w3-{n}");
+                let path = db_path(&tmp_path, &driver_name, &stem);
+                let conn = w3::setup_iter(&driver, &path).expect("W3 setup");
+                (conn, path)
+            },
+            |(mut conn, _path)| {
+                w3::bench_iter(&driver, &mut conn, &dataset).expect("W3 bulk insert");
+                drop(conn);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// W4 — single-row insert
+// ---------------------------------------------------------------------------
+
+fn register_w4<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w4", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w4");
+    let (mut conn, mut next_id) = w4::setup(&driver, &path).expect("W4 setup");
+    w4::correctness_check(&driver, &mut conn).expect("W4 correctness check");
+
+    let mut group = c.benchmark_group(w4::W4.full());
+    let bench_id = format!("{}/default", driver.name());
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let id = next_id;
+            next_id += 1;
+            w4::bench_iter(&driver, &mut conn, id).expect("W4 INSERT");
+        });
+    });
+    group.finish();
+    drop(conn);
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// W5 — mixed OLTP
+// ---------------------------------------------------------------------------
+
+fn register_w5<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w5", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w5");
+    let (mut conn, dataset) = w5::setup(&driver, &path).expect("W5 setup");
+    w5::correctness_check(&driver, &mut conn, &dataset).expect("W5 correctness check");
+
+    let mut group = c.benchmark_group(w5::W5.full());
+    let bench_id = format!("{}/default", driver.name());
+    let keys = dataset.pk_probes.clone();
+    let mut iter_idx = 0usize;
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            w5::bench_iter(&driver, &mut conn, iter_idx, &keys).expect("W5 op");
+            iter_idx = iter_idx.wrapping_add(1);
+        });
+    });
+    group.finish();
+    drop(conn);
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// W6 — secondary-index lookup
+// ---------------------------------------------------------------------------
+
+fn register_w6<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w6", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w6");
+    let (mut conn, dataset) = w6::setup(&driver, &path).expect("W6 setup");
+    w6::correctness_check(&driver, &mut conn, &dataset).expect("W6 correctness check");
+
+    let mut group = c.benchmark_group(w6::W6.full());
+    let bench_id = format!("{}/default", driver.name());
+    let probes = dataset.secondary_probes.clone();
+    let mut idx = 0usize;
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let secondary = probes[idx % probes.len()];
+            idx = idx.wrapping_add(1);
+            let row = w6::bench_iter(&driver, &mut conn, secondary).expect("W6 query");
+            black_box(row)
+        });
+    });
+    group.finish();
+    drop(conn);
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
 fn benches(c: &mut Criterion) {
-    register_w1(c, SQLRiteDriver, "default");
-    register_w1(c, SQLiteDriver, "default");
+    register_w1(c, SQLRiteDriver);
+    register_w1(c, SQLiteDriver);
+    register_w2(c, SQLRiteDriver);
+    register_w2(c, SQLiteDriver);
+    register_w3(c, SQLRiteDriver);
+    register_w3(c, SQLiteDriver);
+    register_w4(c, SQLRiteDriver);
+    register_w4(c, SQLiteDriver);
+    register_w5(c, SQLRiteDriver);
+    register_w5(c, SQLiteDriver);
+    register_w6(c, SQLRiteDriver);
+    register_w6(c, SQLiteDriver);
 }
 
 criterion_group!(suite, benches);

--- a/benchmarks/src/data.rs
+++ b/benchmarks/src/data.rs
@@ -11,6 +11,7 @@
 //! from the seed. Larger workloads (W7's 1M-row aggregate) might need
 //! the on-disk cache; that lands alongside W7 in 9.3.
 
+use rand::Rng;
 use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use rand_chacha::ChaCha8Rng;
@@ -70,6 +71,146 @@ pub fn w1_dataset() -> W1Dataset {
     keys.truncate(W1_KEY_COUNT);
 
     W1Dataset { rows, keys }
+}
+
+/// Dataset for the Group-A "secondary-indexed" workloads: W2 (range
+/// scan), W3 (bulk insert), W5 (mixed OLTP), W6 (secondary-index
+/// lookup).
+///
+/// Schema:
+///
+/// ```sql
+/// CREATE TABLE kv2 (
+///   id        INTEGER PRIMARY KEY,
+///   secondary INTEGER,
+///   payload   TEXT
+/// );
+/// CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary);
+/// ```
+///
+/// `secondary` is a deterministic permutation of `1..=100_000`, so:
+/// - **W6** secondary-index probes are unique-row lookups on a non-PK
+///   index (every probe hits exactly one row).
+/// - **W2** ranges of width N over `secondary` hit exactly N rows (not
+///   ±a few, since the values densely cover `1..=100_000`).
+///
+/// `pk_probes`, `secondary_probes`, and the three `range_probes_*`
+/// slices are pre-shuffled in `setup` and reused across the bench's
+/// hot loop — same pattern as W1's `keys`.
+pub struct GroupADataset {
+    pub rows: Vec<GroupARow>,
+    /// Random PK probes — used by W5 (mixed OLTP) and indirectly by
+    /// any future workload doing PK lookups against this dataset.
+    pub pk_probes: Vec<i64>,
+    /// Random `secondary`-value probes — used by W6 for secondary-
+    /// index lookup.
+    pub secondary_probes: Vec<i64>,
+    /// Random `(lo, hi)` ranges of width 100 over `secondary` — W2.
+    pub range_probes_100: Vec<(i64, i64)>,
+    /// Random `(lo, hi)` ranges of width 1k — W2.
+    pub range_probes_1k: Vec<(i64, i64)>,
+    /// Random `(lo, hi)` ranges of width 10k — W2.
+    pub range_probes_10k: Vec<(i64, i64)>,
+}
+
+pub struct GroupARow {
+    pub id: i64,
+    pub secondary: i64,
+    pub payload: String,
+}
+
+/// Total rows in the Group-A dataset. Same scale as W1 so the
+/// SELECT-by-PK numbers between the two workloads are directly
+/// comparable.
+pub const GROUP_A_ROW_COUNT: usize = 100_000;
+
+/// Hot-loop probe count. Large enough that criterion's iterator
+/// pre-walk doesn't repeat the same key for thousands of iterations
+/// (which would lean on the OS page cache and skew the gap).
+pub const GROUP_A_PROBE_COUNT: usize = 10_000;
+
+/// Number of distinct `(lo, hi)` pairs criterion's hot loop rotates
+/// through for each W2 range size. Smaller than `GROUP_A_PROBE_COUNT`
+/// because each range scan touches up to 10k rows; we don't need
+/// thousands of distinct windows to avoid cache effects.
+pub const GROUP_A_RANGE_PROBE_COUNT: usize = 64;
+
+const GROUP_A_SEED: u64 = 43;
+
+/// Build the Group-A dataset deterministically. Reuses the same
+/// `payload_for` helper as W1, so identical `id`s produce identical
+/// payloads across workloads (cuts down on cross-workload variance
+/// when the row reassembly path is the bottleneck).
+pub fn group_a_dataset() -> GroupADataset {
+    let mut rng = ChaCha8Rng::seed_from_u64(GROUP_A_SEED);
+
+    // Build the secondary-value permutation up front: shuffle
+    // `1..=N` so each id maps to a unique non-PK-ordered value.
+    let mut secondaries: Vec<i64> = (1..=GROUP_A_ROW_COUNT as i64).collect();
+    secondaries.shuffle(&mut rng);
+
+    let mut rows = Vec::with_capacity(GROUP_A_ROW_COUNT);
+    for (i, &secondary) in secondaries.iter().enumerate() {
+        let id = (i + 1) as i64;
+        rows.push(GroupARow {
+            id,
+            secondary,
+            payload: payload_for(id),
+        });
+    }
+
+    let mut pk_probes: Vec<i64> = (1..=GROUP_A_ROW_COUNT as i64).collect();
+    pk_probes.shuffle(&mut rng);
+    pk_probes.truncate(GROUP_A_PROBE_COUNT);
+
+    let mut secondary_probes = secondaries.clone();
+    secondary_probes.shuffle(&mut rng);
+    secondary_probes.truncate(GROUP_A_PROBE_COUNT);
+
+    let range_probes_100 = build_range_probes(&mut rng, 100);
+    let range_probes_1k = build_range_probes(&mut rng, 1_000);
+    let range_probes_10k = build_range_probes(&mut rng, 10_000);
+
+    GroupADataset {
+        rows,
+        pk_probes,
+        secondary_probes,
+        range_probes_100,
+        range_probes_1k,
+        range_probes_10k,
+    }
+}
+
+/// Pick `GROUP_A_RANGE_PROBE_COUNT` non-overlapping random `(lo, hi)`
+/// pairs of `width` rows each. `lo` is uniform in
+/// `1..=GROUP_A_ROW_COUNT - width + 1` so every range stays in-bounds.
+fn build_range_probes(rng: &mut ChaCha8Rng, width: i64) -> Vec<(i64, i64)> {
+    let max_lo = GROUP_A_ROW_COUNT as i64 - width + 1;
+    let mut out = Vec::with_capacity(GROUP_A_RANGE_PROBE_COUNT);
+    for _ in 0..GROUP_A_RANGE_PROBE_COUNT {
+        let lo = rng.gen_range(1..=max_lo);
+        out.push((lo, lo + width - 1));
+    }
+    out
+}
+
+/// W4 single-row-insert dataset. The bench loop generates rows on the
+/// fly with monotonically-increasing PKs starting at this base, so the
+/// preload (rows `1..=BASE-1`) sets a stable table size before timing
+/// begins. Without that, the first iter measures an empty-table insert
+/// while later iters measure a `iters_so_far`-sized table — a steep
+/// O(N) ramp on SQLRite's bottom-up commit path that would dominate
+/// the median.
+pub const W4_PRELOAD_ROWS: i64 = 1_000;
+
+/// Stable payload for W4 inserts. Same length as W1 / Group-A so the
+/// row-write path exercises the same cell-encoding cost.
+pub const W4_PAYLOAD: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/// Reuses [`payload_for`] for any workload that wants the same
+/// per-id-stable 64-char string the Group-A / W1 datasets carry.
+pub fn payload_str(id: i64) -> String {
+    payload_for(id)
 }
 
 fn payload_for(id: i64) -> String {

--- a/benchmarks/src/workloads/bulk_insert.rs
+++ b/benchmarks/src/workloads/bulk_insert.rs
@@ -1,0 +1,97 @@
+//! W3 — bulk insert (100k rows in one transaction).
+//!
+//! ```sql
+//! CREATE TABLE kv (id INTEGER PRIMARY KEY, name TEXT, payload TEXT);
+//! BEGIN;
+//! INSERT INTO kv (id, name, payload) VALUES (?, ?, ?);  -- 100k times
+//! COMMIT;
+//! ```
+//!
+//! This is the macro-bench: each criterion sample is one full
+//! 100k-row transaction. Per-iter cost is dominated by:
+//! - parsing 100k INSERTs (SQLRite has no statement cache yet),
+//! - cell-encoding 100k rows (~6.4 MB of payload + ints),
+//! - the COMMIT — for SQLRite that's a single bottom-up B-tree
+//!   rebuild + WAL append + checkpoint; for SQLite-WAL+NORMAL
+//!   that's an fsync-on-checkpoint at boundary.
+//!
+//! The bench uses [`criterion::Criterion::iter_batched`] with
+//! [`criterion::BatchSize::PerIteration`] so the table is *recreated
+//! fresh per sample* — without that, samples would write into a
+//! growing table and the bench would measure an N² rebuild ramp on
+//! SQLRite's commit path. Setup (open conn + CREATE TABLE) runs in
+//! the batched-setup closure and is excluded from timing.
+//!
+//! Throughput-wise, the relevant unit is "rows/s" rather than the
+//! per-iter latency criterion reports. The aggregator records
+//! `median_ns / row_count` in a downstream view; for now the README
+//! table just shows median latency for one full bulk insert.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{W1_ROW_COUNT, W1Dataset, w1_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W3: WorkloadId = WorkloadId {
+    id: "W3",
+    name: "bulk-insert",
+    version: "v1",
+};
+
+/// One per-iter dataset is reused across samples — the row contents
+/// are deterministic so reuse doesn't hide a correctness bug, and
+/// regenerating ~6 MB of payload per sample would dominate the
+/// "warm-cache" portion of criterion's runtime.
+pub fn dataset() -> W1Dataset {
+    w1_dataset()
+}
+
+/// Per-iter setup: open a fresh DB at `path`, run CREATE TABLE.
+/// Returned conn is moved into the timed closure.
+pub fn setup_iter<D: Driver>(driver: &D, path: &Path) -> Result<D::Conn> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE kv (id INTEGER PRIMARY KEY, name TEXT, payload TEXT)",
+    )?;
+    Ok(conn)
+}
+
+/// One iteration: BEGIN + 100k INSERTs + COMMIT against the freshly-
+/// set-up connection. Caller is responsible for cleaning up the DB
+/// file (handled by the per-iter `TempDir` in `benches/suite.rs`).
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn, dataset: &W1Dataset) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W3 BEGIN")?;
+    for row in &dataset.rows {
+        driver
+            .execute_with_params(
+                conn,
+                "INSERT INTO kv (id, name, payload) VALUES (?, ?, ?)",
+                &[
+                    Value::Integer(row.id),
+                    Value::Text(row.name.clone()),
+                    Value::Text(row.payload.clone()),
+                ],
+            )
+            .with_context(|| format!("W3 INSERT id={}", row.id))?;
+    }
+    driver.execute(conn, "COMMIT").context("W3 COMMIT")?;
+    debug_assert_eq!(dataset.rows.len(), W1_ROW_COUNT);
+    Ok(())
+}
+
+/// Correctness gate. Run after one full insert against a probe DB:
+/// the row count must equal the dataset's row count.
+pub fn correctness_check<D: Driver>(driver: &D, conn: &mut D::Conn, expected: usize) -> Result<()> {
+    let rows = driver.query_one(conn, "SELECT COUNT(*) FROM kv", &[])?;
+    let got = match rows.first() {
+        Some(Value::Integer(n)) => *n,
+        other => anyhow::bail!("W3 correctness: COUNT(*) returned unexpected shape: {other:?}"),
+    };
+    if got as usize != expected {
+        anyhow::bail!("W3 correctness: COUNT(*) = {got}, expected {expected}");
+    }
+    Ok(())
+}

--- a/benchmarks/src/workloads/index_lookup.rs
+++ b/benchmarks/src/workloads/index_lookup.rs
@@ -1,0 +1,102 @@
+//! W6 — secondary-index lookup.
+//!
+//! ```sql
+//! CREATE TABLE kv2 (id INTEGER PRIMARY KEY, secondary INTEGER, payload TEXT);
+//! CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary);
+//! -- Hot loop: SELECT id, payload FROM kv2 WHERE secondary = ?, 10k probes.
+//! ```
+//!
+//! Tests the secondary-index ROWID indirection path. SQLRite's tiny
+//! optimizer recognizes `<indexed_col> = <literal>` and probes the
+//! index — see [`docs/supported-sql.md:210`](../../docs/supported-sql.md).
+//! So unlike W2 (range scan), W6 should hit the index fast-path on
+//! both engines and the comparison is "B-tree probe + secondary fetch
+//! to row" vs "B-tree probe + row reassembly."
+//!
+//! Probes are unique-row lookups (`secondary` is a permutation of
+//! `1..=100_000`) so every `secondary = ?` matches exactly one row.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{GROUP_A_ROW_COUNT, GroupADataset, group_a_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W6: WorkloadId = WorkloadId {
+    id: "W6",
+    name: "index-lookup",
+    version: "v1",
+};
+
+pub const SELECT_SQL: &str = "SELECT id, payload FROM kv2 WHERE secondary = ?";
+
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, GroupADataset)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE kv2 (id INTEGER PRIMARY KEY, secondary INTEGER, payload TEXT)",
+    )?;
+    driver.execute(
+        &mut conn,
+        "CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary)",
+    )?;
+    let dataset = group_a_dataset();
+    insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset))
+}
+
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn, secondary: i64) -> Result<Vec<Value>> {
+    driver.query_one(conn, SELECT_SQL, &[Value::Integer(secondary)])
+}
+
+pub fn correctness_check<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    dataset: &GroupADataset,
+) -> Result<()> {
+    // Pick the first three secondary values from the dataset; assert
+    // each round-trips to the right (id, payload) pair.
+    for row in dataset.rows.iter().take(3) {
+        let result = driver.query_one(conn, SELECT_SQL, &[Value::Integer(row.secondary)])?;
+        match (result.first(), result.get(1)) {
+            (Some(Value::Integer(got_id)), Some(Value::Text(got_payload))) => {
+                if *got_id != row.id {
+                    anyhow::bail!(
+                        "W6 correctness: secondary={} → id {got_id}, expected {}",
+                        row.secondary,
+                        row.id
+                    );
+                }
+                if got_payload != &row.payload {
+                    anyhow::bail!(
+                        "W6 correctness: secondary={} → payload mismatch",
+                        row.secondary
+                    );
+                }
+            }
+            other => anyhow::bail!("W6 correctness: unexpected row shape {other:?}"),
+        }
+    }
+    Ok(())
+}
+
+fn insert_rows<D: Driver>(driver: &D, conn: &mut D::Conn, dataset: &GroupADataset) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W6 BEGIN")?;
+    for row in &dataset.rows {
+        driver
+            .execute_with_params(
+                conn,
+                "INSERT INTO kv2 (id, secondary, payload) VALUES (?, ?, ?)",
+                &[
+                    Value::Integer(row.id),
+                    Value::Integer(row.secondary),
+                    Value::Text(row.payload.clone()),
+                ],
+            )
+            .with_context(|| format!("W6 INSERT id={}", row.id))?;
+    }
+    driver.execute(conn, "COMMIT").context("W6 COMMIT")?;
+    debug_assert_eq!(dataset.rows.len(), GROUP_A_ROW_COUNT);
+    Ok(())
+}

--- a/benchmarks/src/workloads/mixed_oltp.rs
+++ b/benchmarks/src/workloads/mixed_oltp.rs
@@ -1,0 +1,143 @@
+//! W5 — mixed OLTP (50/50 SELECT-by-PK + UPDATE-by-PK).
+//!
+//! ```sql
+//! CREATE TABLE kv2 (id INTEGER PRIMARY KEY, secondary INTEGER, payload TEXT);
+//! CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary);
+//! -- 100k rows from group_a_dataset.
+//! -- Hot loop alternates two op shapes:
+//! --   SELECT id, secondary, payload FROM kv2 WHERE id = ?
+//! --   UPDATE kv2 SET payload = ? WHERE id = ?
+//! ```
+//!
+//! YCSB-A flavor: half reads, half writes, all by primary key. The
+//! plan calls for "100k-row keyed table, 10k ops" — criterion's
+//! per-iter loop drives that count organically (one mixed op per
+//! iter, criterion picks the iter count to fit its measurement
+//! window).
+//!
+//! The 50/50 mix is deterministic — even iterations are SELECT, odd
+//! iterations are UPDATE. That gives stable mix ratios across runs
+//! and keeps both operation paths warm in cache. The keys for both
+//! op kinds rotate through a pre-shuffled `pk_probes` slice so PK
+//! traversal is unpredictable.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{GROUP_A_ROW_COUNT, GroupADataset, group_a_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W5: WorkloadId = WorkloadId {
+    id: "W5",
+    name: "mixed-oltp",
+    version: "v1",
+};
+
+pub const SELECT_SQL: &str = "SELECT id, secondary, payload FROM kv2 WHERE id = ?";
+pub const UPDATE_SQL: &str = "UPDATE kv2 SET payload = ? WHERE id = ?";
+
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, GroupADataset)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE kv2 (id INTEGER PRIMARY KEY, secondary INTEGER, payload TEXT)",
+    )?;
+    driver.execute(
+        &mut conn,
+        "CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary)",
+    )?;
+    let dataset = group_a_dataset();
+    insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset))
+}
+
+/// One iteration. Even `iter_idx` → SELECT; odd → UPDATE.
+///
+/// For UPDATEs, the new payload is a function of the iter index so
+/// successive UPDATEs on the same key actually change the column
+/// (some engines short-circuit no-op UPDATEs). The new payload keeps
+/// the 64-char width of the originals.
+pub fn bench_iter<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    iter_idx: usize,
+    keys: &[i64],
+) -> Result<()> {
+    let key = keys[iter_idx % keys.len()];
+    if iter_idx % 2 == 0 {
+        let row = driver.query_one(conn, SELECT_SQL, &[Value::Integer(key)])?;
+        if row.len() != 3 {
+            anyhow::bail!("W5 SELECT: unexpected row width {}", row.len());
+        }
+    } else {
+        let new_payload = update_payload(iter_idx);
+        driver.execute_with_params(
+            conn,
+            UPDATE_SQL,
+            &[Value::Text(new_payload), Value::Integer(key)],
+        )?;
+    }
+    Ok(())
+}
+
+pub fn correctness_check<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    dataset: &GroupADataset,
+) -> Result<()> {
+    // SELECT round-trip on a known key.
+    let key = dataset.rows[0].id;
+    let row = driver.query_one(conn, SELECT_SQL, &[Value::Integer(key)])?;
+    if row.len() != 3 {
+        anyhow::bail!("W5 correctness: SELECT row width {}", row.len());
+    }
+    // UPDATE / SELECT round-trip.
+    let new_payload = update_payload(99_999);
+    driver.execute_with_params(
+        conn,
+        UPDATE_SQL,
+        &[Value::Text(new_payload.clone()), Value::Integer(key)],
+    )?;
+    let after = driver.query_one(conn, SELECT_SQL, &[Value::Integer(key)])?;
+    match after.get(2) {
+        Some(Value::Text(s)) if s == &new_payload => Ok(()),
+        other => anyhow::bail!("W5 correctness: UPDATE round-trip got {other:?}"),
+    }
+}
+
+fn update_payload(iter_idx: usize) -> String {
+    // 64 chars, deterministic per iter index. Same width as the
+    // original payload so the row's cell layout stays stable.
+    let mut s = String::with_capacity(64);
+    let mut x = (iter_idx as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    for _ in 0..8 {
+        s.push_str(&format!("{x:016x}"));
+        x = x.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+        if s.len() >= 64 {
+            s.truncate(64);
+            break;
+        }
+    }
+    s
+}
+
+fn insert_rows<D: Driver>(driver: &D, conn: &mut D::Conn, dataset: &GroupADataset) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W5 BEGIN")?;
+    for row in &dataset.rows {
+        driver
+            .execute_with_params(
+                conn,
+                "INSERT INTO kv2 (id, secondary, payload) VALUES (?, ?, ?)",
+                &[
+                    Value::Integer(row.id),
+                    Value::Integer(row.secondary),
+                    Value::Text(row.payload.clone()),
+                ],
+            )
+            .with_context(|| format!("W5 INSERT id={}", row.id))?;
+    }
+    driver.execute(conn, "COMMIT").context("W5 COMMIT")?;
+    debug_assert_eq!(dataset.rows.len(), GROUP_A_ROW_COUNT);
+    Ok(())
+}

--- a/benchmarks/src/workloads/mod.rs
+++ b/benchmarks/src/workloads/mod.rs
@@ -14,4 +14,9 @@
 //!    mitigation: catch divergent semantics across engines before the
 //!    "winner" measurement is meaningful).
 
+pub mod bulk_insert;
+pub mod index_lookup;
 pub mod kv;
+pub mod mixed_oltp;
+pub mod range_scan;
+pub mod single_insert;

--- a/benchmarks/src/workloads/range_scan.rs
+++ b/benchmarks/src/workloads/range_scan.rs
@@ -1,0 +1,114 @@
+//! W2 — range scan over an indexed column.
+//!
+//! ```sql
+//! CREATE TABLE kv2 (id INTEGER PRIMARY KEY, secondary INTEGER, payload TEXT);
+//! CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary);
+//! -- 100k rows; secondary is a permutation of 1..=100_000.
+//! -- Hot loop: SELECT id, secondary, payload FROM kv2
+//! --          WHERE secondary >= ? AND secondary <= ?, three width buckets.
+//! ```
+//!
+//! The plan calls for `BETWEEN x AND y`. SQLRite [doesn't implement
+//! `BETWEEN` yet](../../docs/supported-sql.md#not-yet-supported), so the
+//! workload uses the equivalent `>= ? AND <= ?` form — semantically
+//! identical, both engines parse / execute it cleanly. Bumping to
+//! `BETWEEN` once the engine supports it is a workload-version bump
+//! (`W2.v2`).
+//!
+//! ## Methodology note
+//!
+//! Per [`docs/supported-sql.md:210`](../../docs/supported-sql.md):
+//! SQLRite's tiny optimizer probes the index only on `<col> = <literal>`
+//! shape — range predicates *fall back to a full table scan*. SQLite's
+//! optimizer uses the index for range scans. So W2 numbers are
+//! expected to show a much wider gap than W1: the scan is comparing
+//! "SQLRite full-scan + filter" against "SQLite index range probe".
+//! That's the honest comparison for the engine's current state and is
+//! itself a roadmap input — a future range-scan optimizer follow-up
+//! has W2 as its yardstick.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{GROUP_A_ROW_COUNT, GroupADataset, group_a_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W2: WorkloadId = WorkloadId {
+    id: "W2",
+    name: "range-scan",
+    version: "v1",
+};
+
+pub const SELECT_SQL: &str =
+    "SELECT id, secondary, payload FROM kv2 WHERE secondary >= ? AND secondary <= ?";
+
+/// Range size buckets. Plan calls for "100 / 1k / 10k rows" — these
+/// are the only three sizes shipped in v1. Adding a bucket = `v2`.
+pub const RANGE_SIZES: [(&str, i64); 3] = [("100", 100), ("1k", 1_000), ("10k", 10_000)];
+
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, GroupADataset)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE kv2 (id INTEGER PRIMARY KEY, secondary INTEGER, payload TEXT)",
+    )?;
+    driver.execute(
+        &mut conn,
+        "CREATE UNIQUE INDEX idx_kv2_secondary ON kv2(secondary)",
+    )?;
+    let dataset = group_a_dataset();
+    insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset))
+}
+
+/// One iteration: count the rows that come back from the range scan.
+/// Returning the count (rather than the rows themselves) keeps the
+/// black_box fingerprint constant across iterations and lets us assert
+/// the row count matches the requested range width.
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn, lo: i64, hi: i64) -> Result<usize> {
+    let rows = driver.query_all(conn, SELECT_SQL, &[Value::Integer(lo), Value::Integer(hi)])?;
+    Ok(rows.len())
+}
+
+/// Correctness gate. Verifies the engine returns exactly `width` rows
+/// for a known-safe range, and that each row has the 3-column shape.
+/// Run once per (workload, driver) pair before the timed loop.
+pub fn correctness_check<D: Driver>(driver: &D, conn: &mut D::Conn, width: i64) -> Result<()> {
+    let lo = 1_000;
+    let hi = lo + width - 1;
+    let rows = driver.query_all(conn, SELECT_SQL, &[Value::Integer(lo), Value::Integer(hi)])?;
+    let count = rows.len() as i64;
+    if count != width {
+        anyhow::bail!("W2 correctness: range [{lo}, {hi}] returned {count} rows, expected {width}");
+    }
+    for r in rows.iter().take(3) {
+        if r.len() != 3 {
+            anyhow::bail!(
+                "W2 correctness: expected 3 columns (id, secondary, payload), got {}",
+                r.len()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn insert_rows<D: Driver>(driver: &D, conn: &mut D::Conn, dataset: &GroupADataset) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W2 BEGIN")?;
+    for row in &dataset.rows {
+        driver
+            .execute_with_params(
+                conn,
+                "INSERT INTO kv2 (id, secondary, payload) VALUES (?, ?, ?)",
+                &[
+                    Value::Integer(row.id),
+                    Value::Integer(row.secondary),
+                    Value::Text(row.payload.clone()),
+                ],
+            )
+            .with_context(|| format!("W2 INSERT id={}", row.id))?;
+    }
+    driver.execute(conn, "COMMIT").context("W2 COMMIT")?;
+    debug_assert_eq!(dataset.rows.len(), GROUP_A_ROW_COUNT);
+    Ok(())
+}

--- a/benchmarks/src/workloads/single_insert.rs
+++ b/benchmarks/src/workloads/single_insert.rs
@@ -1,0 +1,119 @@
+//! W4 — single-row insert (each in its own implicit transaction).
+//!
+//! ```sql
+//! CREATE TABLE kv_writes (id INTEGER PRIMARY KEY, payload TEXT);
+//! -- preload 1000 rows so the table has a representative size
+//! -- before timing begins (see "Preload rationale" below)
+//! INSERT INTO kv_writes (id, payload) VALUES (?, ?);  -- one per iter
+//! ```
+//!
+//! W4 is the fsync / commit-cost hot path. Each iter is one INSERT
+//! that auto-commits (no `BEGIN` wrapping) — for SQLRite that
+//! triggers a full bottom-up B-tree rebuild + WAL append + checkpoint
+//! per row; for SQLite-WAL+NORMAL that's "WAL frame append, fsync at
+//! checkpoint boundary." The per-iter latency is dominated by these
+//! commit-side costs, which is why the plan flags W4 as the workload
+//! most likely to surface a >100× gap. (If it does, file an
+//! investigation follow-up before moving on.)
+//!
+//! ## Preload rationale
+//!
+//! With no preload the first iters hit a near-empty table and later
+//! iters hit a table grown to `iters_so_far` rows. SQLRite's
+//! bottom-up commit is O(N) per insert, so without a preload the
+//! per-iter cost climbs over the bench window and criterion's median
+//! reflects "table size ≈ samples/2." Preloading [`W4_PRELOAD_ROWS`]
+//! puts the table at a stable size before the timed loop starts, so
+//! the median reflects "small-table single-row INSERT" — the actual
+//! engineering question.
+//!
+//! Bumping the preload (e.g. to 10k or 100k) would measure
+//! "medium / large-table commit cost" and is worth a separate
+//! workload eventually (`W4b` or `W4.v2`). v1 keeps the smaller
+//! preload so the headline number isn't dominated by O(N) rebuild
+//! work that's a separately-tracked roadmap item.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{W4_PAYLOAD, W4_PRELOAD_ROWS};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W4: WorkloadId = WorkloadId {
+    id: "W4",
+    name: "single-insert",
+    version: "v1",
+};
+
+/// Setup: open fresh DB, create `kv_writes`, preload [`W4_PRELOAD_ROWS`]
+/// rows in one transaction (so preload doesn't pay per-row commit
+/// cost — that's W4's measurement, not part of setup).
+///
+/// Returns the conn + the next id the bench loop should use (one
+/// past the preload).
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, i64)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE kv_writes (id INTEGER PRIMARY KEY, payload TEXT)",
+    )?;
+    driver
+        .execute(&mut conn, "BEGIN")
+        .context("W4 preload BEGIN")?;
+    for id in 1..=W4_PRELOAD_ROWS {
+        driver
+            .execute_with_params(
+                &mut conn,
+                "INSERT INTO kv_writes (id, payload) VALUES (?, ?)",
+                &[Value::Integer(id), Value::Text(W4_PAYLOAD.to_string())],
+            )
+            .with_context(|| format!("W4 preload id={id}"))?;
+    }
+    driver
+        .execute(&mut conn, "COMMIT")
+        .context("W4 preload COMMIT")?;
+    Ok((conn, W4_PRELOAD_ROWS + 1))
+}
+
+/// One iteration: a single auto-committed INSERT with the given id.
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn, id: i64) -> Result<()> {
+    driver
+        .execute_with_params(
+            conn,
+            "INSERT INTO kv_writes (id, payload) VALUES (?, ?)",
+            &[Value::Integer(id), Value::Text(W4_PAYLOAD.to_string())],
+        )
+        .with_context(|| format!("W4 INSERT id={id}"))
+}
+
+/// Correctness gate. After setup the table must contain exactly
+/// [`W4_PRELOAD_ROWS`]; insert one extra and verify it round-trips.
+pub fn correctness_check<D: Driver>(driver: &D, conn: &mut D::Conn) -> Result<()> {
+    let probe_id = W4_PRELOAD_ROWS + 1_000_000; // far past the preload
+    bench_iter(driver, conn, probe_id)?;
+    let row = driver.query_one(
+        conn,
+        "SELECT id, payload FROM kv_writes WHERE id = ?",
+        &[Value::Integer(probe_id)],
+    )?;
+    match (row.first(), row.get(1)) {
+        (Some(Value::Integer(got_id)), Some(Value::Text(got_payload))) => {
+            if *got_id != probe_id {
+                anyhow::bail!("W4 correctness: id round-trip {got_id} != {probe_id}");
+            }
+            if got_payload != W4_PAYLOAD {
+                anyhow::bail!("W4 correctness: payload round-trip mismatch");
+            }
+        }
+        other => anyhow::bail!("W4 correctness: unexpected row shape {other:?}"),
+    }
+    // Clean up the correctness-probe row so it doesn't collide with
+    // the bench loop's id space (which starts at W4_PRELOAD_ROWS+1).
+    driver.execute_with_params(
+        conn,
+        "DELETE FROM kv_writes WHERE id = ?",
+        &[Value::Integer(probe_id)],
+    )?;
+    Ok(())
+}

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -62,7 +62,7 @@ See the [Roadmap](roadmap.md) for the full phase plan.
 
 - [Phase 7 plan](phase-7-plan.md) — AI-era extensions (vector column type + HNSW, JSON, NL→SQL `ask()` API across REPL/library/SDKs/desktop/MCP, MCP server). **Implementation complete except 7f, which deferred to Phase 8.**
 - [Phase 8 plan](phase-8-plan.md) — Full-text search (FTS5-style BM25) + hybrid retrieval. The deferred 7f scope. **All six sub-phases (8a–8f) shipped.** Canonical reference: [`docs/fts.md`](fts.md).
-- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phase 9.1 (harness + W1) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench`. The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
+- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phases 9.1 (harness + W1) and 9.2 (Group A: W2–W6) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench`. The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
 
 ## Conventions
 

--- a/docs/benchmarks-plan.md
+++ b/docs/benchmarks-plan.md
@@ -1,6 +1,6 @@
 # Benchmarks plan — SQLRite vs SQLite (and friends)
 
-**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phase 9.1 in flight.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
+**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phases 9.1 + 9.2 shipped.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
 
 **TL;DR.** Stand up a small, focused benchmark suite that pits the engine against `SQLite` (mandatory) and `DuckDB` (optional, analytical-slice only) under a curated set of OLTP + analytical + AI-era workloads. Skip distributed and network-resident options (`Cloudflare D1`, `rqlite`) — they don't share SQLRite's deployment shape. Defer `libSQL` until we have a vector- or replication-flavored axis that justifies a third row-oriented embedded engine. Suite lives in a new top-level `benchmarks/` workspace member, not built by default, runs on demand on a pinned host, emits JSON for trend tracking.
 


### PR DESCRIPTION
## Summary

Sub-phase **9.2** of [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.2-group-a/docs/benchmarks-plan.md). Stacks on top of [#102](https://github.com/joaoh82/rust_sqlite/pull/102) (9.1 harness + W1) to land the OLTP-baseline workloads:

| ID | Shape | Status |
|---|---|---|
| W2 | Range scan — `WHERE secondary >= ? AND <= ?`, 100/1k/10k width buckets | ✅ |
| W3 | Bulk insert — `BEGIN; INSERT…×100k; COMMIT` | ✅ |
| W4 | Single-row insert — auto-commit per row on a 1k-row preloaded table | ✅ |
| W5 | Mixed OLTP — 50/50 SELECT-by-PK + UPDATE-by-PK on a 100k-row table | ✅ |
| W6 | Secondary-index lookup — `WHERE secondary = ?` (unique probes) | ✅ |

## Smoke-run numbers (M1 Pro, criterion `--warm-up-time 1 --measurement-time 1-2 --sample-size 10`)

| Workload | SQLRite | SQLite (rusqlite, WAL+NORMAL) | Ratio |
|---|---|---|---|
| W1 read-by-PK | ~19 µs | ~2.4 µs | ~8× |
| W2 range-100 | ~36.6 ms | ~60 µs | **~610×** |
| W2 range-1k | ~32.2 ms | ~594 µs | ~54× |
| W2 range-10k | ~33.8 ms | ~6.5 ms | ~5× |
| W3 bulk-100k | ~1.35 s | ~206 ms | ~6.6× |
| W4 single-insert | ~7.34 ms | ~10.9 µs | **~673× ⚠️** |
| W5 mixed OLTP | ~71.1 ms | ~12.3 µs | **~5,800×** |
| W6 index lookup | ~14.6 µs | ~3.1 µs | ~5× |

The W2 ratio collapses as the matching set grows — SQLite scales with the result-set size; SQLRite full-scans the table in constant time regardless of width. That's because the engine's tiny optimizer ([`docs/supported-sql.md:210`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.2-group-a/docs/supported-sql.md#L210)) only probes the index on `<col> = <literal>` shape — range predicates fall back to full scan. A future range-scan optimizer is the roadmap unlock.

## Plan-spec adherence

- **W2 uses `>= ? AND <= ?`** instead of `BETWEEN x AND y` — SQLRite doesn't ship `BETWEEN` yet (it's in supported-sql.md's "Not yet supported" list). Semantically equivalent; both engines parse + execute it cleanly. Bumping to `BETWEEN` once SQLRite supports it = `W2.v2`.
- **Q8 versioning preserved** — every workload's `WorkloadId.version` is `v1`. JSON envelope tags every sample with `W{n}.v{v}`.
- **Q3 SQLite tuning honored** — driver still applies the `WAL + synchronous=NORMAL + 64 MB cache + temp_store=MEMORY` profile from 9.1.

## W4 100× heuristic — investigation follow-up filed

The plan's exit criterion for 9.2:

> If W4 shows >100× gap, file a follow-up to investigate the commit path before moving on. (Investigation, not a gate — the gap is informational.)

W4 is at **~673×** and W5 (which amplifies the same root cause across a 100×-larger preload) is at **~5,800×**. Filed **SQLR-18 — "Investigate W4 single-row INSERT gap (~673× vs SQLite)"** — informational, not a release gate. Likely culprit per the existing project conventions doc is the bottom-up B-tree rebuild on every COMMIT; the task spec lists a flamegraph + roadmap-cross-link plan.

Also filed **SQLR-17 — "Investigate desktop-build CI hang on Tauri Linux deps step"** for the 39-min apt-get hang seen on the 9.1 PR's CI run, unrelated to this work.

## Methodology choices documented in code

- **W3** uses `iter_batched(BatchSize::PerIteration)` with a per-sample counter so SQLRite's WAL sidecar from one sample doesn't collide with the next. `sample_size(10)` so a single-driver run finishes in minutes.
- **W4** preloads 1,000 rows in one transaction before timing starts. Without that, the first iters hit a near-empty table and later iters hit a `iters_so_far`-sized table — SQLRite's O(N) bottom-up rebuild would create a steep ramp through the bench window. Preload puts the table at a stable size.
- **W5** alternates SELECT/UPDATE deterministically (even iters SELECT, odd iters UPDATE) so the 50/50 mix is repeatable across runs.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p sqlrite-benchmarks --all-targets` clean
- [x] Full CI-equivalent: `cargo build / test / doc --workspace --exclude {desktop,python,nodejs,benchmarks}` green
- [x] `cargo test -p sqlrite-benchmarks` — 5 tests pass (4 inliner + 1 ymd round-trip)
- [x] Smoke `cargo bench -p sqlrite-benchmarks --bench suite -- --warm-up-time 1 --measurement-time 1-2 --sample-size 10` runs all six workloads end-to-end on both engines
- [x] Aggregator post-processes the criterion output into a 14-row JSON envelope
- [x] W2 / W3 / W4 / W5 / W6 correctness gates pass on both drivers

## Follow-ups

- **SQLR-18** — flamegraph the W4 hot path on SQLRite; cross-link to the roadmap entry for "Possible extras → Alternate storage engines."
- **SQLR-17** — only act if the desktop-build apt hang recurs.
- **9.3** — Group B workloads (W7 aggregate, W8 GROUP BY, W9 INNER JOIN). Exercises the SQLR-3 (GROUP BY/aggregates) + SQLR-5 (JOIN) surface that landed in v0.7.0 / v0.8.0.
- **Prepared-statement support in SQLRite** is the natural unlock for W1's parse-cost-dominated band; would shrink W1/W6/W2-100 ratios. Post-9.6.

## References

- Parent task: SQLR-16
- 9.1: [#102](https://github.com/joaoh82/rust_sqlite/pull/102)
- Plan: [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.2-group-a/docs/benchmarks-plan.md)
- Code: [`benchmarks/src/workloads/`](https://github.com/joaoh82/rust_sqlite/tree/bench-9.2-group-a/benchmarks/src/workloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)