### PR TITLE
bench(W13): Phase 11.11b — concurrent-writers workload (SQLR-22 / SQLR-16)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -29,6 +29,7 @@ Three groups (full descriptions in [`docs/benchmarks-plan.md`](../docs/benchmark
 - **Group A — OLTP baseline.** W1 read-by-PK, W2 range scan, W3 bulk insert, W4 single-row insert, W5 mixed OLTP, W6 index lookup. ✅ shipped (9.1 + 9.2).
 - **Group B — SQL-feature scaling.** W7 aggregate, W8 GROUP BY, W9 INNER JOIN. ✅ shipped (9.3).
 - **Group C — Differentiators.** W10 vector top-10, W11 BM25 top-10, W12 hybrid retrieval. ✅ shipped (9.4).
+- **Group D — Concurrent writes.** W13 concurrent writers, mostly-disjoint rows. ✅ shipped (9.7, Phase 11.11b).
 
 For headline numbers + reading-the-numbers methodology + the engineering debts the suite surfaced, see the canonical [**`docs/benchmarks.md`**](../docs/benchmarks.md).
 
@@ -222,6 +223,21 @@ Both engines use an inverted index + BM25 ranker; the SQL shapes differ because 
 
 **Read this as:** absolute number for the headline RAG pitch. ~650 µs/query for "filter by FTS, rank by 50/50 BM25 + cosine over 384-dim embeddings" on a 1000-doc corpus is solid — competitive with what a Python+sklearn user would pay round-tripping to a separate vector DB + BM25 engine. The number scales with corpus size; bumping the cap (post Phase 8.1) is what unlocks larger-scale headlines.
 
+### W13 — concurrent writers, mostly-disjoint rows (Phase 11.11b)
+
+**1000-row `counters` table, 4 worker threads × 50 BEGIN/UPDATE/COMMIT cycles each.** Each transaction picks a random rowid in `1..=1000` (~0.4% collision probability per op) and runs `UPDATE counters SET n = n + 1 WHERE id = ?`. Retries on `Busy` / `BusySnapshot` (SQLRite) or `SQLITE_BUSY` / `SQLITE_LOCKED` (SQLite). Total committed updates per sample: `4 × 50 = 200`.
+
+| Engine | BEGIN flavour | Connection model |
+|---|---|---|
+| SQLRite | `BEGIN CONCURRENT` (Phase 11.4) | One primary `Connection::open` + 3 siblings via `Connection::connect`; all share `Arc<Mutex<Database>>` |
+| SQLite | `BEGIN IMMEDIATE` + `busy_timeout = 5s` | Four separate `rusqlite::Connection::open` instances; WAL writer lock serializes commits |
+
+Both engines run the same retry-on-busy outer loop (the [`Driver::is_retryable_busy`](src/lib.rs) classifier is engine-dispatched). Only SQLRite actually exercises the retry path under this workload's collision rate; SQLite's `busy_timeout` makes its BEGIN block rather than fail, so the workers serialize behind the writer lock without surfacing busy errors.
+
+The workload's parameters live in [`src/workloads/concurrent_writers.rs`](src/workloads/concurrent_writers.rs) — bumping `W13_PRELOAD_ROWS`, `W13_N_WORKERS`, or `W13_TXS_PER_WORKER` is a workload-version bump under Q8 (current: `W13.v1`).
+
+**Read this as:** the Phase-11 differentiator. SQLRite's `BEGIN CONCURRENT` enables disjoint-row writers to commit in parallel; SQLite's single-writer model serializes them. Headline numbers and the scaling envelope (varying `N` and `K`) will land with the first pinned-host re-publication; the workload's correctness gate (`SUM(n) == n_workers * txs_per_worker` after a 4×10 burst) is what 9.7 ships and what any future numbers stand on. See [`docs/concurrent-writes.md`](../docs/concurrent-writes.md) for the Phase-11 design walkthrough.
+
 ## Adding a workload
 
 Per the [`docs/benchmarks-plan.md`](../docs/benchmarks-plan.md#sub-phases) sequencing:
@@ -269,7 +285,8 @@ benchmarks/
 │   │   ├── join.rs          — W9 INNER JOIN, customer ↔ order
 │   │   ├── vector.rs        — W10 vector top-10 (brute-force + HNSW)
 │   │   ├── fts.rs           — W11 BM25 top-10 (vs SQLite FTS5)
-│   │   └── hybrid.rs        — W12 hybrid BM25 + cosine fusion
+│   │   ├── hybrid.rs        — W12 hybrid BM25 + cosine fusion
+│   │   └── concurrent_writers.rs — W13 concurrent writers (Phase 11.11b)
 │   └── bin/
 │       └── aggregate.rs   — walks target/criterion/ → results/*.json
 ├── benches/

--- a/benchmarks/benches/suite.rs
+++ b/benchmarks/benches/suite.rs
@@ -24,6 +24,7 @@ use criterion::measurement::WallTime;
 use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use sqlrite_benchmarks::Driver;
 #[cfg(feature = "duckdb")]
@@ -31,8 +32,8 @@ use sqlrite_benchmarks::drivers::duckdb::DuckDBDriver;
 use sqlrite_benchmarks::drivers::sqlite::SQLiteDriver;
 use sqlrite_benchmarks::drivers::sqlrite::SQLRiteDriver;
 use sqlrite_benchmarks::workloads::{
-    aggregate as w7, bulk_insert as w3, fts as w11, group_by as w8, hybrid as w12,
-    index_lookup as w6, join as w9, kv as w1, mixed_oltp as w5, range_scan as w2,
+    aggregate as w7, bulk_insert as w3, concurrent_writers as w13, fts as w11, group_by as w8,
+    hybrid as w12, index_lookup as w6, join as w9, kv as w1, mixed_oltp as w5, range_scan as w2,
     single_insert as w4, vector as w10,
 };
 
@@ -478,6 +479,67 @@ fn register_w12<D: Driver>(c: &mut Criterion, driver: D) {
 }
 
 // ---------------------------------------------------------------------------
+// W13 — concurrent writers, mostly-disjoint rows (Phase 11.11b)
+// ---------------------------------------------------------------------------
+
+fn register_w13<D>(c: &mut Criterion, driver: D)
+where
+    D: Driver + Clone + 'static,
+    D::Conn: Send + 'static,
+{
+    let driver = Arc::new(driver);
+    let tmp = tempdir_for("w13", driver.name());
+    let path = db_path(tmp.path(), driver.name(), "w13");
+
+    // Correctness gate FIRST — runs a single 4×10 burst against a
+    // fresh DB and verifies the sum matches commits.
+    w13::correctness_check(Arc::clone(&driver), &path).expect("W13 correctness check");
+
+    // Re-setup so the bench starts from a known preload state.
+    // `correctness_check` left the DB with 40 increments in it;
+    // that doesn't matter for throughput but we want a clean
+    // baseline.
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file({
+        let mut p = path.as_os_str().to_owned();
+        p.push("-wal");
+        PathBuf::from(p)
+    });
+    {
+        let _ = w13::setup(&*driver, &path).expect("W13 setup");
+    }
+
+    let mut group = c.benchmark_group(w13::W13.full());
+    // 4 workers × 50 txs × N samples can run long; criterion's
+    // default sample size (100) would push a single driver past
+    // 30s of wall clock. Cap at 20 — still plenty of statistical
+    // confidence for a throughput comparison; override at the CLI
+    // for a sharper estimate.
+    group.sample_size(20);
+
+    let bench_id = format!(
+        "{}/n={}/m={}",
+        driver.name(),
+        w13::W13_N_WORKERS,
+        w13::W13_TXS_PER_WORKER
+    );
+    group.bench_function(&bench_id, |b| {
+        b.iter(|| {
+            let committed = w13::run_concurrent(
+                Arc::clone(&driver),
+                &path,
+                w13::W13_N_WORKERS,
+                w13::W13_TXS_PER_WORKER,
+            )
+            .expect("W13 run");
+            black_box(committed)
+        });
+    });
+    group.finish();
+    drop(tmp);
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -512,6 +574,8 @@ fn benches(c: &mut Criterion) {
     register_w11(c, SQLiteDriver);
     register_w12(c, SQLRiteDriver);
     register_w12(c, SQLiteDriver); // skipped via driver_supports
+    register_w13(c, SQLRiteDriver);
+    register_w13(c, SQLiteDriver);
 }
 
 criterion_group!(suite, benches);

--- a/benchmarks/src/drivers/sqlite.rs
+++ b/benchmarks/src/drivers/sqlite.rs
@@ -26,6 +26,7 @@ use anyhow::{Context, Result};
 
 use crate::{Driver, Value};
 
+#[derive(Clone, Copy)]
 pub struct SQLiteDriver;
 
 impl Driver for SQLiteDriver {
@@ -49,6 +50,14 @@ impl Driver for SQLiteDriver {
             .context("PRAGMA temp_store=MEMORY")?;
         conn.pragma_update(None, "cache_size", -65536i64)
             .context("PRAGMA cache_size=-65536")?;
+        // Phase 11.11b — `busy_timeout = 5s` so the W13 multi-writer
+        // workload's concurrent COMMITs wait for the writer lock
+        // rather than immediately returning SQLITE_BUSY. Without
+        // this, the bench measures lock-collision rate, not
+        // throughput. Single-writer workloads (W1..W12) never hit
+        // contention so the pragma is a no-op for them.
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .context("busy_timeout=5s")?;
         Ok(conn)
     }
 
@@ -128,6 +137,32 @@ impl Driver for SQLiteDriver {
             out.push(buf);
         }
         Ok(out)
+    }
+
+    fn concurrent_begin_sql(&self) -> &'static str {
+        // SQLite's recommended multi-writer shape: acquire the
+        // write lock at BEGIN so two writers don't race into
+        // SQLITE_BUSY at COMMIT. The `busy_timeout` set at open
+        // makes the BEGIN wait for the lock rather than failing
+        // immediately.
+        "BEGIN IMMEDIATE"
+    }
+
+    fn is_retryable_busy(&self, err: &anyhow::Error) -> bool {
+        // SQLite returns SQLITE_BUSY / SQLITE_BUSY_RETRY /
+        // SQLITE_LOCKED on contention. With `busy_timeout` we
+        // mostly *don't* see these — the call blocks instead —
+        // but if the timeout elapses (very rare with our 5s
+        // setting on the W13 workload sizes) we should retry.
+        err.chain()
+            .filter_map(|e| e.downcast_ref::<rusqlite::Error>())
+            .any(|e| {
+                use rusqlite::ErrorCode::*;
+                matches!(
+                    e.sqlite_error_code(),
+                    Some(DatabaseBusy) | Some(DatabaseLocked)
+                )
+            })
     }
 }
 

--- a/benchmarks/src/drivers/sqlrite.rs
+++ b/benchmarks/src/drivers/sqlrite.rs
@@ -28,6 +28,7 @@ use anyhow::{Context, Result};
 
 use crate::{Driver, Value};
 
+#[derive(Clone, Copy)]
 pub struct SQLRiteDriver;
 
 impl Driver for SQLRiteDriver {
@@ -43,8 +44,15 @@ impl Driver for SQLRiteDriver {
     }
 
     fn execute(&self, conn: &mut Self::Conn, sql: &str) -> Result<()> {
+        // Preserve the typed `SQLRiteError` as the anyhow source so
+        // [`is_retryable_busy`] can downcast — the W13 retry loop
+        // needs to distinguish `Busy` / `BusySnapshot` from other
+        // failures. Adding context via `.with_context` keeps the
+        // human-readable wrapper while threading the typed source
+        // underneath.
         conn.execute(sql)
-            .map_err(|e| anyhow::anyhow!("sqlrite execute: {e}\n  sql: {sql}"))?;
+            .map_err(anyhow::Error::new)
+            .with_context(|| format!("sqlrite execute: {sql}"))?;
         Ok(())
     }
 
@@ -57,9 +65,11 @@ impl Driver for SQLRiteDriver {
         let bound = to_engine_values(params);
         let mut stmt = conn
             .prepare_cached(sql)
-            .map_err(|e| anyhow::anyhow!("sqlrite prepare_cached: {e}\n  sql: {sql}"))?;
+            .map_err(anyhow::Error::new)
+            .with_context(|| format!("sqlrite prepare_cached: {sql}"))?;
         stmt.execute_with_params(&bound)
-            .map_err(|e| anyhow::anyhow!("sqlrite execute_with_params: {e}\n  sql: {sql}"))?;
+            .map_err(anyhow::Error::new)
+            .with_context(|| format!("sqlrite execute_with_params: {sql}"))?;
         Ok(())
     }
 
@@ -118,6 +128,44 @@ impl Driver for SQLRiteDriver {
             out.push(buf);
         }
         Ok(out)
+    }
+
+    /// Mint a sibling Connection that shares the primary's
+    /// `Arc<Mutex<Database>>`. A fresh `Connection::open(path)`
+    /// would fail here because the primary already holds an
+    /// exclusive `flock(LOCK_EX)` on the WAL sidecar.
+    fn connect_sibling(&self, primary: &Self::Conn, _path: &Path) -> Result<Self::Conn> {
+        Ok(primary.connect())
+    }
+
+    fn enable_concurrent_mode(&self, conn: &mut Self::Conn) -> Result<()> {
+        // `BEGIN CONCURRENT` requires `journal_mode = mvcc;`
+        // otherwise the engine surfaces a typed error. The PRAGMA
+        // is per-database (not per-connection), so toggling once
+        // on the primary suffices for every sibling.
+        conn.execute("PRAGMA journal_mode = mvcc")
+            .map_err(anyhow::Error::new)
+            .context("PRAGMA journal_mode = mvcc")?;
+        Ok(())
+    }
+
+    fn concurrent_begin_sql(&self) -> &'static str {
+        "BEGIN CONCURRENT"
+    }
+
+    /// SQLRite signals both `Busy` (write-write conflict at commit)
+    /// and `BusySnapshot` (snapshot GC'd under a long-lived reader)
+    /// via `SQLRiteError::is_retryable()`. The bench harness wraps
+    /// engine errors in `anyhow::Error`, so we peel back to the
+    /// typed source and consult the predicate.
+    fn is_retryable_busy(&self, err: &anyhow::Error) -> bool {
+        err.downcast_ref::<sqlrite::SQLRiteError>()
+            .map(|e| e.is_retryable())
+            .unwrap_or(false)
+            || err
+                .chain()
+                .filter_map(|e| e.downcast_ref::<sqlrite::SQLRiteError>())
+                .any(|e| e.is_retryable())
     }
 }
 

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -116,6 +116,68 @@ pub trait Driver: Send + Sync {
         sql: &str,
         params: &[Value],
     ) -> anyhow::Result<Vec<Vec<Value>>>;
+
+    /// Phase 11.11b — mint a sibling connection sharing the same
+    /// backing state as `primary`. Used by W13 (concurrent writers)
+    /// to drive `N` worker threads against the same database from
+    /// a single process.
+    ///
+    /// The default implementation opens a fresh connection at `path`
+    /// — appropriate for engines (SQLite, DuckDB) whose per-process
+    /// concurrency is mediated by file-level locking + `busy_timeout`.
+    /// Engines whose primary opener takes an exclusive lock (SQLRite,
+    /// where `Connection::open` calls `flock(LOCK_EX)`) override this
+    /// to mint an in-process sibling that shares the lock + the
+    /// backing `Arc<Mutex<Database>>`.
+    #[allow(dead_code)]
+    fn connect_sibling(&self, primary: &Self::Conn, path: &Path) -> anyhow::Result<Self::Conn> {
+        let _ = primary;
+        self.open(path)
+    }
+
+    /// Phase 11.11b — opt the connection into the engine's
+    /// concurrent-write mode before W13 issues its first `BEGIN
+    /// CONCURRENT` (or equivalent). For SQLRite this runs
+    /// `PRAGMA journal_mode = mvcc;`; for SQLite the default is a
+    /// no-op (its WAL + busy_timeout setup happens at `open` time).
+    ///
+    /// Called once per primary connection at workload setup; the
+    /// per-database setting then propagates to every sibling
+    /// minted via [`Driver::connect_sibling`].
+    #[allow(dead_code)]
+    fn enable_concurrent_mode(&self, conn: &mut Self::Conn) -> anyhow::Result<()> {
+        let _ = conn;
+        Ok(())
+    }
+
+    /// Phase 11.11b — engine-idiomatic `BEGIN` flavour for the
+    /// concurrent-writers workload (W13).
+    ///
+    /// - SQLRite returns `"BEGIN CONCURRENT"` (MVCC + commit-time validation).
+    /// - SQLite returns `"BEGIN IMMEDIATE"` (acquire the write lock at BEGIN
+    ///   so two writers don't race into `SQLITE_BUSY` at COMMIT — same shape
+    ///   the SQLite docs recommend for multi-writer apps).
+    /// - DuckDB / future engines return their idiomatic form.
+    ///
+    /// Default is plain `"BEGIN"` for engines that don't yet have a
+    /// W13 story.
+    #[allow(dead_code)]
+    fn concurrent_begin_sql(&self) -> &'static str {
+        "BEGIN"
+    }
+
+    /// Phase 11.11b — does `err` indicate a retryable busy / conflict
+    /// from this engine's concurrent path? W13's per-worker loop
+    /// retries on `true` and bubbles on `false`.
+    ///
+    /// Default: no error is retryable. Drivers that override
+    /// [`Driver::concurrent_begin_sql`] should override this too so
+    /// the workload's retry loop knows when to spin.
+    #[allow(dead_code)]
+    fn is_retryable_busy(&self, err: &anyhow::Error) -> bool {
+        let _ = err;
+        false
+    }
 }
 
 /// Workload-version tag. Mirrors Q8 in `benchmarks-plan.md`: every

--- a/benchmarks/src/workloads/concurrent_writers.rs
+++ b/benchmarks/src/workloads/concurrent_writers.rs
@@ -1,0 +1,345 @@
+//! W13 — concurrent writers, mostly-disjoint rows.
+//!
+//! ```sql
+//! CREATE TABLE counters (id INTEGER PRIMARY KEY, n INTEGER NOT NULL);
+//! -- preload 1_000 rows: (1, 0), (2, 0), ..., (1_000, 0)
+//! -- N worker threads each run M txs of:
+//! --   BEGIN <CONCURRENT|IMMEDIATE>;
+//! --   UPDATE counters SET n = n + 1 WHERE id = ?;  -- random id in 1..=1000
+//! --   COMMIT;                                     -- retry on Busy/Locked
+//! ```
+//!
+//! The headline differentiator workload Phase 11 was designed for.
+//! Two writers on *disjoint* rows make progress in parallel under
+//! SQLRite-MVCC; under SQLite they serialize on the WAL writer
+//! lock. With `N = 4` workers and `K = 1_000` rows, the per-iter
+//! collision probability is roughly `N/K = 0.4%` — "mostly disjoint"
+//! is the workload's actual claim, not just its name.
+//!
+//! ## Per-engine begin / retry shape
+//!
+//! - **SQLRite-MVCC**: `BEGIN CONCURRENT` doesn't acquire a lock at
+//!   BEGIN; the conflict is decided at COMMIT against `MvStore`. The
+//!   loser sees `SQLRiteError::Busy` and retries with a fresh
+//!   `begin_ts`. See [`docs/concurrent-writes.md`](../../docs/concurrent-writes.md).
+//! - **SQLite**: `BEGIN IMMEDIATE` takes the WAL write lock at BEGIN
+//!   so two writers can't race into `SQLITE_BUSY` at COMMIT. The
+//!   driver's `busy_timeout = 5s` keeps BEGIN from failing
+//!   immediately when another worker holds the lock — it blocks
+//!   instead. End result: SQLite serializes the writers.
+//!
+//! Both engines run the same retry-on-busy loop, but only SQLRite
+//! actually exercises the retry path under this workload's shape.
+//! That contrast is the point.
+//!
+//! ## Why this isn't generic over `Driver` like W1..W12
+//!
+//! The other workloads share `bench_iter` across all drivers — they
+//! all do the same SQL, the engine differences are entirely below
+//! the trait. W13 is different: the *concurrency model itself* is
+//! engine-specific (sibling handles vs separate-process handles;
+//! BEGIN flavour; retry semantics). The trait absorbs that
+//! variation via three new methods (`connect_sibling`,
+//! `concurrent_begin_sql`, `is_retryable_busy`) and the workload
+//! stays simple.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::thread;
+
+use anyhow::{Context, Result};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use crate::{Driver, Value, WorkloadId};
+
+pub const W13: WorkloadId = WorkloadId {
+    id: "W13",
+    name: "concurrent-writers",
+    version: "v1",
+};
+
+/// Number of preloaded rows. `4 workers × 0.4% collision per op` is
+/// "mostly disjoint" — a higher number would be ~0 conflicts (and
+/// stop measuring the retry path on SQLRite), a lower number would
+/// flip the workload into "hot-row contention" which is a different
+/// scenario (and a fair follow-up: `W13b — hot-row contention`).
+pub const W13_PRELOAD_ROWS: i64 = 1_000;
+
+/// Worker count per sample. Matches a typical M-series MBP's
+/// performance-core count without pegging the scheduler. Higher
+/// values (8, 16) are interesting future work but turn the
+/// measurement into "OS scheduler noise" on many laptops; v1 keeps
+/// it tight.
+pub const W13_N_WORKERS: usize = 4;
+
+/// Transactions per worker per criterion sample. With 4 workers ×
+/// 50 txs each, a sample is 200 BEGIN/UPDATE/COMMIT cycles —
+/// enough work to dwarf thread-spawn overhead, short enough that
+/// a criterion sample finishes in a few hundred ms.
+pub const W13_TXS_PER_WORKER: usize = 50;
+
+const W13_SEED: u64 = 13;
+
+/// Sets up the `counters` table and preloads [`W13_PRELOAD_ROWS`]
+/// rows with `n = 0`. Returns the primary connection — workers
+/// either share it via [`Driver::connect_sibling`] (SQLRite) or
+/// each open their own (SQLite, by default).
+pub fn setup<D: Driver>(driver: &D, path: &Path) -> Result<D::Conn> {
+    let mut conn = driver.open(path)?;
+    // Opt the engine into its concurrent path before CREATE so the
+    // mode is in force for every later statement. SQLRite needs
+    // `PRAGMA journal_mode = mvcc;` here; SQLite's no-op default
+    // is fine because its concurrency story is set up at `open`
+    // (WAL + busy_timeout).
+    driver
+        .enable_concurrent_mode(&mut conn)
+        .context("W13 enable_concurrent_mode")?;
+    driver.execute(
+        &mut conn,
+        "CREATE TABLE counters (id INTEGER PRIMARY KEY, n INTEGER NOT NULL)",
+    )?;
+    driver
+        .execute(&mut conn, "BEGIN")
+        .context("W13 preload BEGIN")?;
+    for id in 1..=W13_PRELOAD_ROWS {
+        driver
+            .execute_with_params(
+                &mut conn,
+                "INSERT INTO counters (id, n) VALUES (?, ?)",
+                &[Value::Integer(id), Value::Integer(0)],
+            )
+            .with_context(|| format!("W13 preload id={id}"))?;
+    }
+    driver
+        .execute(&mut conn, "COMMIT")
+        .context("W13 preload COMMIT")?;
+    Ok(conn)
+}
+
+/// Drives `n_workers` threads against `path`, each running
+/// `txs_per_worker` BEGIN/UPDATE/COMMIT cycles with retry on busy.
+/// Returns the total number of committed UPDATEs (expected to equal
+/// `n_workers * txs_per_worker` since we retry on conflict).
+///
+/// The bench loop calls this once per criterion sample. The primary
+/// connection is opened up front; each worker either gets a sibling
+/// (engines that override [`Driver::connect_sibling`] — SQLRite) or
+/// opens its own separate connection (default — SQLite).
+pub fn run_concurrent<D>(
+    driver: Arc<D>,
+    path: &Path,
+    n_workers: usize,
+    txs_per_worker: usize,
+) -> Result<usize>
+where
+    D: Driver + Clone + 'static,
+    D::Conn: Send + 'static,
+{
+    let mut primary = driver.open(path).context("W13 primary open")?;
+    // `PRAGMA journal_mode` (SQLRite) is in-memory per-database
+    // state, not persisted to disk. Every fresh `driver.open()`
+    // resets it to the default (`Wal`), so we re-enable on every
+    // primary acquisition before any worker issues a BEGIN
+    // CONCURRENT. Siblings share the same `Arc<Mutex<Database>>`,
+    // so toggling here propagates to all of them.
+    driver
+        .enable_concurrent_mode(&mut primary)
+        .context("W13 primary enable_concurrent_mode")?;
+
+    let mut conns: Vec<D::Conn> = Vec::with_capacity(n_workers);
+    // Worker 0 gets the primary connection. Workers 1..N get
+    // siblings — for SQLRite that's `Connection::connect()` off
+    // the primary; for SQLite (default impl) that's a fresh
+    // `rusqlite::Connection::open` on the same path.
+    let mut primary_opt = Some(primary);
+    for i in 0..n_workers {
+        if i == 0 {
+            conns.push(primary_opt.take().expect("primary present on i=0"));
+        } else {
+            let sibling = driver
+                .connect_sibling(conns.first().expect("primary at conns[0]"), path)
+                .with_context(|| format!("W13 connect_sibling worker={i}"))?;
+            conns.push(sibling);
+        }
+    }
+
+    let mut handles = Vec::with_capacity(n_workers);
+    for (worker_id, conn) in conns.into_iter().enumerate() {
+        let drv = Arc::clone(&driver);
+        handles.push(thread::spawn(move || -> Result<usize> {
+            run_worker(&*drv, conn, worker_id, txs_per_worker)
+        }));
+    }
+
+    let mut total = 0usize;
+    for (i, h) in handles.into_iter().enumerate() {
+        let committed = h
+            .join()
+            .map_err(|e| anyhow::anyhow!("W13 worker {i} panicked: {e:?}"))?
+            .with_context(|| format!("W13 worker {i} returned err"))?;
+        total += committed;
+    }
+    Ok(total)
+}
+
+/// One worker's run. Each iteration picks a random row id and runs
+/// `BEGIN <flavour>; UPDATE counters SET n = n + 1 WHERE id = ?;
+/// COMMIT;` — retrying the whole BEGIN/UPDATE/COMMIT triple on
+/// retryable busy errors. The retry strategy is "spin immediately"
+/// — picking a backoff policy is the caller's job in real apps;
+/// for the bench we want the maximum throughput the engine can
+/// deliver with no artificial delay.
+fn run_worker<D: Driver>(
+    driver: &D,
+    mut conn: D::Conn,
+    worker_id: usize,
+    txs_per_worker: usize,
+) -> Result<usize> {
+    // Per-worker deterministic RNG so a bench run reproduces the
+    // same id-collision pattern across hosts (modulo the worker
+    // scheduling itself).
+    let mut rng = ChaCha8Rng::seed_from_u64(W13_SEED.wrapping_add(worker_id as u64));
+    let begin_sql = driver.concurrent_begin_sql();
+
+    let mut committed = 0usize;
+    for _ in 0..txs_per_worker {
+        let id: i64 = rng.gen_range(1..=W13_PRELOAD_ROWS);
+        loop {
+            // Open the tx. On retry the previous attempt has already
+            // been rolled back (Busy drops the tx server-side); we
+            // need a fresh BEGIN.
+            driver
+                .execute(&mut conn, begin_sql)
+                .with_context(|| format!("W13 worker={worker_id} BEGIN"))?;
+            // The UPDATE itself can also error retryably (rare on
+            // SQLRite, possible on SQLite if busy_timeout elapses
+            // during the statement). Treat it the same as a COMMIT
+            // failure — roll back and spin.
+            let update_res = driver.execute_with_params(
+                &mut conn,
+                "UPDATE counters SET n = n + 1 WHERE id = ?",
+                &[Value::Integer(id)],
+            );
+            if let Err(e) = update_res {
+                if driver.is_retryable_busy(&e) {
+                    let _ = driver.execute(&mut conn, "ROLLBACK");
+                    continue;
+                }
+                return Err(e).with_context(|| format!("W13 worker={worker_id} UPDATE id={id}"));
+            }
+            match driver.execute(&mut conn, "COMMIT") {
+                Ok(()) => {
+                    committed += 1;
+                    break;
+                }
+                Err(e) if driver.is_retryable_busy(&e) => {
+                    // SQLRite drops the tx on a failed COMMIT; no
+                    // explicit ROLLBACK needed (and indeed it
+                    // would error "no transaction is open"). For
+                    // SQLite the COMMIT failure also clears the
+                    // tx state. Either way, spin to retry.
+                    continue;
+                }
+                Err(e) => {
+                    return Err(e)
+                        .with_context(|| format!("W13 worker={worker_id} COMMIT id={id}"));
+                }
+            }
+        }
+    }
+    Ok(committed)
+}
+
+/// Correctness gate. Runs a single 4×10 concurrent burst against a
+/// freshly-set-up DB and verifies the post-state matches the
+/// expected total. Caught divergences here would point at the
+/// retry loop double-counting, the workers dropping commits, or
+/// the engine mis-handling a Busy boundary.
+pub fn correctness_check<D>(driver: Arc<D>, path: &Path) -> Result<()>
+where
+    D: Driver + Clone + 'static,
+    D::Conn: Send + 'static,
+{
+    // Re-build a fresh DB at the same path so we don't reuse the
+    // setup-touched preload. Drop the file (and SQLRite's WAL
+    // sidecar) so `setup` lands a clean schema.
+    let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file({
+        let mut p = path.as_os_str().to_owned();
+        p.push("-wal");
+        std::path::PathBuf::from(p)
+    });
+    let _ = setup(&*driver, path).context("W13 correctness setup")?;
+
+    let n = 4usize;
+    let m = 10usize;
+    let committed = run_concurrent(Arc::clone(&driver), path, n, m)?;
+    let expected = n * m;
+    if committed != expected {
+        anyhow::bail!("W13 correctness: workers reported {committed} commits, expected {expected}");
+    }
+
+    // The table's total counter sum should equal `committed` —
+    // every commit increments exactly one row by exactly one. A
+    // sum mismatch would indicate either a lost commit or a
+    // double-counted retry, both of which W13 is here to catch.
+    let mut probe = driver.open(path)?;
+    let row = driver.query_one(&mut probe, "SELECT SUM(n) FROM counters", &[])?;
+    match row.first() {
+        Some(Value::Integer(sum)) if *sum == committed as i64 => Ok(()),
+        Some(Value::Integer(sum)) => {
+            anyhow::bail!("W13 correctness: SUM(n) = {sum}, expected {committed}",)
+        }
+        other => anyhow::bail!("W13 correctness: SUM returned unexpected shape {other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drivers::sqlite::SQLiteDriver;
+    use crate::drivers::sqlrite::SQLRiteDriver;
+
+    /// Per-driver fast smoke test for W13. Mirrors the criterion
+    /// correctness_check shape but without the criterion harness
+    /// overhead — run with `cargo test -p sqlrite-benchmarks w13`
+    /// to verify the workload works end-to-end in a few seconds.
+    fn run_one<D>(driver: D)
+    where
+        D: Driver + Clone + 'static,
+        D::Conn: Send + 'static,
+    {
+        let tmp = tempfile::Builder::new()
+            .prefix(&format!("w13-test-{}-", driver.name()))
+            .tempdir()
+            .unwrap();
+        let path = tmp.path().join(format!(
+            "w13.{}",
+            match driver.name() {
+                "sqlite" => "sqlite",
+                "duckdb" => "duckdb",
+                _ => "sqlrite",
+            }
+        ));
+        let driver = Arc::new(driver);
+        correctness_check(Arc::clone(&driver), &path).unwrap_or_else(|e| {
+            let name = driver.name();
+            let chain: Vec<String> = e.chain().map(|c| format!("{c}")).collect();
+            panic!(
+                "W13 correctness on {name}:\n  {}",
+                chain.join("\n  caused by: ")
+            );
+        });
+    }
+
+    #[test]
+    fn w13_sqlrite_correctness() {
+        run_one(SQLRiteDriver);
+    }
+
+    #[test]
+    fn w13_sqlite_correctness() {
+        run_one(SQLiteDriver);
+    }
+}

--- a/benchmarks/src/workloads/mod.rs
+++ b/benchmarks/src/workloads/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod aggregate;
 pub mod bulk_insert;
+pub mod concurrent_writers;
 pub mod fts;
 pub mod group_by;
 pub mod hybrid;

--- a/docs/benchmarks-plan.md
+++ b/docs/benchmarks-plan.md
@@ -111,6 +111,16 @@ For W10/W11, the goal isn't to beat the comparators — they're battle-hardened 
 
 For W12, no off-the-shelf comparator exists in a single embedded engine; the number stands on its own.
 
+### Group D — Concurrent writes (Phase 11.11b, the Phase-11 MVCC differentiator)
+
+| ID | Name | Shape | Comparator |
+|----|------|-------|------------|
+| W13 | Concurrent writers | 4 worker threads × 50 BEGIN/UPDATE/COMMIT cycles each, random rowid in `1..=1000` (≈ 0.4% collision per op), `UPDATE counters SET n = n + 1 WHERE id = ?` | SQLite (`BEGIN IMMEDIATE` + `busy_timeout = 5s` per-connection) |
+
+The headline workload Phase 11's MVCC machinery was designed for. SQLRite drives `BEGIN CONCURRENT` across sibling [`Connection::connect`](../docs/concurrent-writes.md) handles minted from the same process; SQLite drives `BEGIN IMMEDIATE` across separate `rusqlite::Connection` handles serializing through the WAL write lock. Both engines run the same retry-on-busy outer loop ([`is_retryable_busy`](../benchmarks/src/lib.rs) is engine-dispatched); only SQLRite actually exercises the retry path under this workload's shape — the contrast *is* the measurement.
+
+Workload parameters live in [`benchmarks/src/workloads/concurrent_writers.rs`](../benchmarks/src/workloads/concurrent_writers.rs) as named constants (`W13_PRELOAD_ROWS`, `W13_N_WORKERS`, `W13_TXS_PER_WORKER`). Bumping any of them is a workload-version bump under Q8.
+
 ---
 
 ## Metrics
@@ -127,8 +137,9 @@ Keep tight. The task brief lists many candidates; the suite measures these:
 Explicitly **not** measured in v1:
 
 - **CPU%.** Noisy on a shared machine, redundant with wall-clock for single-threaded workloads.
-- **Concurrency curves.** Engine is single-writer by design (Phase 4e). No concurrent-writer workload is meaningful until that changes.
 - **Network I/O.** All targets are in-process.
+
+**Updated post-Phase 11.11b:** Group D's `W13` (concurrent writers) lifts the single-writer caveat — SQLRite now has a real multi-writer story via `BEGIN CONCURRENT`, and W13 measures it directly against SQLite's single-writer baseline. Full concurrency-curve sweeps (varying `N` workers and collision rate) are a clean follow-up; v1 reports a single representative point.
 
 ---
 
@@ -190,7 +201,8 @@ benchmarks/
 │       ├── join.rs        — W9
 │       ├── vector.rs      — W10
 │       ├── fts.rs         — W11
-│       └── hybrid.rs      — W12
+│       ├── hybrid.rs      — W12
+│       └── concurrent_writers.rs — W13 (Phase 11.11b)
 ├── benches/
 │   └── suite.rs           — single criterion entry point that fans out
 ├── scripts/
@@ -264,11 +276,18 @@ Add the `duckdb-rs` driver under a `--features duckdb` flag. Wire only into Grou
 
 **Exit criterion:** `docs/benchmarks.md` exists, the README has a "Benchmarks" section pointing at it, the first dated results JSON is committed.
 
-### Post-9.6 ideas (parked)
+### 9.7 — Group D concurrent writers (Phase 11.11b, shipped)
+
+Adds `W13` (concurrent writers, mostly-disjoint rows) under a new Group D. The `Driver` trait grows three optional methods (`connect_sibling`, `concurrent_begin_sql`, `is_retryable_busy`) with defaults that make sense for engines without an MVCC story; SQLRite overrides all three. SQLite gains a `busy_timeout = 5s` pragma at open so its `BEGIN IMMEDIATE` blocks rather than fails on contention. The workload lives in [`benchmarks/src/workloads/concurrent_writers.rs`](../benchmarks/src/workloads/concurrent_writers.rs).
+
+**Exit criterion:** W13 runs under both drivers, correctness gate passes (`SUM(n) == n_workers * txs_per_worker` after a sample), and the JSON envelope picks up `W13.v1` rows for both drivers.
+
+### Post-9.7 ideas (parked)
 
 - **libSQL driver** if/when we want a non-extension vector competitor for W10.
 - **Per-PR regression detector.** A GitHub Action that runs the bench on a self-hosted runner and posts a comment if any workload regresses >20% from the last `main` baseline.
-- **Concurrency workloads** if/when SQLRite gains true multi-writer support.
+- **Concurrency curves for W13.** Sweep `N` workers (1, 2, 4, 8, 16) and `K` rows (10, 100, 1k, 10k) to chart SQLRite-MVCC's scaling envelope vs SQLite's serial baseline. v1 reports a single representative point; the sweep is a clean follow-up.
+- **W13b hot-row contention.** Same workload, `K = 10` rows instead of 1000 — collision probability climbs to ~40% per op, exercising the retry loop hard. Useful for stressing the GC + retry path under adversarial contention.
 - **Larger datasets (10M, 100M).** v1 is sized for fast iteration on a laptop. A "release-blocker run" config could 100× the row counts.
 
 ### Total scope estimate

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -697,9 +697,20 @@ Lift the REPL from a single `Database` to a `Vec<Connection>` so users can mint 
 
 The downstream "N concurrent writers" benchmark workload (originally bundled into 11.11) is its own follow-up: it touches the `benchmarks/` harness, links SQLite + DuckDB drivers, and is much heavier than this slice.
 
-### Phase 11.11b — `N concurrent writers` benchmark workload *(planned)*
+### ✅ Phase 11.11b — `W13 — concurrent writers` benchmark workload
 
-New benchmark in [`benchmarks/`](../benchmarks/) that pits SQLRite-MVCC against SQLite + DuckDB on a disjoint-row "N writers, mostly disjoint rows" scenario. Slots into the existing SQLR-16 harness as a Group D differentiator workload. Also includes Go SDK multi-handle work (cross-pool sibling shape) — see the 11.8 note for why that's a separate slice.
+New `W13` workload in [`benchmarks/`](../benchmarks/) pits SQLRite-MVCC against SQLite on a "N writers, mostly disjoint rows" scenario — the headline shape Phase 11's MVCC machinery was designed for. Lives under a new **Group D** in the [`docs/benchmarks-plan.md`](benchmarks-plan.md#group-d--concurrent-writes-phase-1111b-the-phase-11-mvcc-differentiator) taxonomy.
+
+- **Workload** ([`benchmarks/src/workloads/concurrent_writers.rs`](../benchmarks/src/workloads/concurrent_writers.rs)): 4 worker threads × 50 BEGIN/UPDATE/COMMIT cycles each, random rowid in `1..=1000` (~ 0.4% collision per op). Each engine uses its idiomatic BEGIN flavour: SQLRite `BEGIN CONCURRENT`, SQLite `BEGIN IMMEDIATE` with `busy_timeout = 5s`. Both run the same retry-on-busy outer loop.
+- **Driver trait extension** ([`benchmarks/src/lib.rs`](../benchmarks/src/lib.rs)): three new methods with sensible defaults — `connect_sibling` (SQLRite overrides to call `Connection::connect`; default opens a fresh connection), `concurrent_begin_sql` (default `"BEGIN"`), `is_retryable_busy` (default false). The SQLite driver gains a `busy_timeout = 5s` pragma at open so concurrent commits block instead of immediately erroring.
+- **Correctness gate**: after a 4×10 burst, `SUM(n)` over the counters table must equal `n_workers × txs_per_worker`. Catches lost commits, double-counted retries, and any mis-handling of the Busy boundary.
+- **Sub-phase**: registered as **9.7** in [`docs/benchmarks-plan.md`](benchmarks-plan.md). The original 11.11b also flagged Go SDK cross-pool sibling shape — that's a separate slice (Phase 11.11c) because it touches the Go binding architecture rather than the bench harness.
+
+Headline numbers will land with the first pinned-host re-publication; v1 ships the workload + correctness gate so any future numbers stand on a verified base.
+
+### Phase 11.11c — Go SDK cross-pool sibling shape *(planned)*
+
+Each `sql.Open("sqlrite", path)` today builds an independent backing DB; sharing engine state across `sql.DB` pools needs a process-level registry keyed by path. Bundled into Phase 11.11 originally; split out because it touches the Go binding architecture (cgo + the `database/sql` driver model) rather than the bench harness or the engine. See [`sdk/go/README.md`](../sdk/go/README.md) for the current single-pool sibling story.
 
 ### ✅ Phase 11.12 — Docs sweep *(plan-doc "Phase 10.9")*
 


### PR DESCRIPTION
## Summary

- Adds the headline Phase-11 differentiator workload (`W13` — concurrent writers, mostly-disjoint rows) to the SQLR-16 benchmark harness under a new **Group D**.
- 4 worker threads × 50 BEGIN/UPDATE/COMMIT cycles each, random rowid in `1..=1000` (~ 0.4% collision per op). SQLRite drives `BEGIN CONCURRENT` across sibling [`Connection::connect`](https://github.com/joaoh82/rust_sqlite/blob/main/docs/concurrent-writes.md) handles; SQLite drives `BEGIN IMMEDIATE` across separate `rusqlite::Connection` handles serializing through the WAL writer lock.
- The `Driver` trait grows four optional methods (each with a sensible default so W1..W12 are untouched): `connect_sibling`, `enable_concurrent_mode`, `concurrent_begin_sql`, `is_retryable_busy`. SQLRite overrides all four; SQLite uses the defaults plus a new `busy_timeout = 5s` pragma at open.
- Correctness gate: after a 4×10 burst, `SUM(n)` over the counters table must equal `n_workers × txs_per_worker`. Two new lib tests (`w13_sqlrite_correctness`, `w13_sqlite_correctness`) exercise it in ~1.2s without the criterion harness overhead.

## Why this is split from Phase 11.11

The original 11.11 bundled the REPL `.spawn` work, this bench workload, and a Go SDK cross-pool sibling shape into one slice. They diverged in scope:

- **11.11a** (shipped) — REPL `.spawn` for interactive demos.
- **11.11b** (this PR) — `W13` bench workload.
- **11.11c** (deferred) — Go SDK cross-pool sibling shape; touches the cgo + `database/sql` driver architecture and is genuinely independent of either.

## Per-engine specifics

| Method (defaults shown) | SQLRite override | SQLite override |
|---|---|---|
| `connect_sibling(primary, path) → open(path)` | `primary.connect()` (in-process sibling, shared `Arc<Mutex<Database>>`) | _default_ — fresh `rusqlite::Connection::open(path)` |
| `enable_concurrent_mode(conn) → ()` | `PRAGMA journal_mode = mvcc;` | _default_ — WAL + busy_timeout already set at `open` |
| `concurrent_begin_sql() → "BEGIN"` | `"BEGIN CONCURRENT"` | `"BEGIN IMMEDIATE"` |
| `is_retryable_busy(err) → false` | downcast to `SQLRiteError::is_retryable()` | walk anyhow chain for `DatabaseBusy` / `DatabaseLocked` |

Both engines run the same retry-on-busy outer loop. Only SQLRite actually exercises the retry path under this workload's collision rate; SQLite's `busy_timeout` makes its BEGIN block rather than fail.

## Subtle pitfalls hit during implementation

1. **Anyhow source preservation.** The SQLRite driver's existing `.map_err(|e| anyhow::anyhow!("…{e}…"))` pattern in `execute` / `execute_with_params` was dropping the typed `SQLRiteError` source — `is_retryable_busy` couldn't downcast. Switched to `.map_err(anyhow::Error::new).with_context(...)` so the typed source survives. (Other callers don't depend on the downcast; the change is invisible to them.)
2. **SQLRite's exclusive flock.** SQLRite's `Connection::open` takes `flock(LOCK_EX)` on the WAL sidecar. Workers 2-N can't `open()` the same path — they'd fail to acquire the lock. Solved via `connect_sibling`, which SQLRite overrides to call `primary.connect()`. Default opens a fresh connection (works for SQLite under WAL).
3. **MVCC mode is in-memory state.** `PRAGMA journal_mode` doesn't persist to disk; every fresh `Connection::open` resets to the default (`Wal`). The W13 setup enables it once, then `run_concurrent` re-opens the file at each criterion sample — so we re-enable on every primary acquisition before any worker issues a BEGIN CONCURRENT. (Caught by the correctness gate failing with "BEGIN CONCURRENT requires `PRAGMA journal_mode = mvcc;` first".)

## Docs

- `docs/benchmarks-plan.md` — new Group D section; sub-phase 9.7; post-9.7 ideas list with W13 concurrency-curve sweep + W13b hot-row contention follow-ups.
- `benchmarks/README.md` — Group D entry; new W13 section explaining per-engine BEGIN flavour + connection model + correctness gate.
- `docs/roadmap.md` — Phase 11.11b promoted to ✅ shipped; new Phase 11.11c entry for the deferred Go SDK work.

## Test plan

- [x] `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --all-targets`
- [x] `cargo test  --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks` — 615/615
- [x] `cargo test  -p sqlrite-benchmarks --lib w13` — both drivers' correctness gates pass in ~1.2s
- [x] `cargo build -p sqlrite-benchmarks --benches` — W13 registers cleanly
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --all-targets`
- [x] `cargo clippy -p sqlrite-benchmarks --all-targets` — no new errors
- [x] `cargo doc  --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --no-deps`
- [ ] CI green
- [ ] Pinned-host run + commit headline numbers (`make bench` locally on the owner's host; lands in a follow-up PR alongside the regular bench-republish cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)