### PR TITLE
ci: pin binaryen / wasm-opt for deterministic WASM builds (SQLR-58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,15 @@ jobs:
   wasm-build:
     name: wasm-build
     runs-on: ubuntu-latest
+    # Pinned binaryen version — see docs/release-plan.md
+    # ("Pinned binaryen / wasm-opt") for the bump procedure. Older
+    # binaryen rejects rustc's multi-table WASM output with
+    # "Only 1 table definition allowed in MVP", which the runner
+    # image's cache state used to surface non-deterministically
+    # (SQLR-58). Pinning keeps wasm-opt out of "whatever's cached"
+    # territory.
+    env:
+      BINARYEN_VERSION: version_122
     steps:
       - uses: actions/checkout@v4
 
@@ -313,12 +322,29 @@ jobs:
           workspaces: sdk/wasm
           shared-key: wasm-build
 
+      - name: Install pinned binaryen (wasm-opt)
+        # MUST run before wasm-pack: wasm-pack picks up wasm-opt from
+        # PATH if present, otherwise downloads whatever binaryen its
+        # own internal cache happens to have. Pinning + prepending
+        # to PATH forces a deterministic version across runner images.
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
+            -o "$RUNNER_TEMP/binaryen.tar.gz"
+          tar -xzf "$RUNNER_TEMP/binaryen.tar.gz" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/binaryen-${BINARYEN_VERSION}/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" --version
+
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
 
       - name: wasm-pack build --target web --release
         working-directory: sdk/wasm
-        run: wasm-pack build --target web --release
+        run: |
+          # Sanity-check that the pinned wasm-opt is what wasm-pack sees.
+          which wasm-opt
+          wasm-opt --version
+          wasm-pack build --target web --release
 
       - name: Report .wasm size
         # Surfaces size regressions in PR logs. Not a hard limit yet;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1189,6 +1189,14 @@ jobs:
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     environment: release
+    # Pinned binaryen version — see docs/release-plan.md
+    # ("Pinned binaryen / wasm-opt") for the bump procedure. Older
+    # binaryen rejects rustc's multi-table WASM output with
+    # "Only 1 table definition allowed in MVP" (SQLR-58). The
+    # release pipeline can't tolerate that flake — a failed
+    # publish-wasm leaves the rest of the release wave inconsistent.
+    env:
+      BINARYEN_VERSION: version_122
     permissions:
       # OIDC: required for npm trusted-publisher token exchange.
       # Same flow proven in publish-nodejs after the v0.1.5–0.1.7
@@ -1206,6 +1214,20 @@ jobs:
         with:
           shared-key: publish-wasm
           workspaces: 'sdk/wasm -> target'
+
+      - name: Install pinned binaryen (wasm-opt)
+        # MUST run before wasm-pack: wasm-pack picks up wasm-opt
+        # from PATH if present, otherwise downloads whatever
+        # binaryen its own internal cache happens to have. Pinning
+        # + prepending to PATH forces a deterministic version
+        # across runner images.
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
+            -o "$RUNNER_TEMP/binaryen.tar.gz"
+          tar -xzf "$RUNNER_TEMP/binaryen.tar.gz" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/binaryen-${BINARYEN_VERSION}/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/binaryen-${BINARYEN_VERSION}/bin/wasm-opt" --version
 
       # Install wasm-pack — the canonical tool for building +
       # packaging Rust crates as npm-publishable WASM modules.
@@ -1239,6 +1261,9 @@ jobs:
       - name: Build WASM package
         working-directory: sdk/wasm
         run: |
+          # Sanity-check that the pinned wasm-opt is on PATH (SQLR-58).
+          which wasm-opt
+          wasm-opt --version
           wasm-pack build --release --target bundler --scope joaoh82
           echo "--- generated pkg/ contents ---"
           ls -la pkg/

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -247,7 +247,10 @@ The "publish" half. Auto-fires on the release commit.
     GitHub Release `sqlrite-node-vX.Y.Z`.
   - **publish-wasm** — `wasm-pack build --target bundler --release`,
     then `wasm-pack publish` via OIDC. Creates
-    `sqlrite-wasm-vX.Y.Z` GitHub Release.
+    `sqlrite-wasm-vX.Y.Z` GitHub Release. Installs a
+    [pinned binaryen / wasm-opt](#pinned-binaryen--wasm-opt) before
+    invoking `wasm-pack`, so the published bundle is byte-stable
+    across runner image cache states.
   - **publish-go** — nothing to build on the Go side. Verifies
     `sdk/go/vX.Y.Z` was pushed correctly by `tag-all`. Pulls the
     per-platform `libsqlrite_c` tarballs produced by
@@ -284,6 +287,64 @@ The "publish" half. Auto-fires on the release commit.
   auto-trigger fires. `tag-all` runs and finds the tags already
   exist (because the real release happened weeks ago). Workflow
   aborts with a clear "tag already exists" error. No damage.
+
+## Pinned binaryen / wasm-opt
+
+The WASM build paths in `ci.yml` (`wasm-build`) and `release.yml`
+(`publish-wasm`) both install a **pinned version of binaryen**
+(which provides `wasm-opt`) before invoking `wasm-pack`. The pin
+lives in a `BINARYEN_VERSION` job-level `env:` in each workflow.
+
+**Current pin: `version_122`** (released Feb 2025).
+
+### Why this exists (SQLR-58)
+
+`wasm-pack` invokes `wasm-opt` to size-optimize the published
+bundle. If `wasm-opt` is already on `PATH`, `wasm-pack` uses that
+one; otherwise it downloads its own copy into a per-runner cache.
+That cache is keyed on the runner image and survives across
+images opaquely — which means CI was getting whatever binaryen
+the cache happened to hold. When the cached copy was old enough
+to predate multi-table WASM support, `wasm-opt` would reject
+recent rustc output with:
+
+> `[parse exception: Only 1 table definition allowed in MVP]`
+> `Fatal: error in parsing input`
+> `Error: failed to execute wasm-opt: exited with exit code: 1`
+
+The failure was non-deterministic (re-runs frequently passed,
+because the new image had a different cache state), but it broke
+the release pipeline at least once before [PR #135](https://github.com/joaoh82/rust_sqlite/pull/135).
+Pinning binaryen + prepending it to `PATH` forces `wasm-pack`
+to always see the same `wasm-opt`, regardless of runner state.
+
+### Bump procedure
+
+1. Look at the [binaryen releases page](https://github.com/WebAssembly/binaryen/releases)
+   and pick a recent stable version (avoid release candidates).
+2. Locally, download that release's `x86_64-linux` tarball and
+   run `wasm-opt --version` to confirm it builds. Optional but
+   nice: also run `wasm-pack build --target web --release` in
+   `sdk/wasm` with the new `wasm-opt` on `PATH` and confirm the
+   `.wasm` artifact size is in the same ballpark as before
+   (regressions > 10% are worth investigating).
+3. Update `BINARYEN_VERSION` in both `.github/workflows/ci.yml`
+   (job `wasm-build`) and `.github/workflows/release.yml` (job
+   `publish-wasm`). Keep the two in lockstep — a divergence
+   means CI and release produce subtly different artifacts.
+4. Update the "Current pin" line above to match.
+5. PR + merge. CI will exercise the new version on the WASM
+   build job before the release pipeline ever sees it.
+
+### Why a tarball, not apt-get
+
+Ubuntu's apt-packaged `binaryen` is reliably 1–2 years behind
+upstream and pinning it requires the matching apt index, which is
+itself unstable across runner image refreshes. The official
+WebAssembly/binaryen GitHub release tarballs are stable URLs and
+sha-pinnable (we don't currently verify the sha256 — a follow-up
+if supply-chain integrity becomes a concern; the tarball is
+short-lived and contained to the runner).
 
 ## Secrets / one-time setup
 


### PR DESCRIPTION
## Summary

- Pin `binaryen` (provides `wasm-opt`) to **`version_122`** in both `ci.yml` (`wasm-build`) and `release.yml` (`publish-wasm`) by downloading the official GitHub release tarball before `wasm-pack` runs and prepending it to `PATH`.
- `wasm-pack` auto-detects `wasm-opt` on `PATH` (and falls back to its internal binaryen cache otherwise) — so this single change is enough to force a deterministic `wasm-opt` across runner image cache states.
- Document the pin + bump procedure in [docs/release-plan.md](https://github.com/joaoh82/rust_sqlite/blob/sqlr-58-pin-binaryen/docs/release-plan.md#pinned-binaryen--wasm-opt).

## Why

[PR #135](https://github.com/joaoh82/rust_sqlite/pull/135) flaked with:

```
[parse exception: Only 1 table definition allowed in MVP (at 0:11235)]
Fatal: error in parsing input
Error: failed to execute `wasm-opt`: exited with exit code: 1
```

Root cause: `jetli/wasm-pack-action` and `wasm-pack`'s curl-installer both let `wasm-pack` use whatever binaryen its per-runner cache happens to hold. Older binaryen rejects rustc's multi-table WASM output. The same commit shipped successfully on a rerun (different cache state) and via the release pipeline — proving it's a binaryen-version flake, not a code regression. The release pipeline can't tolerate this: a failed `publish-wasm` leaves the release wave inconsistent.

## Why option 2 (pin via tarball)

- **Option 1 (disable wasm-opt)** would ship a 5–15% larger bundle on every user. Not worth it.
- **Option 3 (bump jetli/wasm-pack-action)** doesn't actually fix this — that action installs `wasm-pack`, which itself picks the binaryen version. No newer tag of `jetli/wasm-pack-action` solves the binaryen problem.
- **Option 2 (pin binaryen tarball + put on PATH)** is what landed: keeps `wasm-opt`'s size optimization, removes the cache-roulette behavior, and turns binaryen bumps into a deliberate two-file diff.

## Verified locally

`wasm-pack build --target web --release` with the pinned binaryen on PATH:

```
[INFO]: found wasm-opt at "/tmp/sqlr58-binaryen/binaryen-version_122/bin/wasm-opt"
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: ✨   Done in 35.82s
```

Output bundle: 2.14 MiB — in line with prior sizes (the v0.10.0 release WASM bundle was ~2.1 MiB).

## Test plan

- [ ] CI `wasm-build` job passes on this PR.
- [ ] CI logs show `wasm-opt version 122 (version_122)` in the "Install pinned binaryen" + "wasm-pack build" steps.
- [ ] Re-run the `wasm-build` job 2–3 times — pass on each run (proving determinism).
- [ ] `release.yml`'s `publish-wasm` path will be exercised on the next release wave; expectation is the same `version_122` line in the build log.

## Follow-ups (separate PRs)

- The `sdk/wasm/Cargo.lock` is stale — it still pins internal crates at `0.1.23` while `Cargo.toml` is at `0.10.0`. The 0.10.0 bump didn't touch it because `sdk/wasm/` is its own workspace and `scripts/bump-version.sh` doesn't `cargo build` inside it. Spinning that off into its own ticket; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)