### PR TITLE
feat(web): syntax highlighting for blog MDX + SDK showcase (SQLR-44)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -146,6 +146,21 @@ backticks or escape (`&lt;`, `\{`). The MDX renderer auto-routes
 internal `[link](/foo)` markdown links through `next/link`; external
 links open in a new tab via `rel="noreferrer"`.
 
+### Code block highlighting
+
+Fenced code blocks are tokenized at build time by
+[`rehype-pretty-code`](https://github.com/rehype-pretty/rehype-pretty-code)
+with [Shiki](https://shiki.style/). The plugin is wired up in
+[`src/components/blog-mdx.tsx`](src/components/blog-mdx.tsx) using a
+`createCssVariablesTheme()` so Shiki emits inline styles like
+`color: var(--shiki-token-keyword)`. The mapping from
+`--shiki-*` to the blog's color palette (`--color-kw`, `--color-str`,
+`--color-num`, …) lives in the `.blog-article-body pre` rule in
+[`src/app/globals.css`](src/app/globals.css) — adjust colors there,
+not in the component. Code fences without a language fall back to
+`plaintext` so unknown / missing language tags don't fail the build.
+Inline `code` keeps its existing chip styling (`bypassInlineCode: true`).
+
 The design tokens (colors, typography, spacing) live in `globals.css`'s
 `@theme` block. The page-level CSS (sections, terminal, feature grid,
 roadmap timeline, etc.) is intentionally hand-rolled — it ports the

--- a/web/README.md
+++ b/web/README.md
@@ -148,18 +148,27 @@ links open in a new tab via `rel="noreferrer"`.
 
 ### Code block highlighting
 
-Fenced code blocks are tokenized at build time by
-[`rehype-pretty-code`](https://github.com/rehype-pretty/rehype-pretty-code)
-with [Shiki](https://shiki.style/). The plugin is wired up in
-[`src/components/blog-mdx.tsx`](src/components/blog-mdx.tsx) using a
+Code is tokenized at build time by [Shiki](https://shiki.style/). The
+shared theme + helper live in
+[`src/lib/highlight.ts`](src/lib/highlight.ts) and use
 `createCssVariablesTheme()` so Shiki emits inline styles like
-`color: var(--shiki-token-keyword)`. The mapping from
-`--shiki-*` to the blog's color palette (`--color-kw`, `--color-str`,
-`--color-num`, …) lives in the `.blog-article-body pre` rule in
+`color: var(--shiki-token-keyword)`. Each surface that needs
+highlighting then maps the `--shiki-*` variables onto the blog's
+palette tokens (`--color-kw`, `--color-str`, `--color-num`, …) in
 [`src/app/globals.css`](src/app/globals.css) — adjust colors there,
-not in the component. Code fences without a language fall back to
-`plaintext` so unknown / missing language tags don't fail the build.
-Inline `code` keeps its existing chip styling (`bypassInlineCode: true`).
+not in the components. Two consumers:
+
+- **Blog MDX** (`src/components/blog-mdx.tsx`) — uses
+  [`rehype-pretty-code`](https://github.com/rehype-pretty/rehype-pretty-code)
+  inside the `MDXRemote` pipeline. Inline `` `code` `` keeps its chip
+  styling (`bypassInlineCode: true`); fences without a language tag
+  fall back to `plaintext` so a missing language never breaks the
+  build. Mapping lives on `.blog-article-body pre`.
+- **SDK showcase** (`src/components/sdk-showcase.tsx` —
+  server-rendered, paired with a small client wrapper for the tab
+  state) pre-renders each language snippet with `highlightCode()` and
+  embeds the resulting HTML inside `.code-body`. Mapping lives on
+  `.code-body`.
 
 The design tokens (colors, typography, spacing) live in `globals.css`'s
 `@theme` block. The page-level CSS (sections, terminal, feature grid,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,8 @@
         "next-mdx-remote": "^6.0.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
+        "rehype-pretty-code": "^0.14.3",
+        "shiki": "^4.0.2",
         "tailwind-merge": "^2.6.0"
       },
       "devDependencies": {
@@ -1096,6 +1098,106 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2843,6 +2945,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
@@ -4052,6 +4166,57 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -4074,6 +4239,29 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -4107,6 +4295,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -4118,6 +4319,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ignore": {
@@ -6271,6 +6499,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6376,6 +6621,24 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse-numeric-range": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
+      "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
+      "license": "ISC"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6645,6 +6908,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -6664,6 +6951,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+      "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-pretty-code": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/rehype-pretty-code/-/rehype-pretty-code-0.14.3.tgz",
+      "integrity": "sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.0",
+        "parse-numeric-range": "^1.3.0",
+        "rehype-parse": "^9.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "shiki": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/rehype-recma": {
@@ -7009,6 +7331,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {
@@ -7819,6 +8161,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-matter": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
@@ -7845,6 +8201,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,8 @@
     "next-mdx-remote": "^6.0.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "rehype-pretty-code": "^0.14.3",
+    "shiki": "^4.0.2",
     "tailwind-merge": "^2.6.0"
   },
   "devDependencies": {

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2202,6 +2202,24 @@ html {
   line-height: 1.65;
   overflow-x: auto;
   color: var(--color-fg);
+
+  /* Shiki (rehype-pretty-code) emits inline styles like
+     `color: var(--shiki-token-keyword)`. Map those onto the blog's
+     existing token palette so the highlighter is theme-coherent. */
+  --shiki-foreground: var(--color-fg);
+  --shiki-background: transparent;
+  --shiki-token-keyword: var(--color-kw);
+  --shiki-token-string: var(--color-str);
+  --shiki-token-string-expression: var(--color-str);
+  --shiki-token-constant: var(--color-num);
+  --shiki-token-comment: var(--color-fg-dim);
+  --shiki-token-function: var(--color-accent);
+  --shiki-token-parameter: var(--color-fg);
+  --shiki-token-punctuation: var(--color-fg-mute);
+  --shiki-token-link: var(--color-accent);
+  --shiki-token-inserted: var(--color-good);
+  --shiki-token-deleted: oklch(0.72 0.16 25);
+  --shiki-token-changed: var(--color-warn);
 }
 .blog-article-body pre code {
   font: inherit;
@@ -2209,6 +2227,17 @@ html {
   padding: 0;
   border: 0;
   color: inherit;
+  display: block;
+}
+.blog-article-body pre [data-line] {
+  display: block;
+  min-height: 1lh;
+}
+/* rehype-pretty-code wraps each fenced block in a <figure>. Strip the
+   browser default figure margins so the block sits flush against the
+   surrounding paragraph rhythm. */
+.blog-article-body figure[data-rehype-pretty-code-figure] {
+  margin: 0;
 }
 .blog-article-body blockquote {
   margin: 0;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -854,6 +854,37 @@ section.no-border {
   white-space: pre;
   overflow-x: auto;
   color: var(--color-fg);
+
+  /* Same shiki → palette mapping as `.blog-article-body pre`. The SDK
+     showcase pre-renders snippets via `lib/highlight.ts` and inlines the
+     resulting <pre><code> here. */
+  --shiki-foreground: var(--color-fg);
+  --shiki-background: transparent;
+  --shiki-token-keyword: var(--color-kw);
+  --shiki-token-string: var(--color-str);
+  --shiki-token-string-expression: var(--color-str);
+  --shiki-token-constant: var(--color-num);
+  --shiki-token-comment: var(--color-fg-dim);
+  --shiki-token-function: var(--color-accent);
+  --shiki-token-parameter: var(--color-fg);
+  --shiki-token-punctuation: var(--color-fg-mute);
+  --shiki-token-link: var(--color-accent);
+}
+.code-body > pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+}
+.code-body > pre > code {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+}
+.code-body .line {
+  display: block;
+  min-height: 1lh;
 }
 
 /* SQL ref table */

--- a/web/src/components/blog-mdx.tsx
+++ b/web/src/components/blog-mdx.tsx
@@ -5,7 +5,7 @@ import rehypePrettyCode, {
   type Options as RehypePrettyCodeOptions,
   type Theme as RehypePrettyCodeTheme,
 } from "rehype-pretty-code";
-import { createCssVariablesTheme } from "shiki";
+import { sqlriteShikiTheme } from "@/lib/highlight";
 
 function isInternal(href: string | undefined): boolean {
   if (!href) return false;
@@ -34,16 +34,12 @@ const components = {
 // Shiki emits inline styles like `style="color: var(--shiki-token-keyword)"`.
 // `globals.css` maps those CSS vars onto the blog's existing color tokens, so
 // the highlighter stays a pure data layer and themes stay coherent.
-// `createCssVariablesTheme` returns `ThemeRegistration` (all-optional fields);
-// rehype-pretty-code wants `ThemeRegistrationRaw` (settings required). The
-// shapes are structurally compatible — shiki tolerates the missing `settings`
-// because the rules live in `tokenColors`.
-const shikiTheme = createCssVariablesTheme({
-  name: "sqlrite-css-vars",
-}) as RehypePrettyCodeTheme;
-
 const prettyCodeOptions: RehypePrettyCodeOptions = {
-  theme: shikiTheme,
+  // `createCssVariablesTheme` returns `ThemeRegistration` (all-optional
+  // fields); rehype-pretty-code wants `ThemeRegistrationRaw` (`settings`
+  // required). The shapes are structurally compatible — shiki tolerates the
+  // missing `settings` because the rules live in `tokenColors`.
+  theme: sqlriteShikiTheme as RehypePrettyCodeTheme,
   keepBackground: false,
   // Inline `code` keeps the existing `.blog-article-body code:not(pre code)`
   // chip style — only fenced blocks get tokenized.

--- a/web/src/components/blog-mdx.tsx
+++ b/web/src/components/blog-mdx.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 import type { ComponentProps } from "react";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import rehypePrettyCode, {
+  type Options as RehypePrettyCodeOptions,
+  type Theme as RehypePrettyCodeTheme,
+} from "rehype-pretty-code";
+import { createCssVariablesTheme } from "shiki";
 
 function isInternal(href: string | undefined): boolean {
   if (!href) return false;
@@ -26,6 +31,38 @@ const components = {
   a: Anchor,
 };
 
+// Shiki emits inline styles like `style="color: var(--shiki-token-keyword)"`.
+// `globals.css` maps those CSS vars onto the blog's existing color tokens, so
+// the highlighter stays a pure data layer and themes stay coherent.
+// `createCssVariablesTheme` returns `ThemeRegistration` (all-optional fields);
+// rehype-pretty-code wants `ThemeRegistrationRaw` (settings required). The
+// shapes are structurally compatible — shiki tolerates the missing `settings`
+// because the rules live in `tokenColors`.
+const shikiTheme = createCssVariablesTheme({
+  name: "sqlrite-css-vars",
+}) as RehypePrettyCodeTheme;
+
+const prettyCodeOptions: RehypePrettyCodeOptions = {
+  theme: shikiTheme,
+  keepBackground: false,
+  // Inline `code` keeps the existing `.blog-article-body code:not(pre code)`
+  // chip style — only fenced blocks get tokenized.
+  bypassInlineCode: true,
+  // Fences without a language tag (or with an unknown one) fall back to
+  // plaintext rather than throwing during the build.
+  defaultLang: { block: "plaintext" },
+};
+
 export function BlogMDX({ source }: { source: string }) {
-  return <MDXRemote source={source} components={components} />;
+  return (
+    <MDXRemote
+      source={source}
+      components={components}
+      options={{
+        mdxOptions: {
+          rehypePlugins: [[rehypePrettyCode, prettyCodeOptions]],
+        },
+      }}
+    />
+  );
 }

--- a/web/src/components/sdk-showcase-client.tsx
+++ b/web/src/components/sdk-showcase-client.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { InstallBar } from "./install-bar";
+
+export type SdkEntry = {
+  key: string;
+  name: string;
+  install: string;
+  version: string;
+  registry: string;
+  note: string;
+  ext: string;
+  /** Pre-rendered shiki output. Built server-side at compile time. */
+  codeHtml: string;
+};
+
+export function SDKShowcaseClient({ sdks }: { sdks: SdkEntry[] }) {
+  const [tab, setTab] = useState(sdks[0]?.key ?? "");
+  const sdk = sdks.find((s) => s.key === tab) ?? sdks[0];
+  if (!sdk) return null;
+
+  return (
+    <section id="sdks">
+      <div className="wrap">
+        <div className="sec-head">
+          <span className="eyebrow tag">05 · embedding</span>
+          <div>
+            <h2>One engine. Six languages.</h2>
+            <p className="sub">
+              The same Rust core — wrapped, never reimplemented. SDKs ship as
+              prebuilt binaries so there&rsquo;s no toolchain to install just to
+              use the database.
+            </p>
+          </div>
+        </div>
+        <div className="sec-body" style={{ paddingTop: 32 }}>
+          <div className="sdk-tabs" role="tablist">
+            {sdks.map((s) => (
+              <button
+                key={s.key}
+                role="tab"
+                aria-selected={tab === s.key}
+                className={`sdk-tab ${tab === s.key ? "active" : ""}`}
+                onClick={() => setTab(s.key)}
+              >
+                {s.name}
+              </button>
+            ))}
+          </div>
+          <div className="sdk-panel">
+            <div className="sdk-meta">
+              <h3>{sdk.name}</h3>
+              <p
+                className="dim"
+                style={{ marginTop: 6, fontSize: 13.5 }}
+              >
+                {sdk.note}
+              </p>
+              <InstallBar cmd={sdk.install} />
+              <div style={{ marginTop: 18 }}>
+                <div className="meta-row">
+                  <span>version</span>
+                  <span className="v">{sdk.version}</span>
+                </div>
+                <div className="meta-row">
+                  <span>registry</span>
+                  <span className="v">{sdk.registry}</span>
+                </div>
+                <div className="meta-row">
+                  <span>license</span>
+                  <span className="v">MIT</span>
+                </div>
+              </div>
+            </div>
+            <div className="code-block">
+              <div className="code-head">
+                <span>example.{sdk.ext}</span>
+                <span>· copy-pasteable</span>
+              </div>
+              <div
+                className="code-body"
+                dangerouslySetInnerHTML={{ __html: sdk.codeHtml }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/sdk-showcase.tsx
+++ b/web/src/components/sdk-showcase.tsx
@@ -1,24 +1,22 @@
-"use client";
-
-import { useState } from "react";
 import { SITE } from "@/lib/site";
-import { InstallBar } from "./install-bar";
+import { highlightCode } from "@/lib/highlight";
+import {
+  SDKShowcaseClient,
+  type SdkEntry,
+} from "./sdk-showcase-client";
 
-type SdkKey = "rust" | "python" | "node" | "go" | "c" | "wasm";
-
-type Sdk = {
-  name: string;
-  install: string;
-  version: string;
-  registry: string;
-  note: string;
-  ext: string;
+type SdkSource = Omit<SdkEntry, "codeHtml"> & {
+  /** Raw snippet — highlighted at build time. */
   code: string;
+  /** Shiki language id. */
+  lang: string;
 };
 
-const SDKS: Record<SdkKey, Sdk> = {
-  rust: {
+const SDKS: SdkSource[] = [
+  {
+    key: "rust",
     name: "Rust",
+    lang: "rust",
     install: `cargo add sqlrite-engine`,
     version: SITE.version,
     registry: "crates.io",
@@ -43,8 +41,10 @@ fn main() -> sqlrite::Result<()> {
     Ok(())
 }`,
   },
-  python: {
+  {
+    key: "python",
     name: "Python",
+    lang: "python",
     install: `pip install sqlrite`,
     version: SITE.version,
     registry: "PyPI",
@@ -64,8 +64,10 @@ with sqlrite.connect("app.sqlrite") as conn:
     for row in cur.fetchall():
         print(row)`,
   },
-  node: {
+  {
+    key: "node",
     name: "Node.js",
+    lang: "javascript",
     install: `npm install @joaoh82/sqlrite`,
     version: SITE.version,
     registry: "npm · scoped",
@@ -86,8 +88,10 @@ insert.run("alice");
 const all = db.prepare("SELECT id, name FROM users").all();
 console.log(all);`,
   },
-  go: {
+  {
+    key: "go",
     name: "Go",
+    lang: "go",
     install: `go get github.com/joaoh82/rust_sqlite/sdk/go`,
     version: `v${SITE.version}`,
     registry: "VCS · proxy.golang.org",
@@ -117,8 +121,10 @@ func main() {
     }
 }`,
   },
-  c: {
+  {
+    key: "c",
     name: "C",
+    lang: "c",
     install: `make -C examples/c run`,
     version: SITE.version,
     registry: "libsqlrite_c · cbindgen header",
@@ -144,8 +150,10 @@ int main(void) {
     return 0;
 }`,
   },
-  wasm: {
+  {
+    key: "wasm",
     name: "WASM",
+    lang: "typescript",
     install: `npm install @joaoh82/sqlrite-wasm`,
     version: SITE.version,
     registry: "npm · ~500 KB gzipped",
@@ -165,75 +173,14 @@ db.exec("INSERT INTO users (name) VALUES ('alice')");
 const rows = db.query("SELECT id, name FROM users");
 console.log(rows);                   // [{ id: 1, name: "alice" }]`,
   },
-};
+];
 
-export function SDKShowcase() {
-  const [tab, setTab] = useState<SdkKey>("rust");
-  const sdk = SDKS[tab];
-
-  return (
-    <section id="sdks">
-      <div className="wrap">
-        <div className="sec-head">
-          <span className="eyebrow tag">05 · embedding</span>
-          <div>
-            <h2>One engine. Six languages.</h2>
-            <p className="sub">
-              The same Rust core — wrapped, never reimplemented. SDKs ship as
-              prebuilt binaries so there&rsquo;s no toolchain to install just to
-              use the database.
-            </p>
-          </div>
-        </div>
-        <div className="sec-body" style={{ paddingTop: 32 }}>
-          <div className="sdk-tabs" role="tablist">
-            {(Object.entries(SDKS) as [SdkKey, Sdk][]).map(([key, s]) => (
-              <button
-                key={key}
-                role="tab"
-                aria-selected={tab === key}
-                className={`sdk-tab ${tab === key ? "active" : ""}`}
-                onClick={() => setTab(key)}
-              >
-                {s.name}
-              </button>
-            ))}
-          </div>
-          <div className="sdk-panel">
-            <div className="sdk-meta">
-              <h3>{sdk.name}</h3>
-              <p
-                className="dim"
-                style={{ marginTop: 6, fontSize: 13.5 }}
-              >
-                {sdk.note}
-              </p>
-              <InstallBar cmd={sdk.install} />
-              <div style={{ marginTop: 18 }}>
-                <div className="meta-row">
-                  <span>version</span>
-                  <span className="v">{sdk.version}</span>
-                </div>
-                <div className="meta-row">
-                  <span>registry</span>
-                  <span className="v">{sdk.registry}</span>
-                </div>
-                <div className="meta-row">
-                  <span>license</span>
-                  <span className="v">MIT</span>
-                </div>
-              </div>
-            </div>
-            <div className="code-block">
-              <div className="code-head">
-                <span>example.{sdk.ext}</span>
-                <span>· copy-pasteable</span>
-              </div>
-              <div className="code-body">{sdk.code}</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
+export async function SDKShowcase() {
+  const entries: SdkEntry[] = await Promise.all(
+    SDKS.map(async ({ code, lang, ...rest }) => ({
+      ...rest,
+      codeHtml: await highlightCode(code, lang),
+    })),
   );
+  return <SDKShowcaseClient sdks={entries} />;
 }

--- a/web/src/lib/highlight.ts
+++ b/web/src/lib/highlight.ts
@@ -1,0 +1,34 @@
+import {
+  codeToHtml,
+  createCssVariablesTheme,
+  type ShikiTransformer,
+} from "shiki";
+
+// Shiki emits inline styles like `color: var(--shiki-token-keyword)`. The
+// CSS-variable mapping onto the project's palette tokens lives in
+// `globals.css` (`.blog-article-body pre`, `.code-body`, …) so colors stay
+// theme-coherent and adjustable in one place.
+export const sqlriteShikiTheme = createCssVariablesTheme({
+  name: "sqlrite-css-vars",
+});
+
+// `createCssVariablesTheme` still sets `background: var(--shiki-background)`
+// on the outer <pre>; that would force the figure to override our existing
+// container backgrounds. Strip the inline style so the surrounding wrapper
+// (.code-body, .blog-article-body pre, etc.) drives layout/colors.
+const stripContainerStyle: ShikiTransformer = {
+  pre(node) {
+    if (node.properties) delete node.properties.style;
+  },
+};
+
+export async function highlightCode(
+  code: string,
+  lang: string,
+): Promise<string> {
+  return codeToHtml(code, {
+    lang,
+    theme: sqlriteShikiTheme,
+    transformers: [stripContainerStyle],
+  });
+}


### PR DESCRIPTION
## Summary

- Wire `rehype-pretty-code` + Shiki into the blog MDX renderer so fenced code blocks tokenize at build time. Inline `` `code` `` keeps its existing chip styling; fences without a language fall back to `plaintext` so a missing tag never breaks the build.
- Pre-render the six landing-page SDK snippets with the same Shiki pipeline. The SDK showcase now splits into a server component that calls `highlightCode()` and a small client wrapper that owns tab state.
- Use `createCssVariablesTheme` so Shiki emits inline styles like `color: var(--shiki-token-keyword)`. The mapping from `--shiki-*` to the existing palette tokens (`--color-kw`, `--color-str`, `--color-num`, …) lives in `globals.css` (`.blog-article-body pre` and `.code-body`) — adjust colors there, not in components.
- Shared theme + helper centralized in `web/src/lib/highlight.ts`; README updated to point future readers at the right files.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — 14.79s wall (baseline 15.88s, no regression). Static HTML contains shiki token spans on `/blog/<slug>` pages and the active rust snippet on `/`. The other five SDK tabs' highlighted HTML is in the RSC payload, so client-side tab switching is instant.
- [x] Home page client bundle: 5.16 kB → 3.98 kB (raw snippet strings now live server-side).
- [ ] Visual smoke check on Vercel preview

## Out of scope

Line numbers, copy buttons, language label chips. Tracked separately as a UX follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)