### PR TITLE
SQLR-70 — Desktop playground: in-app Settings for Anthropic API key

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,52 @@
+# SQLRite Desktop
+
+A Tauri 2 + Svelte 5 SQL playground that embeds the SQLRite engine
+directly (no FFI hop). Open or create a `.sqlrite` file, browse tables,
+run SQL, and — with an Anthropic API key configured — turn
+natural-language questions into SQL via the **Ask…** button.
+
+## Run (dev)
+
+```sh
+cd desktop
+npm install
+npm run tauri dev
+```
+
+The app starts in-memory ("scratch") — use **New…** / **Open…** to back
+it with a file.
+
+## Configuring `ask`
+
+The **Ask…** button calls the LLM server-side (the Rust backend), so the
+API key never crosses into the webview. There are two ways to provide it:
+
+1. **⚙ Settings dialog (recommended).** Click the gear icon in the
+   header and paste an Anthropic key. It's persisted to
+   `$APP_DATA/com.sqlrite.desktop/settings.json`:
+
+   ```
+   ~/Library/Application Support/com.sqlrite.desktop/   (macOS)
+   └── settings.json   # { "anthropic_api_key": "sk-ant-…", "model": "…", "max_tokens": … }
+   ```
+
+   This works regardless of how the app is launched — including from
+   Finder / the Dock, which do **not** inherit a shell's environment.
+
+2. **Env var fallback.** If no key is saved in Settings, the backend
+   falls back to `SQLRITE_LLM_API_KEY` from the environment that launched
+   the app. Handy for `npm run tauri dev` from a terminal, but it won't
+   reach the app if you launch it from Finder.
+
+`get_ask_settings` returns `has_api_key: bool` (never the key value), so
+the UI can show which source is active — "key configured in settings",
+"picked up from SQLRITE_LLM_API_KEY env var", or "no key configured".
+With no key from either source, **Ask…** returns a clear
+"no API key configured" error pointing back at the ⚙ gear icon.
+
+### Security note
+
+The settings file is **plain JSON on disk** — better UX than an env-var
+gate and good enough for a local-first example app, but less secure than
+the OS keychain. A production desktop app shipping the same pattern
+should reach for `tauri-plugin-keyring` / `keyring-rs` instead.

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlrite-desktop-frontend",
-  "version": "0.1.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlrite-desktop-frontend",
-      "version": "0.1.0",
+      "version": "0.10.1",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0"

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -15,20 +15,27 @@
 // Prevent a second console window on Windows in release mode.
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod settings;
+
 use std::path::PathBuf;
 use std::sync::Mutex;
 
 use serde::Serialize;
-use sqlrite::ask::{AskConfig, ask_with_database};
+use sqlrite::ask::ask_with_database;
 use sqlrite::sql::db::table::Value;
 use sqlrite::{Database, SQLRiteError, process_command};
 use tauri::{Manager, State};
 
-/// Holds the single active database for the app. A `None` means "no
-/// database open yet" — the frontend should nudge the user toward
-/// `.open`.
+use settings::{AskSettings, AskSettingsDto, AskSettingsUpdate};
+
+/// Holds the single active database for the app plus the path to the
+/// on-disk `settings.json`. The settings path is immutable for the
+/// app's lifetime, so it lives outside the mutex; reads/writes go
+/// through `AskSettings::load` / `AskSettings::save` which touch disk
+/// directly.
 struct AppState {
     db: Mutex<Database>,
+    settings_path: PathBuf,
 }
 
 /// Mirrors `SecondaryIndex` enough for the UI's sidebar — just name,
