### PR TITLE
feat(bench): Group B workloads — W7..W9 (sub-phase 9.3)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,7 +2,7 @@
 
 Benchmark suite for SQLRite vs SQLite (and friends). Tracks task **SQLR-4** / **SQLR-16**.
 
-> **Status (2026-05-06):** sub-phases 9.1 + 9.2 landed — harness + Group A (W1–W6). W7–W12 land in 9.3–9.4. The first official pinned-host JSON gets committed in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
+> **Status (2026-05-07):** sub-phases 9.1 + 9.2 + 9.3 landed — harness + Group A (W1–W6) + Group B (W7–W9). W10–W12 land in 9.4. The first official pinned-host JSON gets committed in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
 
 ## Quick start
 
@@ -27,7 +27,7 @@ Three drivers, in plan order:
 Three groups (full descriptions in [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md#workloads)):
 
 - **Group A — OLTP baseline.** W1 read-by-PK, W2 range scan, W3 bulk insert, W4 single-row insert, W5 mixed OLTP, W6 index lookup. ✅ shipped (9.1 + 9.2).
-- **Group B — SQL-feature scaling.** W7 aggregate, W8 GROUP BY, W9 INNER JOIN. Lands in 9.3.
+- **Group B — SQL-feature scaling.** W7 aggregate, W8 GROUP BY, W9 INNER JOIN. ✅ shipped (9.3).
 - **Group C — Differentiators.** W10 vector top-10, W11 BM25 top-10, W12 hybrid retrieval. Lands in 9.4.
 
 Workloads are versioned (`W1.v1`, `W1.v2`, …) per Q8 — bumping the version is the explicit "I changed the benchmark" gesture.
@@ -124,6 +124,46 @@ Unique-index probes — every probe matches exactly one row. SQLRite's optimizer
 
 **Read this as:** secondary-index path is healthy — same ~5–8× per-iter-parse-cost band as W1. The index probe itself is fine; what we're measuring is mostly `sqlparser` per call.
 
+### W7 — `SELECT SUM(v) FROM big` (1M-row full-scan aggregate)
+
+Single-statement aggregate. No WHERE, no GROUP BY. Both engines walk every row through their executor; the question is how cheap the per-row "touch" is.
+
+| Engine | Median per SUM | Throughput (rows/s) |
+|---|---|---|
+| SQLRite | ~111 ms | ~9.0M |
+| SQLite (rusqlite, WAL+NORMAL) | ~31 ms | ~32M |
+| **Ratio** | **~3.5×** | |
+
+**Read this as:** healthy. The full-scan aggregator is the closest "engine throughput" measurement we have — no parse cache miss to amortize, just per-row work. Closer to SQLite than W1 (~8×) suggests the per-row machinery is tighter than the per-iter parse path. Encouraging; says the executor isn't broadly slow.
+
+### W8 — `SELECT k, COUNT(*) FROM big GROUP BY k` (three cardinalities)
+
+1M-row table, GROUP BY at 10 / 1k / 100k distinct keys.
+
+| Cardinality | SQLRite | SQLite (rusqlite, WAL+NORMAL) | Notes |
+|---|---|---|---|
+| 10 groups | ~204 ms | ~460 ms | SQLRite faster — likely SQLite's planner picks a sort-then-group path here (small group counts often slower than a hash). Not the headline; small samples. |
+| 1,000 groups | ~1.50 s | ~242 ms | ~6.2× |
+| 100,000 groups | **skipped** | ~241 ms | SQLRite skipped by default — see note below |
+
+**SQLRite × 100k-cardinality is skipped by default** in `make bench`. A first measurement clocked ~245 s/iter (~41 min for 10 samples), strongly suggesting an O(n × cardinality) path inside the GROUP BY executor (a hash aggregator should be O(n + groups)). **SQLR-19** tracks the investigation. Set `SQLRITE_BENCH_W8_CARD_100K_SQLRITE=1` once that lands to re-include the bucket.
+
+**Read this as:** GROUP BY at low cardinality is fine; high-cardinality work is broken. The fix is probably a `Vec`-backed group store → `HashMap`-backed.
+
+### W9 — INNER JOIN, customer ↔ order, probe by customer PK
+
+Plan target was two **100k-row tables**. v1 ships at **10k rows** because SQLRite's join executor doesn't push the ON predicate down to an index probe on the inner side — at the 100k scale, per-iter cost was >5 minutes (88 minutes of measured runtime didn't produce a single sample before the smoke run was killed). **SQLR-20** tracks the join-planner / inner-side index-probe fix. Until then, v1 = 10k rows; bumping to 100k follows the fix + a `W9.v2` tag.
+
+Even at 10k scale, the gap is large:
+
+| Engine | Median per probe | Throughput (probes/s) |
+|---|---|---|
+| SQLRite | ~32 s | ~0.03 |
+| SQLite (rusqlite, WAL+NORMAL) | ~2.3 µs | ~459k |
+| **Ratio** | **~14,000,000×** ⚠️ | |
+
+**Read this as:** SQLRite's join executor scans the entire inner table per outer row (no index probe pushdown), and the per-pair overhead is much higher than a single-table full scan. At 32 s for ~10k inner-row checks, the per-row cost is ~3 ms — about **3,000× slower** than W2's full-scan rate (1 µs/row). The inner-side index probe is the obvious next unlock; the per-pair overhead is the second.
+
 ## Adding a workload
 
 Per the [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md#sub-phases) sequencing:
@@ -165,7 +205,10 @@ benchmarks/
 │   │   ├── bulk_insert.rs   — W3 bulk insert (100k/txn)
 │   │   ├── single_insert.rs — W4 single-row insert
 │   │   ├── mixed_oltp.rs    — W5 50/50 SELECT+UPDATE
-│   │   └── index_lookup.rs  — W6 secondary-index lookup
+│   │   ├── index_lookup.rs  — W6 secondary-index lookup
+│   │   ├── aggregate.rs     — W7 SUM(v) over 1M rows
+│   │   ├── group_by.rs      — W8 GROUP BY (10/1k/100k cardinalities)
+│   │   └── join.rs          — W9 INNER JOIN, customer ↔ order
 │   └── bin/
 │       └── aggregate.rs   — walks target/criterion/ → results/*.json
 ├── benches/

--- a/benchmarks/benches/suite.rs
+++ b/benchmarks/benches/suite.rs
@@ -29,8 +29,8 @@ use sqlrite_benchmarks::Driver;
 use sqlrite_benchmarks::drivers::sqlite::SQLiteDriver;
 use sqlrite_benchmarks::drivers::sqlrite::SQLRiteDriver;
 use sqlrite_benchmarks::workloads::{
-    bulk_insert as w3, index_lookup as w6, kv as w1, mixed_oltp as w5, range_scan as w2,
-    single_insert as w4,
+    aggregate as w7, bulk_insert as w3, group_by as w8, index_lookup as w6, join as w9, kv as w1,
+    mixed_oltp as w5, range_scan as w2, single_insert as w4,
 };
 
 /// Pick a DB filename inside `dir` based on the driver — keeps a
@@ -277,6 +277,105 @@ fn register_w6<D: Driver>(c: &mut Criterion, driver: D) {
 }
 
 // ---------------------------------------------------------------------------
+// W7 — SUM aggregate over 1M rows
+// ---------------------------------------------------------------------------
+
+fn register_w7<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w7", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w7");
+    let (mut conn, dataset) = w7::setup(&driver, &path).expect("W7 setup");
+    w7::correctness_check(&driver, &mut conn, &dataset).expect("W7 correctness check");
+
+    let mut group = c.benchmark_group(w7::W7.full());
+    // SUM over 1M rows is single-shot heavy work — drop sample size
+    // so a smoke run finishes in a couple of minutes per driver.
+    group.sample_size(10);
+    let bench_id = format!("{}/default", driver.name());
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let n = w7::bench_iter(&driver, &mut conn).expect("W7 SUM");
+            black_box(n)
+        });
+    });
+    group.finish();
+    drop(conn);
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// W8 — GROUP BY at three cardinalities (10 / 1k / 100k groups)
+// ---------------------------------------------------------------------------
+
+fn register_w8<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w8", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w8");
+    let (mut conn, _dataset) = w8::setup(&driver, &path).expect("W8 setup");
+    w8::correctness_check(&driver, &mut conn).expect("W8 correctness check");
+
+    for &(label, bucket, _expected) in &w8::BUCKETS {
+        // SQLRite's GROUP BY at 100k-cardinality over 1M rows is
+        // pathologically slow today (~245 s per iter on an M-series
+        // MBP — see SQLR-19 for the investigation follow-up). That
+        // would block a smoke run for ~40 min, so we skip the cell
+        // by default. Set `SQLRITE_BENCH_W8_CARD_100K_SQLRITE=1` to
+        // force-include it once the blowup is resolved.
+        if label == "card-100k"
+            && driver.name() == "sqlrite"
+            && std::env::var("SQLRITE_BENCH_W8_CARD_100K_SQLRITE")
+                .ok()
+                .as_deref()
+                != Some("1")
+        {
+            continue;
+        }
+        let group_name = format!("{}/{}", w8::W8.full(), label);
+        let mut group = c.benchmark_group(&group_name);
+        group.sample_size(10);
+        let bench_id = format!("{}/default", driver.name());
+        group.bench_function(&bench_id, |b| {
+            b.iter(|| {
+                let n = w8::bench_iter(&driver, &mut conn, bucket).expect("W8 GROUP BY");
+                black_box(n)
+            });
+        });
+        group.finish();
+    }
+    drop(conn);
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
+// W9 — INNER JOIN, customer ↔ order, probe by customer PK
+// ---------------------------------------------------------------------------
+
+fn register_w9<D: Driver>(c: &mut Criterion, driver: D) {
+    let tmp = tempdir_for("w9", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w9");
+    let (mut conn, dataset) = w9::setup(&driver, &path).expect("W9 setup");
+    w9::correctness_check(&driver, &mut conn, &dataset).expect("W9 correctness check");
+
+    let mut group = c.benchmark_group(w9::W9.full());
+    // SQLRite's nested-loop join + un-indexed inner scan is heavy
+    // (~100k rows scanned per probe). Cap the sample size so a
+    // smoke run finishes; override at the CLI for a sharper estimate.
+    group.sample_size(10);
+    let bench_id = format!("{}/default", driver.name());
+    let probes = dataset.probes.clone();
+    let mut idx = 0usize;
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let cid = probes[idx % probes.len()];
+            idx = idx.wrapping_add(1);
+            let row = w9::bench_iter(&driver, &mut conn, cid).expect("W9 JOIN");
+            black_box(row)
+        });
+    });
+    group.finish();
+    drop(conn);
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -293,6 +392,12 @@ fn benches(c: &mut Criterion) {
     register_w5(c, SQLiteDriver);
     register_w6(c, SQLRiteDriver);
     register_w6(c, SQLiteDriver);
+    register_w7(c, SQLRiteDriver);
+    register_w7(c, SQLiteDriver);
+    register_w8(c, SQLRiteDriver);
+    register_w8(c, SQLiteDriver);
+    register_w9(c, SQLRiteDriver);
+    register_w9(c, SQLiteDriver);
 }
 
 criterion_group!(suite, benches);

--- a/benchmarks/src/data.rs
+++ b/benchmarks/src/data.rs
@@ -194,6 +194,154 @@ fn build_range_probes(rng: &mut ChaCha8Rng, width: i64) -> Vec<(i64, i64)> {
     out
 }
 
+/// Dataset for the Group-B "SQL-feature scaling" workloads — W7
+/// (SUM aggregate) and W8 (GROUP BY at three cardinalities).
+///
+/// Schema:
+///
+/// ```sql
+/// CREATE TABLE big (
+///   id     INTEGER PRIMARY KEY,
+///   v      INTEGER,
+///   k_10   INTEGER,
+///   k_1k   INTEGER,
+///   k_100k INTEGER
+/// );
+/// ```
+///
+/// - `v = (id * 7) mod 1000` — varied non-monotone integer for SUM.
+/// - `k_10 = id mod 10` — 10 distinct groups (W8 low-cardinality).
+/// - `k_1k = id mod 1000` — 1k distinct groups.
+/// - `k_100k = id mod 100_000` — 100k distinct groups (essentially
+///   one group per ~10 rows on a 1M-row table; the high-cardinality
+///   stress-test for the hash aggregator).
+///
+/// 1M rows is the plan's W7 target — the largest single-table dataset
+/// in the suite. 1M × ~40 bytes/row ≈ 40 MB on disk; well within
+/// SQLRite's whole-DB-in-RAM model on a 32 GiB host.
+pub struct GroupBDataset {
+    pub rows: Vec<GroupBRow>,
+    /// Pre-computed `SUM(v)` so the W7 correctness gate doesn't have
+    /// to re-derive it on every probe.
+    pub sum_v: i64,
+}
+
+pub struct GroupBRow {
+    pub id: i64,
+    pub v: i64,
+    pub k_10: i64,
+    pub k_1k: i64,
+    pub k_100k: i64,
+}
+
+/// 1M rows. Plan target for W7. W8 reuses the same dataset.
+pub const GROUP_B_ROW_COUNT: usize = 1_000_000;
+
+const GROUP_B_SEED: u64 = 44;
+
+pub fn group_b_dataset() -> GroupBDataset {
+    // Seed kept for forward-compat — the dataset is currently fully
+    // deterministic from `id`, but a future variant may shuffle `v`
+    // independently and we want the seed surface ready.
+    let _rng = ChaCha8Rng::seed_from_u64(GROUP_B_SEED);
+
+    let mut rows = Vec::with_capacity(GROUP_B_ROW_COUNT);
+    let mut sum_v: i64 = 0;
+    for i in 1..=GROUP_B_ROW_COUNT as i64 {
+        let v = (i.wrapping_mul(7)).rem_euclid(1_000);
+        sum_v += v;
+        rows.push(GroupBRow {
+            id: i,
+            v,
+            k_10: i.rem_euclid(10),
+            k_1k: i.rem_euclid(1_000),
+            k_100k: i.rem_euclid(100_000),
+        });
+    }
+    GroupBDataset { rows, sum_v }
+}
+
+/// W9 INNER JOIN dataset. Two 100k-row tables with a 1:1 PK/FK
+/// relationship — every customer has exactly one order. The hot loop
+/// probes by customer PK and joins to the matching order.
+///
+/// Schema:
+///
+/// ```sql
+/// CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT);
+/// CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, amount INTEGER);
+/// CREATE INDEX idx_orders_customer ON orders(customer_id);
+/// ```
+///
+/// SQLRite's join is a nested-loop driver without an inner-side index
+/// probe (see [`docs/supported-sql.md`](../../docs/supported-sql.md)
+/// "JOIN semantics" / `executor.rs::execute_select_rows_joined`). So
+/// per-PK-probe joins should show a meaningful gap vs SQLite's
+/// indexed-nested-loop join. That gap is informational — the plan
+/// flags it as the most useful "what does the join planner cost us?"
+/// number.
+pub struct JoinDataset {
+    pub customers: Vec<JoinCustomer>,
+    pub orders: Vec<JoinOrder>,
+    /// Random customer-PK probes for the bench hot loop.
+    pub probes: Vec<i64>,
+}
+
+pub struct JoinCustomer {
+    pub id: i64,
+    pub name: String,
+}
+
+pub struct JoinOrder {
+    pub id: i64,
+    pub customer_id: i64,
+    pub amount: i64,
+}
+
+/// Plan-deviation note (W9): the plan spec calls for "two 100k-row
+/// tables." A first smoke at that scale measured SQLRite at >5
+/// minutes per iteration on the criterion hot loop — the engine's
+/// join executor is a left-folded nested-loop driver that doesn't
+/// push the ON predicate down to an index probe on the inner side
+/// (`src/sql/executor.rs::execute_select_rows_joined`), so each
+/// per-PK probe scans the full 100k-row inner table. That scale is
+/// untenable for `make bench`.
+///
+/// v1 ships at **10k rows** instead. SQLRite still scans the whole
+/// inner side per probe — the per-probe cost is ~10× lower at this
+/// scale, the gap vs SQLite's indexed nested-loop join stays
+/// meaningful, and the bench finishes in seconds. Bumping back to
+/// 100k follows a SQLRite join-planner / indexed-inner-side
+/// improvement (tracked separately) and a `W9.v2` tag.
+pub const JOIN_ROW_COUNT: usize = 10_000;
+pub const JOIN_PROBE_COUNT: usize = 1_000;
+const JOIN_SEED: u64 = 45;
+
+pub fn join_dataset() -> JoinDataset {
+    let mut rng = ChaCha8Rng::seed_from_u64(JOIN_SEED);
+    let mut customers = Vec::with_capacity(JOIN_ROW_COUNT);
+    let mut orders = Vec::with_capacity(JOIN_ROW_COUNT);
+    for i in 1..=JOIN_ROW_COUNT as i64 {
+        customers.push(JoinCustomer {
+            id: i,
+            name: format!("customer_{i}"),
+        });
+        orders.push(JoinOrder {
+            id: i,
+            customer_id: i,
+            amount: i.rem_euclid(10_000),
+        });
+    }
+    let mut probes: Vec<i64> = (1..=JOIN_ROW_COUNT as i64).collect();
+    probes.shuffle(&mut rng);
+    probes.truncate(JOIN_PROBE_COUNT);
+    JoinDataset {
+        customers,
+        orders,
+        probes,
+    }
+}
+
 /// W4 single-row-insert dataset. The bench loop generates rows on the
 /// fly with monotonically-increasing PKs starting at this base, so the
 /// preload (rows `1..=BASE-1`) sets a stable table size before timing

--- a/benchmarks/src/workloads/aggregate.rs
+++ b/benchmarks/src/workloads/aggregate.rs
@@ -1,0 +1,82 @@
+//! W7 — `SELECT SUM(v) FROM big` over 1M rows.
+//!
+//! Full-scan + accumulator throughput. The query is the simplest
+//! possible aggregate — no GROUP BY, no WHERE, no projection-side
+//! arithmetic. SQLRite's executor (after the SQLR-3 GROUP BY /
+//! aggregates landing in v0.7.0) walks every row and accumulates a
+//! running `i64` sum; SQLite walks every row through its VM. This
+//! workload measures *the cost of touching every row* on a single
+//! engine more than anything else.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{GROUP_B_ROW_COUNT, GroupBDataset, group_b_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W7: WorkloadId = WorkloadId {
+    id: "W7",
+    name: "aggregate-sum",
+    version: "v1",
+};
+
+pub const SELECT_SQL: &str = "SELECT SUM(v) FROM big";
+
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, GroupBDataset)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE big (id INTEGER PRIMARY KEY, v INTEGER, k_10 INTEGER, k_1k INTEGER, k_100k INTEGER)",
+    )?;
+    let dataset = group_b_dataset();
+    insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset))
+}
+
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn) -> Result<i64> {
+    let row = driver.query_one(conn, SELECT_SQL, &[])?;
+    match row.first() {
+        Some(Value::Integer(n)) => Ok(*n),
+        Some(Value::Real(f)) => Ok(*f as i64),
+        other => anyhow::bail!("W7: SUM(v) returned {other:?}"),
+    }
+}
+
+pub fn correctness_check<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    dataset: &GroupBDataset,
+) -> Result<()> {
+    let got = bench_iter(driver, conn)?;
+    if got != dataset.sum_v {
+        anyhow::bail!("W7 correctness: SUM(v) = {got}, expected {}", dataset.sum_v);
+    }
+    Ok(())
+}
+
+pub(crate) fn insert_rows<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    dataset: &GroupBDataset,
+) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W7 BEGIN")?;
+    for row in &dataset.rows {
+        driver
+            .execute_with_params(
+                conn,
+                "INSERT INTO big (id, v, k_10, k_1k, k_100k) VALUES (?, ?, ?, ?, ?)",
+                &[
+                    Value::Integer(row.id),
+                    Value::Integer(row.v),
+                    Value::Integer(row.k_10),
+                    Value::Integer(row.k_1k),
+                    Value::Integer(row.k_100k),
+                ],
+            )
+            .with_context(|| format!("W7 INSERT id={}", row.id))?;
+    }
+    driver.execute(conn, "COMMIT").context("W7 COMMIT")?;
+    debug_assert_eq!(dataset.rows.len(), GROUP_B_ROW_COUNT);
+    Ok(())
+}

--- a/benchmarks/src/workloads/group_by.rs
+++ b/benchmarks/src/workloads/group_by.rs
@@ -1,0 +1,82 @@
+//! W8 — `SELECT k, COUNT(*) FROM big GROUP BY k` at three cardinalities.
+//!
+//! Three buckets:
+//! - **k_10** — 10 distinct groups; lots of rows per group, the
+//!   hash-aggregator is mostly in cache.
+//! - **k_1k** — 1k distinct groups.
+//! - **k_100k** — 100k distinct groups; one row per ~10 of input,
+//!   the high-cardinality stress test.
+//!
+//! All three queries scan the same 1M-row `big` table. The shape is
+//! "scan + group + count" — no WHERE, no ORDER BY, no LIMIT — so
+//! the comparison is "engine's hash-aggregator vs SQLite's sort-then-
+//! aggregate / hash-aggregate planner choice".
+//!
+//! Per-iter cost is dominated by:
+//! - parse + plan (every iter for SQLRite; cached on SQLite)
+//! - full table scan
+//! - hash insertion / counter increment per row
+//! - result materialization (10 / 1k / 100k rows depending on bucket)
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{GROUP_B_ROW_COUNT, GroupBDataset, group_b_dataset};
+use crate::workloads::aggregate as w7;
+use crate::{Driver, WorkloadId};
+
+pub const W8: WorkloadId = WorkloadId {
+    id: "W8",
+    name: "group-by",
+    version: "v1",
+};
+
+/// Cardinality buckets. `(label, group-key column, expected group count)`.
+pub const BUCKETS: [(&str, &str, usize); 3] = [
+    ("card-10", "k_10", 10),
+    ("card-1k", "k_1k", 1_000),
+    ("card-100k", "k_100k", 100_000),
+];
+
+/// Reuses W7's `big` table — same schema, same dataset. The criterion
+/// register fn makes one connection and runs all three buckets
+/// against it.
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, GroupBDataset)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE big (id INTEGER PRIMARY KEY, v INTEGER, k_10 INTEGER, k_1k INTEGER, k_100k INTEGER)",
+    )?;
+    let dataset = group_b_dataset();
+    w7::insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset))
+}
+
+pub fn select_sql(bucket: &str) -> String {
+    format!("SELECT {bucket}, COUNT(*) FROM big GROUP BY {bucket}")
+}
+
+/// One iteration: run the GROUP BY for one bucket and return the
+/// number of groups that came back.
+pub fn bench_iter<D: Driver>(driver: &D, conn: &mut D::Conn, bucket: &str) -> Result<usize> {
+    let sql = select_sql(bucket);
+    let rows = driver.query_all(conn, &sql, &[])?;
+    Ok(rows.len())
+}
+
+/// Correctness gate. Run the GROUP BY at each cardinality and verify
+/// the group count matches.
+pub fn correctness_check<D: Driver>(driver: &D, conn: &mut D::Conn) -> Result<()> {
+    for &(label, bucket, expected) in &BUCKETS {
+        let got =
+            bench_iter(driver, conn, bucket).with_context(|| format!("W8 correctness {label}"))?;
+        if got != expected {
+            anyhow::bail!(
+                "W8 correctness ({label}): GROUP BY {bucket} returned {got} groups, expected {expected}"
+            );
+        }
+    }
+    const _: () = assert!(GROUP_B_ROW_COUNT >= 100_000);
+    Ok(())
+}

--- a/benchmarks/src/workloads/join.rs
+++ b/benchmarks/src/workloads/join.rs
@@ -1,0 +1,134 @@
+//! W9 — INNER JOIN, customer ↔ order, probe by customer PK.
+//!
+//! ```sql
+//! CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT);
+//! CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, amount INTEGER);
+//! CREATE INDEX idx_orders_customer ON orders(customer_id);
+//! -- 100k customers, 100k orders, 1:1 relationship.
+//! -- Hot loop:
+//! --   SELECT c.id, c.name, o.amount
+//! --   FROM customers c INNER JOIN orders o ON c.id = o.customer_id
+//! --   WHERE c.id = ?
+//! ```
+//!
+//! Per-PK probe + single-row join shape. Each iter looks up one
+//! customer and joins to its single matching order.
+//!
+//! ## Plan deviation
+//!
+//! The plan target is **100k-row tables**. v1 ships at **10k rows**
+//! because SQLRite's join (see methodology note below) takes >5 min
+//! per criterion iteration at the 100k scale on an M-series MBP — too
+//! long for `make bench`. The 10k scale still surfaces the gap
+//! meaningfully; bumping back to 100k follows a SQLRite join-planner
+//! improvement and a `W9.v2` tag. See [`data::JOIN_ROW_COUNT`] for
+//! the full deviation note.
+//!
+//! ## Methodology note
+//!
+//! SQLRite's join executor is a left-folded nested-loop driver
+//! (`src/sql/executor.rs::execute_select_rows_joined`). The outer
+//! WHERE narrows `c` to one row via the PK fast-path, but the inner
+//! `o` scan is **un-indexed** — the engine doesn't push the
+//! `c.id = o.customer_id` predicate down to an index probe on
+//! `idx_orders_customer`. So per probe SQLRite walks every
+//! `orders` row checking the ON predicate.
+//!
+//! SQLite's planner *does* push the predicate down and uses
+//! `idx_orders_customer` for the inner side. The plan flags this
+//! workload as "the most informative number" — the magnitude of the
+//! gap is itself a roadmap input toward a real join planner /
+//! optimizer pass.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::data::{JOIN_ROW_COUNT, JoinDataset, join_dataset};
+use crate::{Driver, Value, WorkloadId};
+
+pub const W9: WorkloadId = WorkloadId {
+    id: "W9",
+    name: "inner-join",
+    version: "v1",
+};
+
+pub const SELECT_SQL: &str = "SELECT c.id, c.name, o.amount FROM customers AS c INNER JOIN orders AS o ON c.id = o.customer_id WHERE c.id = ?";
+
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<(D::Conn, JoinDataset)> {
+    let mut conn = driver.open(path)?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE customers (id INTEGER PRIMARY KEY, name TEXT)",
+    )?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, customer_id INTEGER, amount INTEGER)",
+    )?;
+    driver.execute(
+        &mut conn,
+        "CREATE INDEX idx_orders_customer ON orders(customer_id)",
+    )?;
+    let dataset = join_dataset();
+    insert_rows(driver, &mut conn, &dataset)?;
+    Ok((conn, dataset))
+}
+
+pub fn bench_iter<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    customer_id: i64,
+) -> Result<Vec<Value>> {
+    driver.query_one(conn, SELECT_SQL, &[Value::Integer(customer_id)])
+}
+
+pub fn correctness_check<D: Driver>(
+    driver: &D,
+    conn: &mut D::Conn,
+    dataset: &JoinDataset,
+) -> Result<()> {
+    for c in dataset.customers.iter().take(3) {
+        let row = bench_iter(driver, conn, c.id)?;
+        match (row.first(), row.get(1), row.get(2)) {
+            (
+                Some(Value::Integer(got_id)),
+                Some(Value::Text(got_name)),
+                Some(Value::Integer(_amount)),
+            ) => {
+                if *got_id != c.id {
+                    anyhow::bail!("W9 correctness: id round-trip {got_id} != {}", c.id);
+                }
+                if got_name != &c.name {
+                    anyhow::bail!("W9 correctness: name round-trip mismatch");
+                }
+            }
+            other => anyhow::bail!("W9 correctness: unexpected row shape {other:?}"),
+        }
+    }
+    Ok(())
+}
+
+fn insert_rows<D: Driver>(driver: &D, conn: &mut D::Conn, dataset: &JoinDataset) -> Result<()> {
+    driver.execute(conn, "BEGIN").context("W9 BEGIN")?;
+    for c in &dataset.customers {
+        driver.execute_with_params(
+            conn,
+            "INSERT INTO customers (id, name) VALUES (?, ?)",
+            &[Value::Integer(c.id), Value::Text(c.name.clone())],
+        )?;
+    }
+    for o in &dataset.orders {
+        driver.execute_with_params(
+            conn,
+            "INSERT INTO orders (id, customer_id, amount) VALUES (?, ?, ?)",
+            &[
+                Value::Integer(o.id),
+                Value::Integer(o.customer_id),
+                Value::Integer(o.amount),
+            ],
+        )?;
+    }
+    driver.execute(conn, "COMMIT").context("W9 COMMIT")?;
+    debug_assert_eq!(dataset.customers.len(), JOIN_ROW_COUNT);
+    Ok(())
+}

--- a/benchmarks/src/workloads/mod.rs
+++ b/benchmarks/src/workloads/mod.rs
@@ -14,8 +14,11 @@
 //!    mitigation: catch divergent semantics across engines before the
 //!    "winner" measurement is meaningful).
 
+pub mod aggregate;
 pub mod bulk_insert;
+pub mod group_by;
 pub mod index_lookup;
+pub mod join;
 pub mod kv;
 pub mod mixed_oltp;
 pub mod range_scan;

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -62,7 +62,7 @@ See the [Roadmap](roadmap.md) for the full phase plan.
 
 - [Phase 7 plan](phase-7-plan.md) — AI-era extensions (vector column type + HNSW, JSON, NL→SQL `ask()` API across REPL/library/SDKs/desktop/MCP, MCP server). **Implementation complete except 7f, which deferred to Phase 8.**
 - [Phase 8 plan](phase-8-plan.md) — Full-text search (FTS5-style BM25) + hybrid retrieval. The deferred 7f scope. **All six sub-phases (8a–8f) shipped.** Canonical reference: [`docs/fts.md`](fts.md).
-- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phases 9.1 (harness + W1) and 9.2 (Group A: W2–W6) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench`. The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
+- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phases 9.1 (harness + W1), 9.2 (Group A: W2–W6) and 9.3 (Group B: W7–W9) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench`. The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
 
 ## Conventions
 

--- a/docs/benchmarks-plan.md
+++ b/docs/benchmarks-plan.md
@@ -1,6 +1,6 @@
 # Benchmarks plan — SQLRite vs SQLite (and friends)
 
-**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phases 9.1 + 9.2 shipped.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
+**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phases 9.1 + 9.2 + 9.3 shipped.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
 
 **TL;DR.** Stand up a small, focused benchmark suite that pits the engine against `SQLite` (mandatory) and `DuckDB` (optional, analytical-slice only) under a curated set of OLTP + analytical + AI-era workloads. Skip distributed and network-resident options (`Cloudflare D1`, `rqlite`) — they don't share SQLRite's deployment shape. Defer `libSQL` until we have a vector- or replication-flavored axis that justifies a third row-oriented embedded engine. Suite lives in a new top-level `benchmarks/` workspace member, not built by default, runs on demand on a pinned host, emits JSON for trend tracking.
 


### PR DESCRIPTION
## Summary

Sub-phase **9.3** of [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.3-group-b/docs/benchmarks-plan.md). Builds on [#102](https://github.com/joaoh82/rust_sqlite/pull/102) (9.1 harness + W1) and [#103](https://github.com/joaoh82/rust_sqlite/pull/103) (9.2 Group A) to land the SQL-feature-scaling workloads:

| ID | Shape | Status |
|---|---|---|
| W7 | `SELECT SUM(v) FROM big` over 1M rows | ✅ |
| W8 | `SELECT k, COUNT(*) FROM big GROUP BY k` at 10 / 1k / 100k cardinalities | ✅ (SQLRite × 100k skipped — see below) |
| W9 | INNER JOIN customers ⨝ orders, per-PK probe | ✅ (scaled-down dataset — see below) |

## Smoke-run numbers (M1 Pro, criterion `--warm-up-time 1 --measurement-time 1 --sample-size 10`)

| Workload | SQLRite | SQLite | Ratio |
|---|---|---|---|
| W7 sum (1M rows) | ~111 ms | ~31 ms | **~3.5×** |
| W8 GROUP BY card-10 | ~204 ms | ~460 ms | SQLRite wins (small samples) |
| W8 GROUP BY card-1k | ~1.50 s | ~242 ms | ~6.2× |
| W8 GROUP BY card-100k | **skipped** | ~241 ms | — |
| W9 INNER JOIN (10k×10k) | ~32 s | ~2.3 µs | **~14,000,000×** ⚠️ |

**W7's ~3.5× is the closest SQLRite has come to SQLite on any workload** — the executor's per-row "touch" cost is tighter than the per-iter parse cost that dominates W1 / W6. Encouraging signal.

## Two plan deviations, both documented + tracked

### W8 × 100k-cardinality on SQLRite — skipped by default

A first measurement clocked **~245 s per iteration** (~41 min for 10 samples) on SQLRite. Set `SQLRITE_BENCH_W8_CARD_100K_SQLRITE=1` to re-enable once fixed. SQLite runs the same bucket fine.

The 245 s ≈ 1M × 100k = 1e11 ops timing strongly suggests an **O(n × cardinality)** GROUP BY path — likely a `Vec`-backed group store doing linear scans per row instead of an O(1) hash lookup. **SQLR-19** tracks the investigation.

### W9 dataset scaled down: 100k rows → 10k rows

Plan target was two 100k-row tables. A first smoke ran **88 minutes on SQLRite without producing a single sample** before being killed. SQLRite's join executor (`src/sql/executor.rs::execute_select_rows_joined`) is a left-folded nested-loop driver with **no inner-side index probe** — so per-PK probe walks every row in `orders`. **SQLR-20** tracks the planner / index-pushdown fix.

At the reduced 10k scale, the gap is still **~14 million×**:

- SQLRite: ~32 s / probe (10k inner-row scan, with ~3 ms per row of per-pair overhead)
- SQLite: ~2.3 µs / probe (indexed nested-loop)

That ~3 ms/row is **3,000× slower** than W2's full-scan rate (1 µs/row). Two unlocks: (a) push the ON predicate into an index probe, (b) trim the per-pair scope-construction overhead.

Bumping W9 back to 100k follows the SQLR-20 fix + a `W9.v2` tag. Plan deviation captured in [`benchmarks/src/data.rs`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.3-group-b/benchmarks/src/data.rs) (`JOIN_ROW_COUNT` const + comment) and [`benchmarks/src/workloads/join.rs`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.3-group-b/benchmarks/src/workloads/join.rs) (top-of-file "Plan deviation" section).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p sqlrite-benchmarks --all-targets` clean
- [x] Full CI-equivalent: `cargo build / test / doc --workspace --exclude {desktop,python,nodejs,benchmarks}` green
- [x] `cargo test -p sqlrite-benchmarks` — 5 tests pass (4 inliner + 1 ymd round-trip)
- [x] Smoke `cargo bench -p sqlrite-benchmarks --bench suite -- --warm-up-time 1 --measurement-time 1 '^W[789]'` runs all three workloads end-to-end on both engines (with documented skips)
- [x] Aggregator post-processes the criterion output into a 9-row JSON envelope (W7×2, W8×4 with SQLRite × 100k absent, W9×2)
- [x] W7 / W8 / W9 correctness gates pass on both drivers

## Follow-ups

- **SQLR-19** — fix W8 GROUP BY high-cardinality blowup. Likely a `Vec` → `HashMap` group store swap.
- **SQLR-20** — push JOIN ON predicate into inner-side index probe. The single-table executor already has the `<col> = <literal>` fast-path; the join executor needs to reuse it.
- **SQLR-18** (carried from 9.2) — investigate W4 single-row INSERT gap.
- **9.4** — Group C differentiators (W10 vector top-10, W11 BM25 top-10, W12 hybrid retrieval). Phase 7d / 8 surface validation.

## References

- Parent task: SQLR-16
- 9.1: [#102](https://github.com/joaoh82/rust_sqlite/pull/102)
- 9.2: [#103](https://github.com/joaoh82/rust_sqlite/pull/103)
- Plan: [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.3-group-b/docs/benchmarks-plan.md)
- Workloads: [`benchmarks/src/workloads/{aggregate,group_by,join}.rs`](https://github.com/joaoh82/rust_sqlite/tree/bench-9.3-group-b/benchmarks/src/workloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)