### PR TITLE
feat(bench): DuckDB driver, Group B only (sub-phase 9.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ cargo run -p sqlrite-mcp -- /path/to.sqlrite     # MCP server (stdio)
 
 # Benchmarks (SQLR-4 / SQLR-16) — local-only, never CI
 make bench                                 # SQLRite + SQLite (lean)
-# make bench-duckdb                        # adds DuckDB driver (Group B only) — lands in 9.5
+make bench-duckdb                          # adds DuckDB driver (Group B only)
 
 # Release plumbing
 scripts/bump-version.sh 0.2.0              # bumps version across 11 manifests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +138,179 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "arrow-select"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "arrow-string"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +337,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -196,6 +403,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +430,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -239,6 +482,28 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -360,6 +625,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -510,6 +777,37 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comfy-table"
+version = "7.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
+dependencies = [
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -778,6 +1076,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1258,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8685352ce688883098b61a361e86e87df66fc8c444f4a2411e884c16d5243a65"
+dependencies = [
+ "arrow",
+ "cast",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num-integer",
+ "rust_decimal",
+ "strum 0.27.2",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1418,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1442,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1172,6 +1510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,6 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1388,8 +1733,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1399,9 +1746,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1573,6 +1922,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1581,6 +1931,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1590,6 +1943,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1724,6 +2083,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2078,6 +2453,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2532,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2619,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78bacb8933586cee3b550c39b610d314f9b7a48701ac7a914a046165a4ad8da"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,12 +2656,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2242,6 +2710,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2475,10 +2949,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2487,6 +3025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2711,7 +3250,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2922,6 +3461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3123,6 +3668,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,6 +3760,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,6 +3834,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -3251,6 +3877,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,6 +3907,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,6 +3932,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3337,6 +3992,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3413,6 +4077,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +4198,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,6 +4238,23 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3547,6 +4306,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3670,6 +4430,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "selectors"
@@ -3815,6 +4581,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +4688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3958,7 +4742,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4018,6 +4802,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "duckdb",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rusqlite",
@@ -4171,6 +4956,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4292,6 +5117,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4327,7 +5169,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4687,6 +5529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tiny_http"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,6 +5570,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,6 +5596,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -5206,6 +6082,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -5304,6 +6181,16 @@ name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6032,6 +6919,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11"
 version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6050,6 +6946,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -6156,7 +7062,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,8 @@ bench:
 	@echo '${GREEN}Running${RESET} ${YELLOW}benchmark suite${RESET} (SQLRite vs SQLite, lean profile)'
 	@./benchmarks/scripts/run.sh
 
-# `make bench-duckdb` lands alongside the DuckDB driver in sub-phase 9.5
-# (Group B only). Until then, the `duckdb` feature isn't declared on
-# the bench crate so invoking it would be a build error.
+.PHONY: bench-duckdb
+## Run the benchmark suite with DuckDB enabled (Group B only — W7/W8/W9)
+bench-duckdb:
+	@echo '${GREEN}Running${RESET} ${YELLOW}benchmark suite${RESET} (with DuckDB driver, Group B only)'
+	@FEATURES=duckdb ./benchmarks/scripts/run.sh

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -41,9 +41,10 @@ harness = false
 [features]
 default = []
 
-# `duckdb` feature lands alongside the driver in sub-phase 9.5
-# (Group B only). Heavy dep — keeping it out of the dep graph until
-# the driver is actually wired up.
+# Optional DuckDB driver (Group B only — W7 / W8 / W9). Heavy dep
+# (~50 MB compiled), so kept off by default. `make bench-duckdb`
+# enables it; the regular `make bench` stays lean.
+duckdb = ["dep:duckdb"]
 
 [dependencies]
 # The engine. Default features off (no rustyline / clap / `ask`), but
@@ -56,6 +57,10 @@ sqlrite = { package = "sqlrite-engine", path = "..", version = "0.8.0", default-
 # `extra_check` and `column_decltype` would be nice-to-have but cost
 # binary size; skipping until a workload needs them.
 rusqlite = { version = "0.36", features = ["bundled"] }
+
+# DuckDB via duckdb-rs (optional, feature-gated). `bundled` for the
+# same reason as rusqlite — pin a known DuckDB version.
+duckdb = { version = "1.4", features = ["bundled"], optional = true }
 
 # Criterion for the actual measurement loop. v0.5 ships HDR-style
 # sampling, statistical confidence intervals, and JSON output to

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,14 +2,14 @@
 
 Benchmark suite for SQLRite vs SQLite (and friends). Tracks task **SQLR-4** / **SQLR-16**.
 
-> **Status (2026-05-07):** sub-phases 9.1 + 9.2 + 9.3 + 9.4 landed — harness + Group A (W1–W6) + Group B (W7–W9) + Group C (W10–W12). The full workload set is in. The first official pinned-host JSON + canonical `docs/benchmarks.md` reference land in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
+> **Status (2026-05-07):** sub-phases 9.1 + 9.2 + 9.3 + 9.4 + 9.5 landed — harness + all 12 workloads + DuckDB driver. The first official pinned-host JSON + canonical `docs/benchmarks.md` reference land in 9.6. See [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md) for the canonical design + the resolved Q1–Q8 decisions.
 
 ## Quick start
 
 ```sh
 # From repo root.
 make bench                  # SQLRite + SQLite (lean, ~4 min)
-# make bench-duckdb         # adds DuckDB driver (Group B only) — lands in 9.5
+make bench-duckdb           # adds DuckDB driver (Group B only — W7/W8/W9)
 ```
 
 Each invocation runs the criterion suite, then aggregates the per-bench JSON criterion writes under `target/criterion/` into a single envelope under [`results/`](results/), keyed by date + host fingerprint + commit short-SHA. The shape is locked in [`src/envelope.rs`](src/envelope.rs).
@@ -38,7 +38,7 @@ Workloads are versioned (`W1.v1`, `W1.v2`, …) per Q8 — bumping the version i
 |---|---|---|---|
 | SQLRite | `sqlrite-engine` (path dep, `default-features = false` + `file-locks`) | Default | ✅ 9.1 |
 | SQLite | `rusqlite` v0.36 (bundled libsqlite3) | `WAL` + `synchronous=NORMAL` + 64 MB cache + `temp_store=MEMORY` (Q3 — tuned headline) | ✅ 9.1 |
-| DuckDB | `duckdb-rs` | Defaults | 🟡 9.5, opt-in via `--features duckdb` |
+| DuckDB | `duckdb-rs` v1.4 (bundled libduckdb) | Defaults — DuckDB's MVCC + commit semantics are uniform; no equivalent to SQLite's WAL+NORMAL opt-in | ✅ 9.5, opt-in via `--features duckdb` (Group B only) |
 | libSQL | — | — | 🟡 deferred (post-9.6) |
 
 The SQLite driver runs the **tuned profile** as the headline (Q3). A SQLite-default column is opt-in, post-9.6.
@@ -126,15 +126,29 @@ Unique-index probes — every probe matches exactly one row. SQLRite's optimizer
 
 ### W7 — `SELECT SUM(v) FROM big` (1M-row full-scan aggregate)
 
-Single-statement aggregate. No WHERE, no GROUP BY. Both engines walk every row through their executor; the question is how cheap the per-row "touch" is.
+Single-statement aggregate. No WHERE, no GROUP BY. All three engines walk every row through their executor; the question is how cheap the per-row "touch" is — and how much an OLAP-shaped engine wins on a workload built for it.
 
 | Engine | Median per SUM | Throughput (rows/s) |
 |---|---|---|
 | SQLRite | ~111 ms | ~9.0M |
 | SQLite (rusqlite, WAL+NORMAL) | ~31 ms | ~32M |
-| **Ratio** | **~3.5×** | |
+| DuckDB (default) | ~378 µs | **~2.6B** |
 
-**Read this as:** healthy. The full-scan aggregator is the closest "engine throughput" measurement we have — no parse cache miss to amortize, just per-row work. Closer to SQLite than W1 (~8×) suggests the per-row machinery is tighter than the per-iter parse path. Encouraging; says the executor isn't broadly slow.
+**Read this as:** vectorized columnar wins big on a workload built for it. DuckDB is **~80× faster than SQLite** on the same SUM-over-1M, and ~290× faster than SQLRite. SQLite-vs-SQLRite is the closest gap (~3.5×) — solid for our row-store. The DuckDB column is the "what does a different storage model look like?" sister number from the plan.
+
+### W8 — `SELECT k, COUNT(*) FROM big GROUP BY k` (three cardinalities)
+
+1M-row table, GROUP BY at 10 / 1k / 100k distinct keys.
+
+| Cardinality | SQLRite | SQLite (WAL+NORMAL) | DuckDB | Notes |
+|---|---|---|---|---|
+| 10 groups | ~204 ms | ~460 ms | ~634 µs | DuckDB **~720×** faster than SQLite |
+| 1,000 groups | ~1.50 s | ~242 ms | ~701 µs | DuckDB **~345×** faster than SQLite |
+| 100,000 groups | **skipped** | ~241 ms | ~20.4 ms | SQLR-19 (SQLRite); DuckDB still ~12× faster than SQLite |
+
+**SQLRite × 100k-cardinality is skipped by default** in `make bench`. A first measurement clocked ~245 s/iter (~41 min for 10 samples), strongly suggesting an O(n × cardinality) path inside the GROUP BY executor (a hash aggregator should be O(n + groups)). **SQLR-19** tracks the investigation. Set `SQLRITE_BENCH_W8_CARD_100K_SQLRITE=1` once that lands to re-include the bucket.
+
+**Read this as:** GROUP BY at low cardinality is fine on SQLRite; high-cardinality work is broken. DuckDB's vectorized hash aggregator dominates SQLite at every cardinality — that's the analytical-engine value proposition in one workload.
 
 ### W8 — `SELECT k, COUNT(*) FROM big GROUP BY k` (three cardinalities)
 
@@ -163,6 +177,8 @@ Even at 10k scale, the gap is large:
 | **Ratio** | **~14,000,000×** ⚠️ | |
 
 **Read this as:** SQLRite's join executor scans the entire inner table per outer row (no index probe pushdown), and the per-pair overhead is much higher than a single-table full scan. At 32 s for ~10k inner-row checks, the per-row cost is ~3 ms — about **3,000× slower** than W2's full-scan rate (1 µs/row). The inner-side index probe is the obvious next unlock; the per-pair overhead is the second.
+
+**DuckDB on W9 (10k×10k):** ~500 µs / probe — about **220× slower than SQLite**. Per-PK probe + single-row JOIN is the workload SQLite was built for; DuckDB pays a much higher per-query overhead because it's optimized for analytical scans, not sub-millisecond OLTP probes. The plan's viability section flags exactly this — DuckDB is "apples-to-oranges" on PK-probe-by-rowid workloads and we include it here for the directional comparison only.
 
 ### W10 — vector top-10 (cosine), brute-force vs HNSW
 
@@ -237,7 +253,7 @@ benchmarks/
 │   │   ├── mod.rs
 │   │   ├── sqlrite.rs     — engine-side driver (inlines params)
 │   │   ├── sqlite.rs      — rusqlite + Q3 tuned profile
-│   │   └── duckdb.rs      — feature-gated; lands in 9.5
+│   │   └── duckdb.rs      — feature-gated; Group B only
 │   ├── workloads/
 │   │   ├── mod.rs
 │   │   ├── kv.rs            — W1 read-by-PK

--- a/benchmarks/benches/suite.rs
+++ b/benchmarks/benches/suite.rs
@@ -26,6 +26,8 @@ use std::hint::black_box;
 use std::path::{Path, PathBuf};
 
 use sqlrite_benchmarks::Driver;
+#[cfg(feature = "duckdb")]
+use sqlrite_benchmarks::drivers::duckdb::DuckDBDriver;
 use sqlrite_benchmarks::drivers::sqlite::SQLiteDriver;
 use sqlrite_benchmarks::drivers::sqlrite::SQLRiteDriver;
 use sqlrite_benchmarks::workloads::{
@@ -494,10 +496,16 @@ fn benches(c: &mut Criterion) {
     register_w6(c, SQLiteDriver);
     register_w7(c, SQLRiteDriver);
     register_w7(c, SQLiteDriver);
+    #[cfg(feature = "duckdb")]
+    register_w7(c, DuckDBDriver);
     register_w8(c, SQLRiteDriver);
     register_w8(c, SQLiteDriver);
+    #[cfg(feature = "duckdb")]
+    register_w8(c, DuckDBDriver);
     register_w9(c, SQLRiteDriver);
     register_w9(c, SQLiteDriver);
+    #[cfg(feature = "duckdb")]
+    register_w9(c, DuckDBDriver);
     register_w10(c, SQLRiteDriver);
     register_w10(c, SQLiteDriver); // skipped via driver_supports
     register_w11(c, SQLRiteDriver);

--- a/benchmarks/src/drivers/duckdb.rs
+++ b/benchmarks/src/drivers/duckdb.rs
@@ -1,0 +1,170 @@
+//! DuckDB driver via [`duckdb-rs`] (bundled libduckdb).
+//!
+//! Wired into Group B only — W7 / W8 / W9. The plan-doc viability
+//! section explicitly excludes Group A (single-row INSERTs are
+//! pathological by design on a columnar engine) and Group C
+//! (DuckDB doesn't ship vector or BM25 native primitives the way
+//! SQLRite / SQLite + extensions do).
+//!
+//! Feature-gated under `duckdb`. `make bench-duckdb` enables it;
+//! plain `make bench` keeps the heavier dep out of the build.
+//!
+//! ## Configuration
+//!
+//! Defaults. DuckDB's out-of-the-box settings are already sensible
+//! for analytical workloads — there's no equivalent to SQLite's
+//! `WAL+NORMAL` opt-in (DuckDB's MVCC + commit semantics are uniform).
+//! That asymmetry is documented in the README; the SQLite tuned
+//! profile (Q3) and the DuckDB defaults are both "the headline"
+//! configuration on their respective engines.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::{Driver, Value};
+
+pub struct DuckDBDriver;
+
+impl Driver for DuckDBDriver {
+    type Conn = duckdb::Connection;
+
+    fn name(&self) -> &'static str {
+        "duckdb"
+    }
+
+    fn open(&self, path: &Path) -> Result<Self::Conn> {
+        duckdb::Connection::open(path).with_context(|| format!("duckdb open({})", path.display()))
+    }
+
+    fn execute(&self, conn: &mut Self::Conn, sql: &str) -> Result<()> {
+        conn.execute_batch(sql)
+            .with_context(|| format!("duckdb execute_batch: {sql}"))?;
+        Ok(())
+    }
+
+    fn execute_with_params(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<()> {
+        let bound: Vec<duckdb::types::Value> = params.iter().map(to_duckdb).collect();
+        conn.execute(sql, duckdb::params_from_iter(bound.iter()))
+            .with_context(|| format!("duckdb execute: {sql}"))?;
+        Ok(())
+    }
+
+    fn query_one(&self, conn: &mut Self::Conn, sql: &str, params: &[Value]) -> Result<Vec<Value>> {
+        // duckdb-rs doesn't expose a `prepare_cached` (the C API
+        // doesn't have an LRU under the hood the way libsqlite3 does);
+        // every query reprepares, which is honest for the comparison —
+        // the SQL parser is part of what we're measuring. Per-iter
+        // parse cost on DuckDB's optimizer is heavier than libsqlite3
+        // on simple queries, but DuckDB amortizes that with a much
+        // faster vectorized executor on full-scan paths (W7 / W8).
+        //
+        // DuckDB's column_count is only valid AFTER query execution
+        // (it reads from the result struct, not the parsed plan), so
+        // we pull it from the first Row via `Row::as_ref()`.
+        let mut stmt = conn
+            .prepare(sql)
+            .with_context(|| format!("duckdb prepare: {sql}"))?;
+        let bound: Vec<duckdb::types::Value> = params.iter().map(to_duckdb).collect();
+        let mut rows = stmt
+            .query(duckdb::params_from_iter(bound.iter()))
+            .with_context(|| format!("duckdb query: {sql}"))?;
+        let row = rows
+            .next()
+            .with_context(|| format!("duckdb row read: {sql}"))?
+            .context("duckdb query_one: zero rows returned")?;
+        let cols = row.as_ref().column_count();
+        let mut out = Vec::with_capacity(cols);
+        for i in 0..cols {
+            out.push(extract_column(row, i)?);
+        }
+        if rows
+            .next()
+            .with_context(|| format!("duckdb row read: {sql}"))?
+            .is_some()
+        {
+            anyhow::bail!("duckdb query_one: >1 rows returned");
+        }
+        Ok(out)
+    }
+
+    fn query_all(
+        &self,
+        conn: &mut Self::Conn,
+        sql: &str,
+        params: &[Value],
+    ) -> Result<Vec<Vec<Value>>> {
+        let mut stmt = conn
+            .prepare(sql)
+            .with_context(|| format!("duckdb prepare: {sql}"))?;
+        let bound: Vec<duckdb::types::Value> = params.iter().map(to_duckdb).collect();
+        let mut rows = stmt
+            .query(duckdb::params_from_iter(bound.iter()))
+            .with_context(|| format!("duckdb query: {sql}"))?;
+        let mut out = Vec::new();
+        let mut cols: Option<usize> = None;
+        while let Some(row) = rows
+            .next()
+            .with_context(|| format!("duckdb row read: {sql}"))?
+        {
+            // Column count is the same for every row in a result set;
+            // grab it once from the first row.
+            let n = *cols.get_or_insert_with(|| row.as_ref().column_count());
+            let mut buf = Vec::with_capacity(n);
+            for i in 0..n {
+                buf.push(extract_column(row, i)?);
+            }
+            out.push(buf);
+        }
+        Ok(out)
+    }
+}
+
+fn to_duckdb(v: &Value) -> duckdb::types::Value {
+    match v {
+        Value::Null => duckdb::types::Value::Null,
+        Value::Integer(i) => duckdb::types::Value::BigInt(*i),
+        Value::Real(f) => duckdb::types::Value::Double(*f),
+        Value::Text(s) => duckdb::types::Value::Text(s.clone()),
+    }
+}
+
+fn extract_column(row: &duckdb::Row<'_>, idx: usize) -> Result<Value> {
+    // DuckDB returns rich types — coerce the integer family down to
+    // i64 (the harness's Value::Integer). Booleans, decimals, dates,
+    // etc. aren't produced by any Group B workload's projections, so
+    // the catch-all bails loudly if one shows up.
+    let raw: duckdb::types::Value = row.get(idx)?;
+    Ok(match raw {
+        duckdb::types::Value::Null => Value::Null,
+        duckdb::types::Value::TinyInt(n) => Value::Integer(n as i64),
+        duckdb::types::Value::SmallInt(n) => Value::Integer(n as i64),
+        duckdb::types::Value::Int(n) => Value::Integer(n as i64),
+        duckdb::types::Value::BigInt(n) => Value::Integer(n),
+        // DuckDB widens SUM(BIGINT) to HugeInt(i128) defensively, even
+        // when the result fits in i64. W7's `SUM(v)` over 1M small ints
+        // produces ~5e8 — comfortably in range. Downcast when it fits;
+        // bail loudly if a future workload genuinely overflows.
+        duckdb::types::Value::HugeInt(n) => {
+            if n >= i64::MIN as i128 && n <= i64::MAX as i128 {
+                Value::Integer(n as i64)
+            } else {
+                anyhow::bail!("duckdb extract_column: HugeInt {n} doesn't fit i64");
+            }
+        }
+        duckdb::types::Value::UTinyInt(n) => Value::Integer(n as i64),
+        duckdb::types::Value::USmallInt(n) => Value::Integer(n as i64),
+        duckdb::types::Value::UInt(n) => Value::Integer(n as i64),
+        duckdb::types::Value::UBigInt(n) => Value::Integer(n as i64),
+        duckdb::types::Value::Boolean(b) => Value::Integer(b as i64),
+        duckdb::types::Value::Float(f) => Value::Real(f as f64),
+        duckdb::types::Value::Double(f) => Value::Real(f),
+        duckdb::types::Value::Text(s) => Value::Text(s),
+        other => anyhow::bail!("duckdb extract_column: unsupported type {other:?}"),
+    })
+}

--- a/benchmarks/src/drivers/mod.rs
+++ b/benchmarks/src/drivers/mod.rs
@@ -12,7 +12,7 @@
 pub mod sqlite;
 pub mod sqlrite;
 
-// DuckDB driver lands in sub-phase 9.5 (Group B only). Feature-gated
-// then; the module file gets created alongside the implementation.
-// #[cfg(feature = "duckdb")]
-// pub mod duckdb;
+// DuckDB driver — Group B only. Feature-gated to keep the heavy
+// `libduckdb` dep out of the default `make bench` build.
+#[cfg(feature = "duckdb")]
+pub mod duckdb;

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -62,7 +62,7 @@ See the [Roadmap](roadmap.md) for the full phase plan.
 
 - [Phase 7 plan](phase-7-plan.md) — AI-era extensions (vector column type + HNSW, JSON, NL→SQL `ask()` API across REPL/library/SDKs/desktop/MCP, MCP server). **Implementation complete except 7f, which deferred to Phase 8.**
 - [Phase 8 plan](phase-8-plan.md) — Full-text search (FTS5-style BM25) + hybrid retrieval. The deferred 7f scope. **All six sub-phases (8a–8f) shipped.** Canonical reference: [`docs/fts.md`](fts.md).
-- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phases 9.1 (harness + W1), 9.2 (Group A: W2–W6), 9.3 (Group B: W7–W9), and 9.4 (Group C: W10–W12) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench`. The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
+- [Benchmarks plan](benchmarks-plan.md) — SQLRite-vs-SQLite (and friends) benchmark suite. SQLR-4 / SQLR-16. Q1–Q8 resolved 2026-05-06. **Sub-phases 9.1 (harness + W1), 9.2 (Group A: W2–W6), 9.3 (Group B: W7–W9), 9.4 (Group C: W10–W12) and 9.5 (DuckDB driver) shipped.** Lives under [`benchmarks/`](../benchmarks/) — workspace member, run via `make bench` (or `make bench-duckdb`). The canonical user-facing reference (`docs/benchmarks.md`) lands in 9.6.
 
 ## Conventions
 

--- a/docs/benchmarks-plan.md
+++ b/docs/benchmarks-plan.md
@@ -1,6 +1,6 @@
 # Benchmarks plan — SQLRite vs SQLite (and friends)
 
-**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phases 9.1 + 9.2 + 9.3 + 9.4 shipped.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
+**Status:** *approved 2026-05-06 — Q1–Q8 resolved; sub-phases 9.1 + 9.2 + 9.3 + 9.4 + 9.5 shipped.* All eight design questions were resolved by the project owner; see the **Decisions** section below for the canonical answers. Tracks task **SQLR-4** / **SQLR-16** (execution).
 
 **TL;DR.** Stand up a small, focused benchmark suite that pits the engine against `SQLite` (mandatory) and `DuckDB` (optional, analytical-slice only) under a curated set of OLTP + analytical + AI-era workloads. Skip distributed and network-resident options (`Cloudflare D1`, `rqlite`) — they don't share SQLRite's deployment shape. Defer `libSQL` until we have a vector- or replication-flavored axis that justifies a third row-oriented embedded engine. Suite lives in a new top-level `benchmarks/` workspace member, not built by default, runs on demand on a pinned host, emits JSON for trend tracking.
 


### PR DESCRIPTION
## Summary

Sub-phase **9.5** of [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.5-duckdb/docs/benchmarks-plan.md). Builds on 9.1–9.4 ([#102](https://github.com/joaoh82/rust_sqlite/pull/102) / [#103](https://github.com/joaoh82/rust_sqlite/pull/103) / [#104](https://github.com/joaoh82/rust_sqlite/pull/104) / [#105](https://github.com/joaoh82/rust_sqlite/pull/105)). Adds the optional `duckdb-rs` driver, feature-gated and wired into Group B (W7 / W8 / W9) only per the plan's viability section.

| Feature | What it does |
|---|---|
| `make bench` | unchanged — SQLRite + SQLite (lean profile, no DuckDB dep) |
| `make bench-duckdb` | new — same suite + DuckDB on Group B |
| `cargo build -p sqlrite-benchmarks` | unchanged (no DuckDB dep pulled) |
| `cargo build -p sqlrite-benchmarks --features duckdb` | builds with `libduckdb` (~50 MB compiled) |

## Smoke-run numbers (M1 Pro)

| Workload | SQLRite | SQLite (WAL+NORMAL) | DuckDB (default) |
|---|---|---|---|
| W7 SUM (1M rows) | ~111 ms | ~31 ms | **~378 µs** (~80× faster than SQLite) |
| W8 GROUP BY card-10 | ~204 ms | ~460 ms | **~634 µs** (~720× faster than SQLite) |
| W8 GROUP BY card-1k | ~1.50 s | ~242 ms | **~701 µs** (~345× faster than SQLite) |
| W8 GROUP BY card-100k | skipped (SQLR-19) | ~241 ms | ~20.4 ms (~12× faster than SQLite) |
| W9 JOIN (10k×10k) | ~32 s | **~2.3 µs** | ~500 µs (~220× **slower** than SQLite) |

Two findings the plan predicted:

1. **Vectorized columnar wins big on aggregate / GROUP BY workloads.** W7 / W8 are exactly the shape DuckDB was built for, and it's ~80–720× faster than the same query on SQLite's tuned WAL+NORMAL profile. That's the "what does a different storage model look like?" sister number from the plan's "Why include DuckDB?" rationale.

2. **DuckDB is much slower than SQLite on per-PK-probe single-row JOIN (W9).** ~220× slower. Per-PK-probe + single-row OLTP is SQLite's home turf — DuckDB's analytical optimizer pays much higher per-query overhead. Plan flagged this as "apples-to-oranges"; the directional measurement is the point.

## Engineering quirks worth knowing

- **DuckDB's `Statement::column_count` is only valid AFTER query execution** (it reads from the result struct, not the parse tree). The first version of the driver crashed with `The statement was not executed yet`; fixed by pulling `cols` from the first `Row` via `Row::as_ref().column_count()`.
- **DuckDB widens `SUM(BIGINT)` to `HugeInt(i128)` defensively** even when the result fits in i64. The driver downcasts with a range check; bails loudly on genuine overflow.
- **No `prepare_cached` on duckdb-rs** (the C API doesn't have an LRU). Every query reprepares — honest for the comparison since the parser is part of what we're measuring.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p sqlrite-benchmarks --all-targets` clean (default features)
- [x] `cargo clippy -p sqlrite-benchmarks --features duckdb --all-targets` clean
- [x] Full CI-equivalent: `cargo build / test / doc --workspace --exclude {desktop,python,nodejs,benchmarks}` green (CI never sees the bench crate; this verifies nothing in the engine broke)
- [x] `cargo test -p sqlrite-benchmarks` (default features) passes — 5 tests
- [x] `cargo bench -p sqlrite-benchmarks --features duckdb -- 'duckdb'` runs all five DuckDB cells (W7 / W8×3 / W9) end-to-end

## Follow-ups still open from prior sub-phases

- **SQLR-21** — Phase 8.1 FTS overflow chaining (W11/W12 corpus cap)
- **SQLR-20** — W9 JOIN inner-side index pushdown (SQLRite)
- **SQLR-19** — W8 GROUP BY high-cardinality blowup (SQLRite)
- **SQLR-18** — W4 single-row INSERT gap (SQLRite)
- **SQLR-17** — desktop-build CI hang (only act if recurs)

## What's left

**9.6** — Reporting + first published run. `scripts/compare.py` to render any two JSONs into a Markdown diff table, the first official pinned-host JSON committed under `benchmarks/results/`, and the canonical `docs/benchmarks.md` reference + top-level README "Benchmarks" section.

## References

- Parent: SQLR-16
- Plan: [`docs/benchmarks-plan.md`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.5-duckdb/docs/benchmarks-plan.md) — Q4 (DuckDB gating decision)
- Driver: [`benchmarks/src/drivers/duckdb.rs`](https://github.com/joaoh82/rust_sqlite/blob/bench-9.5-duckdb/benchmarks/src/drivers/duckdb.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)