### PR TITLE
ci(release): exclude sqlrite-journal from release-pr lock refresh

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -86,13 +86,15 @@ jobs:
 
       - name: Refresh Cargo.lock
         # `cargo build` updates Cargo.lock with the new workspace
-        # member versions. `--exclude sqlrite-desktop` because the
-        # desktop crate needs the Svelte frontend compiled first
-        # (Tauri's build.rs looks for `desktop/dist/`) — we're not
-        # building a release artifact here, just refreshing the lock.
-        # `--quiet` keeps the log tidy; a real compile failure still
-        # surfaces.
-        run: cargo build --workspace --exclude sqlrite-desktop --quiet
+        # member versions. We exclude the two Tauri crates
+        # (`sqlrite-desktop`, `sqlrite-journal`): both need their Svelte
+        # frontend compiled first (Tauri's build.rs looks for a `dist/`)
+        # and pull in the GTK/glib system stack that this runner doesn't
+        # install — we're not building a release artifact here, just
+        # refreshing the lock. Keep this exclude list in sync with the
+        # cargo steps in ci.yml. `--quiet` keeps the log tidy; a real
+        # compile failure still surfaces.
+        run: cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-journal --quiet
 
       - name: Configure git identity
         # Use the github-actions[bot] identity so the commit shows


### PR DESCRIPTION
## Problem

Dispatching the **Release PR** workflow (`release-pr.yml`) for `0.10.2` failed in the **Refresh Cargo.lock** step ([run 26697159818](https://github.com/joaoh82/rust_sqlite/actions/runs/26697159818)):

```
The system library `glib-2.0` required by crate `glib-sys` was not found.
error: failed to run custom build command for `glib-sys v0.18.1`
```

## Root cause (not the SQLR-70 change)

[#145](https://github.com/joaoh82/rust_sqlite/pull/145) added `examples/desktop-journal/src-tauri` (package `sqlrite-journal`, a second Tauri/GTK crate) as a workspace member. It correctly updated **ci.yml**'s build/test/clippy/doc steps to `--exclude sqlrite-journal` — but the **release-pr.yml** lock-refresh step was missed. So:

```
cargo build --workspace --exclude sqlrite-desktop --quiet
```

now tries to compile `sqlrite-journal` → `glib-sys`, which fails on the runner (no GTK/glib system libs installed). CI stayed green because it excludes the journal everywhere; this only surfaced on the first release-PR dispatch since #145 merged.

## Fix

Mirror ci.yml — also `--exclude sqlrite-journal` in the lock-refresh step. That step only needs to resolve versions into `Cargo.lock`, not build the desktop/journal apps.

```diff
- run: cargo build --workspace --exclude sqlrite-desktop --quiet
+ run: cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-journal --quiet
```

`release.yml` was checked and has no equivalent bare `cargo build --workspace` step (its `publish-desktop` job installs the Tauri Linux deps and builds via `tauri-action`), so no change is needed there.

## After merge

Re-dispatch `release-pr.yml` for `0.10.2` (the original SQLR-70 release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)