@@ -176,12 +183,11 @@ fn table_rows(
 /// Flow:
 /// 1. Lock the `Database` (so the schema dump is consistent with what
 ///    the user would see if they ran `.tables`).
-/// 2. Read `AskConfig` from the process's environment
-///    (`SQLRITE_LLM_API_KEY` etc.). Tauri inherits the parent shell's
-///    env when launched via `npm run tauri dev` / when launched from
-///    a terminal in production. If the var isn't set, the call fails
-///    with a clear "missing API key" message that the frontend surfaces
-///    in the existing error slot.
+/// 2. Build `AskConfig` from the saved settings (`settings.json`),
+///    falling back to `SQLRITE_LLM_API_KEY` in the environment when no
+///    key is saved. If neither is present, the call fails with a clear
+///    "no API key configured" message — pointing at the ⚙ gear icon —
+///    that the frontend surfaces in the existing error slot.
 /// 3. Call into `sqlrite::ask::ask_with_database` — schema dump +
 ///    cache-friendly prompt + sync HTTP POST happens in the Rust
 ///    backend. **The API key never crosses into the webview.** That's
@@ -203,13 +209,36 @@ fn table_rows(
 ///   strings ask() produces.
 #[tauri::command]
 fn ask_sql(question: String, state: State<'_, AppState>) -> Result<AskCommandResult, String> {
-    let cfg = AskConfig::from_env().map_err(|e| format!("ask config error: {e}"))?;
+    let saved = AskSettings::load(&state.settings_path);
+    let cfg = settings::build_ask_config(&saved)?;
     let locked = state.db.lock().map_err(engine_err)?;
     let resp = ask_with_database(&*locked, &question, &cfg).map_err(engine_err)?;
     Ok(AskCommandResult {
         sql: resp.sql,
         explanation: resp.explanation,
     })
+}
+
+/// Returns the current `ask` settings, scrubbed for the webview — the
+/// raw API key never crosses the IPC boundary, only `has_api_key`.
+#[tauri::command]
+fn get_ask_settings(state: State<'_, AppState>) -> Result<AskSettingsDto, String> {
+    Ok(AskSettings::load(&state.settings_path).to_dto())
+}
+
+/// Applies a partial update to `settings.json` (three-valued per field —
+/// see [`AskSettingsUpdate`]) and returns the scrubbed result.
+#[tauri::command]
+fn update_ask_settings(
+    update: AskSettingsUpdate,
+    state: State<'_, AppState>,
+) -> Result<AskSettingsDto, String> {
+    let mut current = AskSettings::load(&state.settings_path);
+    current.apply_update(update);
+    current
+        .save(&state.settings_path)
+        .map_err(|e| format!("save settings: {e}"))?;
+    Ok(current.to_dto())
 }
 
 #[tauri::command]
@@ -344,8 +373,19 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
+            // Resolve the OS app-data directory so the `ask` settings
+            // file has a stable home. The playground starts in-memory
+            // (no DB file), but the settings live on disk regardless so
+            // a saved API key survives restarts.
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|e| format!("app_data_dir: {e}"))?;
+            std::fs::create_dir_all(&app_data_dir)?;
+            let settings_path = settings::settings_path(&app_data_dir);
             app.manage(AppState {
                 db: Mutex::new(Database::new("scratch".into())),
+                settings_path,
             });
             Ok(())
         })
