### PR TITLE
release: v0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ask"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-desktop"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-engine"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clap",
  "env_logger",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ffi"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "cbindgen",
  "serde",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-mcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clap",
  "libc",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-nodejs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "napi",
  "napi-build",
@@ -4887,7 +4887,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-python"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "pyo3",
  "sqlrite-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "3"
 # `package =` key so the import name stays `sqlrite` internally:
 #     sqlrite = { package = "sqlrite-engine", path = "…" }
 name = "sqlrite-engine"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -150,4 +150,4 @@ fs2 = { version = "0.4", optional = true }
 # crate publishes to crates.io, and a path-only dep without a
 # version field fails the manifest verification step. See PR #58
 # retrospective in docs/roadmap.md.
-sqlrite-ask = { version = "0.10.0", path = "sqlrite-ask", optional = true }
+sqlrite-ask = { version = "0.10.1", path = "sqlrite-ask", optional = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -50,7 +50,7 @@ duckdb = ["dep:duckdb"]
 # The engine. Default features off (no rustyline / clap / `ask`), but
 # `file-locks` is on so the comparison runs the same lock-acquisition
 # path that any real SQLRite consumer pays.
-sqlrite = { package = "sqlrite-engine", path = "..", version = "0.10.0", default-features = false, features = ["file-locks"] }
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.10.1", default-features = false, features = ["file-locks"] }
 
 # SQLite via rusqlite, with `bundled` so the comparison is against a
 # known SQLite version (not whatever happens to be on the host).

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlrite-desktop-frontend",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-desktop"
-version = "0.10.0"
+version = "0.10.1"
 description = "SQLRite desktop app — Tauri 2 shell around the engine"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SQLRite",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "com.sqlrite.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/sdk/nodejs/Cargo.toml
+++ b/sdk/nodejs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-nodejs"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joaoh82/sqlrite",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Node.js bindings for SQLRite — a small, embeddable SQLite clone written in Rust.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-python"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sqlrite"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python bindings for SQLRite — a small, embeddable SQLite clone written in Rust."
 authors = [{ name = "Joao Henrique Machado Silva", email = "joaoh82@gmail.com" }]
 license = { text = "MIT" }

--- a/sdk/wasm/Cargo.toml
+++ b/sdk/wasm/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "sqlrite-wasm"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -46,7 +46,7 @@ sqlrite = { package = "sqlrite-engine", path = "../..", default-features = false
 # builds for wasm32). Per Q9, the WASM SDK never makes the HTTP call
 # itself — the JS caller does that. Browser → backend → LLM provider
 # → JS hands the raw response back to `db.askParse()`.
-sqlrite-ask = { version = "0.10.0", path = "../../sqlrite-ask", default-features = false }
+sqlrite-ask = { version = "0.10.1", path = "../../sqlrite-ask", default-features = false }
 
 # wasm-bindgen + friends. `serde-serialize` on wasm-bindgen gives
 # us `serde_wasm_bindgen` interop for structured row objects.

--- a/sqlrite-ask/Cargo.toml
+++ b/sqlrite-ask/Cargo.toml
@@ -10,7 +10,7 @@
 # Published to crates.io as `sqlrite-ask`. Joins the lockstep release
 # wave (`sqlrite-ask-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-ask"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-ffi/Cargo.toml
+++ b/sqlrite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-ffi"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-mcp/Cargo.toml
+++ b/sqlrite-mcp/Cargo.toml
@@ -18,7 +18,7 @@
 # Published to crates.io as `sqlrite-mcp`. Joins the lockstep
 # release wave (`sqlrite-mcp-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-mcp"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -52,7 +52,7 @@ ask = ["sqlrite/ask"]
 # off (which excludes the `cli` feature and its rustyline/clap pull
 # weight) and only enable `ask` when our own `ask` feature is on.
 # Keeps the MCP binary small + boot-fast.
-sqlrite = { package = "sqlrite-engine", path = "..", version = "0.10.0", default-features = false }
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.10.1", default-features = false }
 
 # JSON-RPC + tool I/O. The MCP wire format is JSON in / JSON out;
 # tool argument schemas are JSON; tool results are JSON. serde +


### PR DESCRIPTION
## Release

Prepares SQLRite v0.10.1 as a patch release for the SQLR-8 HNSW delete/reinsert bugfix.

This is the release PR half of the existing release flow. Once this PR merges, `.github/workflows/release.yml` should detect the merge commit message `release: v0.10.1`, tag the release, and publish the configured artifacts.

## Why

PR #142 fixed a process-aborting engine bug where HNSW could panic after DELETE followed by INSERT within one open connection. The fix affects SDK consumers as well as the REPL/MCP surfaces, so it should ship as a patch release.

## Changes

- Bump all published package manifests from `0.10.0` to `0.10.1`.
- Refresh `Cargo.lock`.
- Update inter-workspace path dependency pins, including the benchmark harness pin.

## Validation

- `scripts/bump-version.sh 0.10.1`
- `cargo build`
- `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --all-targets`
- `cargo test --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --all-targets` (passes with existing warnings)
- `cargo doc --workspace --exclude sqlrite-desktop --exclude sqlrite-python --exclude sqlrite-nodejs --exclude sqlrite-benchmarks --no-deps` (passes with existing rustdoc warnings)
- `npm ci && npm test` in `examples/nodejs-notes`

## Post-Merge Release Watch

After merge:

1. Confirm `release.yml` starts for v0.10.1.
2. Approve the `release` environment gates if GitHub requests approval.
3. Confirm crates.io publishes for `sqlrite-ask`, `sqlrite-engine`, and `sqlrite-mcp`.
4. Confirm SDK/package artifacts publish successfully: Python, Node.js, WASM, Go tag/release, FFI/MCP binaries, and desktop artifacts.
5. Confirm the umbrella GitHub release exists for `v0.10.1`.
6. If the workflow does not auto-trigger, manually run `gh workflow run release.yml -f version=0.10.1`.