@@ -356,6 +396,8 @@ fn main() {
             table_rows,
             execute_sql,
             ask_sql,
+            get_ask_settings,
+            update_ask_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running sqlrite-desktop");

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -1,0 +1,303 @@
+//! In-app settings for the `Ask…` panel.
+//!
+//! Lives at `$APP_DATA/com.sqlrite.desktop/settings.json` — under the
+//! app's data directory, on its own so the key never rides along if the
+//! user copies or syncs a `.sqlrite` file they opened in the playground.
+//!
+//! **Why this exists.** The playground used to read its `ask` config
+//! exclusively from `SQLRITE_LLM_API_KEY` in the environment. That's
+//! hostile for a GUI: launch the app from Finder / the Dock and the env
+//! var isn't inherited, so the **Ask…** button just errors. Persisting
+//! the key in-app fixes that while keeping the env var as a fallback for
+//! existing dev workflows.
+//!
+//! **Security note (documented in README too).** The settings file is
+//! plain JSON on disk. That's the right tradeoff for an example app:
+//! better UX than an env var, no OS-keychain plugin dep. A production
+//! desktop app shipping the same pattern should reach for
+//! `tauri-plugin-keyring` / `keyring-rs` instead.
+//!
+//! The webview never receives the API key. `get_ask_settings` returns
+//! `has_api_key: bool` (so the UI can show "configured" vs "not set")
+//! but the raw key value only crosses the IPC boundary in one
+//! direction: webview → Rust on `update_ask_settings`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// What gets persisted to `settings.json`. Every field is optional so
+/// older settings files still parse after we add knobs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AskSettings {
+    /// Anthropic API key. None = unset. Empty string in a saved file
+    /// is normalised to None on load.
+    #[serde(default)]
+    pub anthropic_api_key: Option<String>,
+    /// Override the engine default model if set.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Override the engine's default max tokens.
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+}
+
+/// What we send to the webview. Notice the api key is replaced by a
+/// boolean — the value itself stays in the Rust side.
+#[derive(Debug, Clone, Serialize)]
+pub struct AskSettingsDto {
+    pub has_api_key: bool,
+    pub model: String,
+    pub max_tokens: u32,
+    /// Whether `SQLRITE_LLM_API_KEY` is set in the parent shell; the
+    /// UI uses this to explain "your settings file is empty but the
+    /// env var is providing the key" without having to dig.
+    pub env_api_key_present: bool,
+}
+
+const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+const DEFAULT_MAX_TOKENS: u32 = 1024;
+const ENV_KEY: &str = "SQLRITE_LLM_API_KEY";
+
+impl AskSettings {
+    pub fn load(path: &Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(s) => {
+                let mut parsed: AskSettings = serde_json::from_str(&s).unwrap_or_default();
+                // Normalise: an empty-string api key on disk is
+                // equivalent to "not set".
+                if parsed.anthropic_api_key.as_deref() == Some("") {
+                    parsed.anthropic_api_key = None;
+                }
+                parsed
+            }
+            Err(_) => Self::default(),
+        }
+    }
+
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let body = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
+        std::fs::write(path, body)
+    }
+
+    pub fn to_dto(&self) -> AskSettingsDto {
+        AskSettingsDto {
+            has_api_key: self
+                .anthropic_api_key
+                .as_ref()
+                .map(|k| !k.is_empty())
+                .unwrap_or(false),
+            model: self
+                .model
+                .clone()
+                .filter(|m| !m.is_empty())
+                .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+            max_tokens: self
+                .max_tokens
+                .filter(|t| *t > 0)
+                .unwrap_or(DEFAULT_MAX_TOKENS),
+            env_api_key_present: std::env::var(ENV_KEY)
+                .map(|v| !v.is_empty())
+                .unwrap_or(false),
+        }
+    }
+}
+
+/// What `update_ask_settings` accepts.
+///
+/// Three-valued semantics per field:
+///   * `Some(non_empty)` → set
+///   * `Some("")` → clear
+///   * `None`     → leave untouched
+#[derive(Debug, Deserialize)]
+pub struct AskSettingsUpdate {
+    #[serde(default)]
+    pub anthropic_api_key: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub max_tokens: Option<u32>,
+}
+
+impl AskSettings {
+    pub fn apply_update(&mut self, update: AskSettingsUpdate) {
+        if let Some(k) = update.anthropic_api_key {
+            self.anthropic_api_key = if k.is_empty() { None } else { Some(k) };
+        }
+        if let Some(m) = update.model {
+            self.model = if m.is_empty() { None } else { Some(m) };
+        }
+        if let Some(t) = update.max_tokens {
+            self.max_tokens = if t == 0 { None } else { Some(t) };
+        }
+    }
+}
+
+/// Returns the canonical settings file path inside the resolved
+/// app-data directory. The directory may not exist yet — callers
+/// using [`AskSettings::save`] handle that.
+pub fn settings_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("settings.json")
+}
+
+// ----- ask config plumbing --------------------------------------------
+
+/// Builds an [`AskConfig`] for one `ask_sql` call. Prefers the saved
+/// settings; falls back to `SQLRITE_LLM_API_KEY` from the environment
+/// when nothing is saved, so existing dev workflows keep working.
+///
+/// The desktop crate always builds the engine with its `ask` feature
+/// on, so this is unconditional (no `cfg(feature = "ask")` gate).
+pub fn build_ask_config(settings: &AskSettings) -> Result<sqlrite::ask::AskConfig, String> {
+    use sqlrite::ask::AskConfig;
+    let api_key = settings
+        .anthropic_api_key
+        .clone()
+        .filter(|k| !k.is_empty())
+        .or_else(|| std::env::var(ENV_KEY).ok().filter(|k| !k.is_empty()));
+    let cfg = AskConfig {
+        api_key,
+        model: settings
+            .model
+            .clone()
+            .filter(|m| !m.is_empty())
+            .unwrap_or_else(|| AskConfig::default().model),
+        max_tokens: settings
+            .max_tokens
+            .filter(|t| *t > 0)
+            .unwrap_or(DEFAULT_MAX_TOKENS),
+        ..AskConfig::default()
+    };
+    if cfg.api_key.is_none() {
+        return Err(format!(
+            "No Anthropic API key configured. Open Settings (gear icon) and \
+             paste a key from console.anthropic.com — or set {ENV_KEY} in \
+             the shell that launched the app."
+        ));
+    }
+    Ok(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_key_normalises_to_none() {
+        // Round-trip an empty-string saved key through load() and
+        // confirm it lands as None — that's the contract callers rely
+        // on so the "configured" indicator stays accurate.
+        let dir = tempdir();
+        let path = dir.join("settings.json");
+        std::fs::write(&path, r#"{"anthropic_api_key": ""}"#).unwrap();
+        let s = AskSettings::load(&path);
+        assert!(s.anthropic_api_key.is_none());
+    }
+
+    #[test]
+    fn update_three_valued_semantics() {
+        let mut s = AskSettings {
+            anthropic_api_key: Some("old".into()),
+            model: Some("custom-model".into()),
+            max_tokens: Some(512),
+        };
+        // None → unchanged
+        s.apply_update(AskSettingsUpdate {
+            anthropic_api_key: None,
+            model: None,
+            max_tokens: None,
+        });
+        assert_eq!(s.anthropic_api_key.as_deref(), Some("old"));
+        assert_eq!(s.model.as_deref(), Some("custom-model"));
+        // Some("") → clear
+        s.apply_update(AskSettingsUpdate {
+            anthropic_api_key: Some(String::new()),
+            model: Some(String::new()),
+            max_tokens: Some(0),
+        });
+        assert!(s.anthropic_api_key.is_none());
+        assert!(s.model.is_none());
+        assert!(s.max_tokens.is_none());
+        // Some(value) → set
+        s.apply_update(AskSettingsUpdate {
+            anthropic_api_key: Some("new".into()),
+            model: Some("haiku".into()),
+            max_tokens: Some(2048),
+        });
+        assert_eq!(s.anthropic_api_key.as_deref(), Some("new"));
+        assert_eq!(s.model.as_deref(), Some("haiku"));
+        assert_eq!(s.max_tokens, Some(2048));
+    }
+
+    #[test]
+    fn dto_hides_api_key_value() {
+        let s = AskSettings {
+            anthropic_api_key: Some("sk-ant-secret".into()),
+            model: None,
+            max_tokens: None,
+        };
+        let dto = s.to_dto();
+        assert!(dto.has_api_key);
+        // The DTO doesn't have a field that would carry the secret —
+        // this assertion is a compile-time guarantee that future
+        // refactors keep that contract.
+        let serialized = serde_json::to_string(&dto).unwrap();
+        assert!(!serialized.contains("sk-ant-secret"));
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir();
+        let path = dir.join("settings.json");
+        let s = AskSettings {
+            anthropic_api_key: Some("sk-ant-xyz".into()),
+            model: Some("opus".into()),
+            max_tokens: Some(2048),
+        };
+        s.save(&path).unwrap();
+        let loaded = AskSettings::load(&path);
+        assert_eq!(loaded.anthropic_api_key.as_deref(), Some("sk-ant-xyz"));
+        assert_eq!(loaded.model.as_deref(), Some("opus"));
+        assert_eq!(loaded.max_tokens, Some(2048));
+    }
+
+    #[test]
+    fn build_ask_config_prefers_settings_over_env() {
+        // SAFETY: this test mutates global process env, which can
+        // race with parallel tests reading the same var. The Rust
+        // test harness runs unit tests in parallel within a crate, so
+        // we use a known-unique value and don't assert the env var's
+        // post-state.
+        use std::env;
+        unsafe {
+            env::set_var(ENV_KEY, "env-value");
+        }
+        let s = AskSettings {
+            anthropic_api_key: Some("settings-value".into()),
+            ..Default::default()
+        };
+        let cfg = build_ask_config(&s).unwrap();
+        assert_eq!(cfg.api_key.as_deref(), Some("settings-value"));
+        unsafe {
+            env::remove_var(ENV_KEY);
+        }
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        // A process-wide atomic counter guarantees a unique directory
+        // per call even when the test harness runs these in parallel —
+        // a timestamp alone can collide on its sub-second fraction and
+        // let two tests stomp on the same settings.json.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let mut p = std::env::temp_dir();
+        let pid = std::process::id();
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        p.push(format!("sqlrite-desktop-test-{pid}-{n}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/desktop/src/App.svelte
+++ b/desktop/src/App.svelte
@@ -2,6 +2,12 @@
   import { onMount, tick } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
   import { open as openFileDialog, save as saveFileDialog } from "@tauri-apps/plugin-dialog";
+  import SettingsPanel from "./lib/SettingsPanel.svelte";
+
+  // ⚙ Settings dialog — paste an Anthropic API key so the Ask… button
+  // works without exporting SQLRITE_LLM_API_KEY in the launching shell
+  // (which Finder / the Dock don't inherit).
+  let settingsVisible = $state<boolean>(false);
 
   type ColumnInfo = {
     name: string;
@@ -374,8 +380,21 @@
       <button onclick={onNewClick}>New…</button>
       <button onclick={onOpenClick}>Open…</button>
       <button onclick={onSaveAsClick}>Save As…</button>
+      <button
+        class="settings-button"
+        onclick={() => (settingsVisible = true)}
+        aria-label="Settings"
+        title="Settings"
+      >⚙</button>
     </div>
   </header>
+
+  {#if settingsVisible}
+    <SettingsPanel
+      onClose={() => (settingsVisible = false)}
+      onSaved={() => {}}
+    />
+  {/if}
 
   <div class="layout">
     <aside class="sidebar">

--- a/desktop/src/app.css
+++ b/desktop/src/app.css
@@ -54,6 +54,15 @@ header {
 .actions {
   display: flex;
   gap: 8px;
+  align-items: center;
+}
+
+/* Gear button sits at the end of the header actions. Square, icon-only,
+ * deliberately quieter than the labelled file buttons next to it. */
+.settings-button {
+  padding: 6px 10px;
+  font-size: 14px;
+  line-height: 1;
 }
 
 .logo {

--- a/desktop/src/lib/SettingsPanel.svelte
+++ b/desktop/src/lib/SettingsPanel.svelte
@@ -1,0 +1,327 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { api, type AskSettings } from "./api";
+
+  type Props = {
+    onClose: () => void;
+    onSaved: () => void;
+  };
+
+  let { onClose, onSaved }: Props = $props();
+
+  let current = $state<AskSettings | null>(null);
+  let apiKey = $state("");
+  let clearKey = $state(false);
+  let model = $state("");
+  let maxTokens = $state<number | "">("");
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+  let info = $state<string | null>(null);
+
+  onMount(async () => {
+    try {
+      current = await api.getAskSettings();
+      model = current.model;
+      maxTokens = current.max_tokens;
+    } catch (e) {
+      error = String(e);
+    }
+  });
+
+  async function save() {
+    busy = true;
+    error = null;
+    info = null;
+    try {
+      const update: Parameters<typeof api.updateAskSettings>[0] = {};
+      if (clearKey) {
+        update.anthropic_api_key = "";
+      } else if (apiKey.trim().length > 0) {
+        update.anthropic_api_key = apiKey;
+      }
+      if (model && current && model !== current.model) {
+        update.model = model;
+      }
+      if (
+        typeof maxTokens === "number" &&
+        current &&
+        maxTokens !== current.max_tokens
+      ) {
+        update.max_tokens = maxTokens;
+      }
+      const next = await api.updateAskSettings(update);
+      current = next;
+      apiKey = "";
+      clearKey = false;
+      info = "Settings saved.";
+      onSaved();
+    } catch (e) {
+      error = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+<div
+  class="overlay"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Settings"
+>
+  <div class="dialog">
+    <div class="dialog-header">
+      <h2>Settings</h2>
+      <button
+        type="button"
+        class="close"
+        onclick={onClose}
+        aria-label="Close settings"
+      >×</button>
+    </div>
+
+    <div class="dialog-body">
+      <div class="section-label">Used by the Ask… button</div>
+
+      <label for="ask-api-key">Anthropic API key</label>
+      <input
+        id="ask-api-key"
+        type="password"
+        autocomplete="off"
+        spellcheck="false"
+        placeholder={current?.has_api_key
+          ? "(saved key on disk — leave blank to keep)"
+          : "sk-ant-…"}
+        bind:value={apiKey}
+        disabled={clearKey}
+      />
+      <div class="checkbox-row">
+        <input type="checkbox" id="clear-key" bind:checked={clearKey} />
+        <label for="clear-key" class="checkbox-label">Clear the saved key</label>
+      </div>
+      {#if current}
+        <div class="status-line">
+          Status: {current.has_api_key
+            ? "key configured in settings"
+            : current.env_api_key_present
+              ? "key picked up from SQLRITE_LLM_API_KEY env var"
+              : "no key configured"}.
+        </div>
+      {/if}
+
+      <label for="ask-model">Model</label>
+      <input id="ask-model" type="text" bind:value={model} />
+      <div class="field-hint">
+        Defaults to <span class="mono">claude-sonnet-4-6</span>. Use any
+        current Anthropic model id.
+      </div>
+
+      <label for="ask-max-tokens">Max tokens</label>
+      <input
+        id="ask-max-tokens"
+        class="narrow"
+        type="number"
+        min="64"
+        max="8192"
+        bind:value={maxTokens}
+      />
+
+      <p class="security-note">
+        Stored as plain JSON in the app's data directory
+        (<span class="mono">com.sqlrite.desktop/settings.json</span>). Better
+        than an env var for desktop UX; a production app should reach for the
+        OS keychain (e.g. tauri-plugin-keyring). The API key never crosses
+        into the webview after this dialog closes — only the Rust backend
+        reads it.
+      </p>
+
+      {#if error}
+        <div class="msg error">{error}</div>
+      {/if}
+      {#if info}
+        <div class="msg info">{info}</div>
+      {/if}
+    </div>
+
+    <div class="dialog-footer">
+      <button type="button" onclick={onClose}>Close</button>
+      <button type="button" class="primary" onclick={save} disabled={busy}>
+        {busy ? "Saving…" : "Save"}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+  }
+
+  .dialog {
+    width: 100%;
+    max-width: 520px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .dialog-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 18px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .dialog-header h2 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .close {
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    font-size: 16px;
+    line-height: 1;
+    color: var(--fg-muted);
+  }
+  .close:hover:not(:disabled) {
+    color: var(--fg);
+    border-color: var(--accent);
+  }
+
+  .dialog-body {
+    padding: 16px 18px;
+  }
+
+  .section-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--fg-muted);
+    margin-bottom: 12px;
+  }
+
+  .dialog-body label {
+    display: block;
+    font-size: 13px;
+    margin: 14px 0 6px;
+  }
+  .dialog-body label:first-of-type {
+    margin-top: 0;
+  }
+
+  .dialog-body input[type="text"],
+  .dialog-body input[type="password"],
+  .dialog-body input[type="number"] {
+    width: 100%;
+    background: var(--panel-2);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 7px 10px;
+    font-family: var(--mono);
+    font-size: 12px;
+    outline: none;
+  }
+  .dialog-body input:focus {
+    border-color: var(--accent);
+  }
+  .dialog-body input:disabled {
+    opacity: 0.5;
+  }
+  .dialog-body input.narrow {
+    width: 130px;
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+  }
+  .checkbox-row input {
+    accent-color: var(--accent);
+  }
+  .checkbox-label {
+    display: inline;
+    margin: 0;
+    font-size: 12px;
+    color: var(--fg-muted);
+    cursor: pointer;
+  }
+
+  .status-line {
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--fg-muted);
+  }
+
+  .field-hint {
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--fg-muted);
+  }
+
+  .security-note {
+    margin: 18px 0 0;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--fg-muted);
+  }
+
+  .mono {
+    font-family: var(--mono);
+  }
+
+  .msg {
+    margin-top: 12px;
+    font-family: var(--mono);
+    font-size: 12px;
+    white-space: pre-wrap;
+  }
+  .msg.error {
+    color: var(--error);
+  }
+  .msg.info {
+    color: var(--accent);
+  }
+
+  .dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border);
+  }
+
+  .primary {
+    background: var(--accent);
+    color: var(--bg);
+    border-color: var(--accent);
+    font-weight: 600;
+  }
+  .primary:hover:not(:disabled) {
+    border-color: var(--accent);
+  }
+</style>

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -1,0 +1,45 @@
+// Typed thin wrappers around the `ask` settings command surface exposed
+// by src-tauri/src/main.rs. The rest of the playground calls `invoke`
+// inline from App.svelte; the settings surface earns its own module
+// because the three-valued update shape needs a little massaging before
+// it crosses the IPC boundary.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export type AskSettings = {
+  has_api_key: boolean;
+  model: string;
+  max_tokens: number;
+  env_api_key_present: boolean;
+};
+
+// Three-valued: undefined → leave untouched, "" → clear, value → set.
+// Frontend code uses `null` to mean "leave untouched" so we map it to
+// the absent field when sending; Rust's serde sees that as None.
+export type AskSettingsUpdate = {
+  anthropic_api_key?: string | null;
+  model?: string | null;
+  max_tokens?: number | null;
+};
+
+function normaliseUpdate(u: AskSettingsUpdate): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (u.anthropic_api_key !== null && u.anthropic_api_key !== undefined) {
+    out.anthropic_api_key = u.anthropic_api_key;
+  }
+  if (u.model !== null && u.model !== undefined) {
+    out.model = u.model;
+  }
+  if (u.max_tokens !== null && u.max_tokens !== undefined) {
+    out.max_tokens = u.max_tokens;
+  }
+  return out;
+}
+
+export const api = {
+  getAskSettings: () => invoke<AskSettings>("get_ask_settings"),
+  updateAskSettings: (update: AskSettingsUpdate) =>
+    invoke<AskSettings>("update_ask_settings", {
+      update: normaliseUpdate(update),
+    }),
+};


### PR DESCRIPTION
## What & why

The SQL playground (`sqlrite-desktop`) read its `ask` config exclusively from `SQLRITE_LLM_API_KEY` in the environment. Launched from Finder / the Dock — which don't inherit a shell's env — the **Ask…** button just errored. This ports the in-app settings pattern we shipped for the journal example app ([SQLR-41 / #145](https://github.com/joaoh82/rust_sqlite/pull/145)) into the playground, so a user can paste a key in a ⚙ dialog and it persists across restarts. Env var still works as a fallback for existing dev workflows.

## Changes

**Rust (`desktop/src-tauri/`)**
- `src/settings.rs` (new) — `AskSettings` persisted as JSON to `$APP_DATA/com.sqlrite.desktop/settings.json`; scrubbed `AskSettingsDto` (`has_api_key: bool` — the raw key never crosses to the webview); three-valued `AskSettingsUpdate`; `build_ask_config()` (prefers saved key, falls back to `SQLRITE_LLM_API_KEY`); `settings_path()`. 5 unit tests.
- `src/main.rs` — `AppState` gains `settings_path` (resolved from `app_data_dir()` in `setup`); `ask_sql` builds config from saved settings instead of `AskConfig::from_env()`; new `get_ask_settings` / `update_ask_settings` commands registered.

**Frontend (`desktop/src/`)**
- `lib/SettingsPanel.svelte` (new) — gear-modal, rewritten in the playground's plain-CSS idiom (the playground uses global `app.css` vars, not Tailwind like the journal). Password field, model, max-tokens, "Clear saved key", status line, Esc-to-close, security note.
- `lib/api.ts` (new) — `getAskSettings` / `updateAskSettings` wrappers with null→absent normalisation.
- `App.svelte` — ⚙ header button mounts the panel. `app.css` — `.settings-button` rule.

**`desktop/README.md`** (new) — "Configuring `ask`" section + security note (no README existed).

## Deviations from the journal port
- `build_ask_config` is **unconditional** — the desktop crate has no `ask` feature gate and always builds the engine with `ask` on (matching the existing unconditional `ask_sql`). So all 5 tests always run.
- `tempdir()` in tests uses a process-wide `AtomicU64` counter instead of `subsec_nanos()` — the journal's version has a latent parallel-run collision that surfaced here (fixed; see follow-up).

## Test plan — all green locally
- `npm install` + `npm run build` (vite) + `npm run check` (svelte-check: 0 errors/warnings)
- `cargo test -p sqlrite-desktop` → **5/5 pass**, stable across 3 runs
- `cargo build -p sqlrite-desktop --all-targets`, `cargo fmt --check`, `cargo clippy` → new code has 0 warnings (remaining clippy hits are pre-existing)

Not verified: live end-to-end LLM call (needs a real key + network) and the literal Finder-launch scenario (headless run). Both are covered indirectly by unit tests + the binary compiling against the embedded `dist/`.

## Follow-up
The journal app's `examples/desktop-journal/src-tauri/src/settings.rs` has the identical flaky `tempdir()` — worth a small ticket to port this fix back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)