### PR TITLE
SQLR-43 — Go edge/IoT event collector (concurrent-writes showcase)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,43 @@ jobs:
         run: go test -v ./...
 
   # ---------------------------------------------------------------------------
+  # Go edge/IoT collector example (SQLR-43). Builds + tests the example
+  # app against the in-repo libsqlrite_c, so an engine/SDK API change
+  # that breaks the example is caught here. Same {ubuntu, macos} matrix
+  # and cgo wiring as the go-sdk job.
+  go-collector:
+    name: go-collector (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache-dependency-path: examples/go-collector/go.mod
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: go-collector-${{ matrix.os }}
+
+      - name: Build libsqlrite_c
+        # The Go driver's `#cgo LDFLAGS` references target/release.
+        run: cargo build --release -p sqlrite-ffi
+
+      - name: go vet ./...
+        working-directory: examples/go-collector
+        run: go vet ./...
+
+      - name: go test ./...
+        working-directory: examples/go-collector
+        run: go test -v ./...
+
+  # ---------------------------------------------------------------------------
   # WASM: only the build + size check (no tests — the WASM module's
   # behavior is covered by the other SDKs' test suites; WASM just
   # re-targets the same engine). One cell because WASM is a

--- a/docs/concurrent-writes.md
+++ b/docs/concurrent-writes.md
@@ -332,6 +332,7 @@ Decoders accept v1..=v3. A v2 reader on a v3 WAL emits a clean "unsupported WAL 
 - [`docs/design-decisions.md`](design-decisions.md) §12a–§12h — the design notes accumulated across Phase 11 sub-phases.
 - [`docs/roadmap.md`](roadmap.md#phase-11--concurrent-writes-via-mvcc--begin-concurrent-sqlr-22-in-flight--see-concurrent-writes-planmd) — phase-by-phase shipped vs deferred status.
 - [`examples/rust/concurrent_writers.rs`](../examples/rust/concurrent_writers.rs) — runnable retry-loop example.
+- [`examples/go-collector/`](../examples/go-collector/) — a Go edge/IoT collector that drives `BEGIN CONCURRENT` from two writers (HTTP path + background uploader) against one file, with **measured** throughput/latency numbers that honestly show the v0 cost of the limitations above (per-tx clone + per-commit rebuild). The README is a good worked example of designing an app around the v0 sharp edges (4 KiB commit cap, no param binding, app-assigned ids under MVCC).
 
 External:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Beyond the per-SDK quick-start tours above, the [SQLR-38 umbrella](../docs/roadm
 | Chat with your notes (MCP)       | Node.js | Markdown → SQLRite hybrid retrieval, served to Claude Desktop via `sqlrite-mcp --read-only` | [`nodejs-notes/`](nodejs-notes/) |
 | Local-first journaling           | Tauri 2 + Svelte 5 | Markdown daily notes in one `.sqlrite` file, BM25 full-text search, "ask my journal" natural-language SQL | [`desktop-journal/`](desktop-journal/) |
 | Browser SQL playground           | WASM | The full engine in WebAssembly — SQL editor, sample datasets, HNSW vector search, all in a browser tab. Live at [sqlritedb.com/playground](https://sqlritedb.com/playground) | [`wasm-playground/`](wasm-playground/) |
+| Edge / IoT event collector       | Go | HTTP collector + background uploader writing one `.sqlrite` buffer concurrently via `BEGIN CONCURRENT`; durable-buffer-for-unreliable-networks shape, with measured throughput | [`go-collector/`](go-collector/) |
 
 ## Running the Rust quickstart
 

--- a/examples/go-collector/.dockerignore
+++ b/examples/go-collector/.dockerignore
@@ -1,0 +1,10 @@
+# The Docker build context is the repo root (see Dockerfile header).
+# Keep the context lean: the Rust stage rebuilds target/ anyway, and
+# node_modules / git history bloat the upload.
+**/target
+**/node_modules
+.git
+**/*.sqlrite
+**/*.sqlrite-wal
+web/.next
+desktop/src-tauri/target

--- a/examples/go-collector/Dockerfile
+++ b/examples/go-collector/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-stage build for the SQLRite Go edge/IoT collector (SQLR-43).
+#
+# Build context MUST be the repository root, because the Go module
+# links the engine's C library (built from `sqlrite-ffi`) and depends
+# on `sdk/go` via a replace directive:
+#
+#   docker build -f examples/go-collector/Dockerfile -t sqlrite-collector .
+#
+# cgo + cross-compilation note: this image is built for the host's
+# architecture. cgo binaries can't be cross-compiled with the plain Go
+# toolchain, so produce per-arch images with `docker buildx --platform`
+# (the Rust and Go stages both honor the target platform). See the
+# README's "Build & distribution matrix" section.
+
+# ---- Stage 1: build libsqlrite_c.so from the engine source ----
+FROM rust:1-bookworm AS rust
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p sqlrite-ffi
+
+# ---- Stage 2: build the Go binaries against that library ----
+FROM golang:1.22-bookworm AS go
+ENV CGO_ENABLED=1
+WORKDIR /src
+# Bring the whole tree over (we need sdk/go, sqlrite-ffi/include, and
+# the freshly-built target/release/libsqlrite_c.so from the rust stage).
+COPY --from=rust /src /src
+WORKDIR /src/examples/go-collector
+RUN go build -trimpath -o /out/collector ./cmd/collector \
+ && go build -trimpath -o /out/loadgen ./cmd/loadgen
+
+# ---- Stage 3: slim runtime ----
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --create-home --uid 10001 collector
+# Install the shared library where the dynamic linker will find it.
+# The Go binary was linked with an rpath pointing at the build tree;
+# that path is absent here, so cgo falls through to the ldconfig cache.
+COPY --from=rust /src/target/release/libsqlrite_c.so /usr/local/lib/
+RUN ldconfig
+COPY --from=go /out/collector /usr/local/bin/collector
+COPY --from=go /out/loadgen /usr/local/bin/loadgen
+USER collector
+WORKDIR /data
+VOLUME ["/data"]
+EXPOSE 8080
+ENTRYPOINT ["collector"]
+CMD ["-db", "/data/events.sqlrite", "-addr", ":8080"]

--- a/examples/go-collector/Makefile
+++ b/examples/go-collector/Makefile
@@ -1,0 +1,46 @@
+# Convenience targets for the SQLRite Go edge/IoT collector.
+#
+# Everything depends on the engine's C library. `make lib` builds it
+# from the repo root; the other targets assume it exists.
+
+REPO_ROOT := ../..
+
+.PHONY: lib build test vet run loadtest bench docker clean
+
+## lib: build the SQLRite cdylib (libsqlrite_c) the cgo driver links.
+lib:
+	cd $(REPO_ROOT) && cargo build --release -p sqlrite-ffi
+
+## build: compile the collector + loadgen binaries.
+build: lib
+	go build -o bin/collector ./cmd/collector
+	go build -o bin/loadgen   ./cmd/loadgen
+
+## test: run the Go test suite (needs lib).
+test: lib
+	go test ./... -count=1
+
+## vet: type-check all packages and tests.
+vet: lib
+	go vet ./...
+
+## run: start the collector on :8080 with a local DB file.
+run: build
+	./bin/collector -db events.sqlrite -addr :8080
+
+## loadtest: fire concurrent producers at a running collector.
+loadtest: build
+	./bin/loadgen -target http://localhost:8080 -workers 64 -duration 30s
+
+## bench: in-process throughput matrix (concurrent vs serialized, ±index).
+bench: build
+	./bin/loadgen -bench -workers 32 -duration 30s
+
+## docker: build the container image (context = repo root).
+docker:
+	cd $(REPO_ROOT) && docker build -f examples/go-collector/Dockerfile -t sqlrite-collector .
+
+## clean: remove build artifacts and local DB files.
+clean:
+	rm -rf bin
+	rm -f events.sqlrite events.sqlrite-wal

--- a/examples/go-collector/README.md
+++ b/examples/go-collector/README.md
@@ -1,0 +1,405 @@
+# Edge / IoT event collector — Go + SQLRite
+
+A small Go service that simulates an **edge / IoT event collector**: it
+accepts telemetry over HTTP from many concurrent producers, writes each
+event into a local file-backed [SQLRite](../../README.md) database, and
+runs a background goroutine that drains the buffer to a remote sink. The
+`.sqlrite` file is the **durable buffer between an unreliable network and
+the upstream system** — it survives reboots, can be queried with SQL
+on-device for diagnostics, and can be handed to `sqlrite-mcp` so an
+operator can ask questions in natural language.
+
+This is the Go entry in the [SQLR-38 example-apps umbrella](../README.md#end-to-end-example-apps).
+It exercises the **Go SDK** (cgo via [`sqlrite-ffi`](../../sqlrite-ffi))
+and SQLRite's **Phase 11 concurrent writes** (`BEGIN CONCURRENT` / MVCC,
+[SQLR-22](../../docs/concurrent-writes.md)).
+
+> **What this example proves — read this first.** Concurrent writes here
+> is a **capability and correctness** feature, *not* a throughput win.
+> An HTTP handler and a background uploader each hold their own
+> independent transaction against one database — something a
+> single-writer engine cannot express — and the engine detects
+> row-level conflicts and tells the caller to retry. We measured the
+> throughput honestly and, **on SQLRite v0, `BEGIN CONCURRENT` is
+> slightly *slower* than a single mutex** for this workload (see
+> [Measured throughput](#measured-throughput) for the numbers and
+> [why](#why-concurrent-isnt-faster-yet)). We ship the numbers as we
+> found them rather than an aspirational headline.
+
+---
+
+## Architecture
+
+```
+HTTP producers ──▶ Go service ──▶ events.sqlrite  (durable buffer)
+  (many, concurrent)   │                  │
+                       │                  ├──▶ uploader goroutine ──▶ sink (log / webhook)
+                       │                  │        (its own BEGIN CONCURRENT txn)
+                       │                  │
+                       └── POST /events ──┘
+                            BEGIN CONCURRENT txn per write
+
+   GET /healthz · GET /stats          sqlrite-mcp --read-only (against a snapshot)
+                                              └─▶ operator: "any errors in the last hour?"
+```
+
+Two writers run against one database at the same time:
+
+- The **HTTP write path** (`POST /events`) inserts each event in its own
+  `BEGIN CONCURRENT` transaction, pulled from the `database/sql` pool.
+- The **uploader goroutine** scans the backlog, ships a batch, and writes
+  its checkpoint (mark events uploaded + an `upload_runs` audit row + a
+  `devices` upsert) in its own `BEGIN CONCURRENT` transaction(s).
+
+They share the same backing engine through the Go driver's process-level
+**sibling-handle registry** (Phase 11.11c) — every `sql.Open` /
+pool-connection for the same file path mints a sibling off one shared
+`Arc<Mutex<Database>>`, so each can hold its own concurrent transaction.
+
+---
+
+## Quick start
+
+### Prerequisite — build the engine's C library once
+
+The Go driver links `libsqlrite_c` (the [`sqlrite-ffi`](../../sqlrite-ffi)
+cdylib) over cgo. From the repo root:
+
+```bash
+cargo build --release -p sqlrite-ffi
+```
+
+This example points cgo at `target/release/libsqlrite_c.{so,dylib}` via
+the `sdk/go` driver's `#cgo` directives — no `LD_LIBRARY_PATH` dance.
+
+### Run the collector
+
+```bash
+cd examples/go-collector
+go run ./cmd/collector -db events.sqlrite -addr :8080
+# or: make run
+```
+
+### Send events
+
+```bash
+# Single event (server stamps ts if you omit it):
+curl -s -X POST localhost:8080/events \
+  -H 'content-type: application/json' \
+  -d '{"device_id":"sensor-001","kind":"telemetry","payload":{"temp_c":21.4}}'
+# → {"accepted":1,"ids":[1]}
+
+# A batch (JSON array):
+curl -s -X POST localhost:8080/events \
+  -H 'content-type: application/json' \
+  -d '[{"device_id":"sensor-001","kind":"telemetry"},{"device_id":"sensor-002","kind":"error","payload":{"code":"E07"}}]'
+
+# Ops:
+curl -s localhost:8080/healthz   # 200 healthy / 503 when uploader is failing or buffer full
+curl -s localhost:8080/stats     # counters + uploader health
+```
+
+### Drive concurrent load (and prove no drops)
+
+```bash
+# Fire 64 concurrent producers for 30s and assert every write landed:
+go run ./cmd/loadgen -target http://localhost:8080 -workers 64 -duration 30s
+# or: make loadtest
+```
+
+The load generator reports achieved req/s and **fails the run if any
+write was dropped** (a non-200, non-503 response). 503s are counted
+separately — they're backpressure, not data loss; a well-behaved producer
+retries them.
+
+---
+
+## HTTP API
+
+| Method · Path | Body | Response |
+|---|---|---|
+| `POST /events` | one event object, or a JSON array of them | `200 {"accepted":N,"ids":[…]}`; `400` on bad JSON / missing `device_id`/`kind` / malformed `payload`; `503` when the buffer is full |
+| `GET /healthz` | — | `200`/`503` + `{ok, uploader, backlog, backlog_ok}` |
+| `GET /stats`   | — | `200` + `{store, uploader}` counters |
+
+Event shape:
+
+```jsonc
+{
+  "device_id": "sensor-001",   // required
+  "kind": "telemetry",         // required (e.g. telemetry | error | heartbeat)
+  "payload": { "temp_c": 21 }, // optional; validated as JSON, stored in a JSON column
+  "ts": 1748722000000          // optional unix-millis; server-stamps receipt time if 0
+}
+```
+
+`id` is assigned by the server and returned. Auth / TLS are out of scope
+(v1 assumes a sidecar / reverse proxy).
+
+---
+
+## Schema
+
+```sql
+events(id PK, device_id, kind, payload_json JSON, ts, uploaded_at)
+       -- uploaded_at IS NULL  ⇒  the upload backlog
+devices(id PK, device_key, label, last_seen_at)
+upload_runs(id PK, started_at, finished_at, event_count, status, error)
+       -- the uploader's per-cycle audit trail (success AND failure rows)
+```
+
+With `-indexed`, a single-column B-tree index on `events(device_id)` is
+created at first launch (it speeds per-device diagnostic queries; the
+write-side cost is measured below).
+
+---
+
+## Measured throughput
+
+All numbers below are **measured on this machine, not estimated** —
+reproduce them with the commands shown. They are the honest result, not
+the result we hoped for.
+
+> **Environment.** Apple M1 Pro (10 cores), macOS 14 (Darwin 23.5),
+> Go 1.24, `sqlrite-engine` 0.10.2, release `libsqlrite_c`. Absolute
+> numbers will differ on your hardware; the **ratios between modes** are
+> the point.
+
+### 1. Insert throughput — `make bench`
+
+A fresh DB per cell; N goroutines insert events (one durable commit each)
+as fast as they can.
+
+```bash
+go run ./cmd/loadgen -bench -workers 16 -duration 8s -devices 50
+```
+
+| write mode | indexed | events/sec | vs serialized |
+|---|---|---:|---:|
+| serialized (single mutex) | no  | **156** | 1.00× |
+| concurrent (`BEGIN CONCURRENT`) | no  | 142 | 0.91× |
+| concurrent (`BEGIN CONCURRENT`) | yes | 136 | 0.87× |
+
+`BEGIN CONCURRENT` is ~9% **slower** than a single mutex here, and the
+secondary index costs another ~4%. Throughput is ~150 durable
+single-event commits/sec regardless of mode (see [why](#why-concurrent-isnt-faster-yet)).
+
+### 2. Insert tail latency under a concurrent checkpoint writer — `-contention`
+
+A background goroutine runs a wide multi-statement transaction in a loop
+(the uploader's shape) while producers insert events and time each
+insert. This is where you'd *expect* concurrent writes to win by avoiding
+head-of-line blocking.
+
+```bash
+go run ./cmd/loadgen -contention -workers 16 -duration 8s
+```
+
+| write mode | p50 | p90 | p99 | max |
+|---|---:|---:|---:|---:|
+| serialized | **146 ms** | **155 ms** | **164 ms** | **181 ms** |
+| concurrent | 184 ms | 265 ms | 333 ms | 431 ms |
+
+Concurrent mode's tail is ~2× worse, not better — the per-transaction
+snapshot clone (below) dominates any head-of-line-blocking it removes.
+
+### 3. Disjoint-row batched writers (MVCC's textbook best case) — `-disjoint`
+
+Each writer owns its own row range and updates it in 20-statement
+transactions, so there are **zero conflicts**. Both modes amortize the
+per-commit cost over the batch; serialized uses an explicit `BEGIN…COMMIT`
+(a fair single-writer baseline, not autocommit-per-row).
+
+```bash
+go run ./cmd/loadgen -disjoint -workers 8 -duration 8s
+```
+
+| write mode | updates/sec | conflicts |
+|---|---:|---:|
+| serialized | **2,655** | 0 |
+| concurrent | 2,018 | 0 |
+
+Even in the case MVCC is built for, v0 `BEGIN CONCURRENT` is ~0.76×.
+
+### Correctness, which is the actual win
+
+```bash
+go run ./cmd/loadgen -target http://localhost:8080 -workers 32 -duration 6s
+# accepted (200): 723  (≈120 events/sec)   backpressure (503): 0   failed: 0
+# OK: no writes dropped.
+# server /stats → events_written: 723, events_uploaded: 723, backlog: 0, commit_conflicts: 0
+```
+
+32 producers and a background uploader, all writing one database
+concurrently, **zero dropped events** — and when two transactions *do*
+collide on a row, the loser gets `ErrBusy` and the store's retry loop
+re-runs it. That correctness-under-concurrency is the thing a
+single-writer engine fundamentally cannot give you.
+
+### Why concurrent isn't faster yet
+
+All three SQLRite v0 limitations are documented in
+[`docs/concurrent-writes.md` → Limitations](../../docs/concurrent-writes.md#limitations):
+
+1. **Every operation still serializes through one per-database
+   `Arc<Mutex<Database>>`.** Phase 11 made multi-writer a *capability*,
+   not a throughput win — "every operation still serializes through the
+   per-database mutex."
+2. **`BEGIN CONCURRENT` deep-clones the table set twice per
+   transaction** (working copy + begin snapshot). For single-statement
+   writes that's pure overhead with no contention to relieve; for the
+   contention test it's what fattens the tail.
+3. **Every commit triggers an O(N) bottom-up B-tree rebuild via the
+   legacy save path.** This caps durable commit throughput at ~150/sec
+   here regardless of mode, and won't amortize to checkpoint time until
+   the parked checkpoint-drain follow-up lands.
+
+The follow-ups that would flip these numbers — column-level
+copy-on-write table cloning, and folding MVCC commits into the pager at
+checkpoint time instead of rebuilding on every commit — are explicitly
+carved out in the plan doc. Until they land, **prefer the default
+serialized path for raw throughput; reach for `BEGIN CONCURRENT` when you
+need independent in-process writers with conflict detection.**
+
+The collector defaults to **concurrent** mode because demonstrating that
+capability is the point of this example. Switch with `-mode serialized`.
+
+---
+
+## How it works (engine constraints worth knowing)
+
+The Go SDK binds only to SQLRite's public surface, so this example also
+documents the v0 sharp edges it had to design around — each verified
+against the engine, each with a code comment pointing here:
+
+| Constraint | Where it bites | How the collector handles it |
+|---|---|---|
+| **No parameter binding** in the Go driver | every write | All values are inlined through `internal/store/sqlquote.go`, the single chokepoint that escapes text (doubled `''`) and validates JSON. |
+| **`CREATE TABLE IF NOT EXISTS` not honored**; `sqlrite_master` not queryable | reopening a populated DB | `migrate()` probes for the `events` table with a `SELECT` and only runs DDL on a fresh database. |
+| **`CREATE INDEX` rejected under `journal_mode = mvcc`** | the optional index | All DDL runs in WAL mode *before* the MVCC switch; the index choice is fixed at DB-creation time. |
+| **`BEGIN CONCURRENT` commit batch capped at 4 KiB** (the encoded row image, not just the SQL) | a large checkpoint, and any single oversized row | Two guards: event payloads are bounded at ingest (`maxPayloadBytes`, returns `400`) so any one row commits; and `CommitUpload` marks rows in adaptively-sized chunks that halve on a cap error down to one-per-commit (`writeAdaptive`). Relaxes the checkpoint from atomic to incremental → at-least-once delivery. |
+| **`AUTOINCREMENT` rowids collide under MVCC** | concurrent inserts | Event ids are assigned application-side from an atomic counter seeded off `MAX(id)` at open. |
+| **`IS NULL` never uses an index** | the backlog scan | `WHERE uploaded_at IS NULL` is a full scan by design — fine for a bounded edge buffer; the optional index is on `device_id` instead. |
+
+Delivery semantics: the uploader **ships before it marks**, and marks
+incrementally, so a crash mid-checkpoint can re-ship a batch but never
+loses one — standard **at-least-once** delivery.
+
+---
+
+## Configuration
+
+```
+-db              database file path (default events.sqlrite)
+-addr            HTTP listen address (default :8080)
+-mode            concurrent | serialized (default concurrent)
+-indexed         create a secondary index on events(device_id) (default false)
+-max-conns       database/sql pool ceiling (default 8)
+-max-backlog     reject writes with 503 once backlog reaches this; 0 = unlimited (default 50000)
+-upload-interval uploader drain interval (default 1s)
+-upload-batch    max events per uploader cycle (default 200)
+-sink            log | webhook (default log)
+-webhook-url     sink URL (required when -sink=webhook)
+-flaky-every     wrap the sink to fail every Nth cycle (demo backpressure; 0 = off)
+```
+
+Demonstrate backpressure during a simulated outage:
+
+```bash
+go run ./cmd/collector -flaky-every 3 -max-backlog 500
+# watch /stats: backlog climbs while the sink fails, then drains on recovery;
+# POST /events returns 503 once backlog hits 500.
+```
+
+---
+
+## Docker
+
+The build context **must be the repository root** (the image compiles
+`libsqlrite_c` from source, then the Go binaries against it):
+
+```bash
+# From the repo root:
+docker build -f examples/go-collector/Dockerfile -t sqlrite-collector .
+docker run -p 8080:8080 -v sqlrite-data:/data sqlrite-collector
+
+# Or via compose (also from the repo root):
+docker compose -f examples/go-collector/docker-compose.yml up --build
+```
+
+The DB lives on a volume so the durable buffer survives container
+restarts — the same property a real edge box relies on.
+
+### Build & distribution matrix
+
+cgo binaries **cannot be cross-compiled** with the plain Go toolchain, so
+the supported distribution story is per-arch images, not a fat binary:
+
+| Target | How |
+|---|---|
+| linux/amd64, linux/arm64 | `docker buildx build --platform linux/amd64,linux/arm64 …` — the Rust + Go stages both honor the target platform |
+| macOS (dev) | `make build` against a locally-built `libsqlrite_c` (host arch) |
+| static musl binary | not provided in v1 — `libsqlrite_c` is a cdylib; a fully-static build would need a musl Rust target + `CGO_ENABLED=1` cross toolchain (follow-up) |
+
+For a non-Docker deployment, ship the per-platform `libsqlrite_c` tarball
+from a `sdk/go/v*` GitHub release alongside the collector binary and point
+the dynamic linker at it (see [`sdk/go/README.md`](../../sdk/go/README.md)).
+
+---
+
+## "Ask the collector" (optional MCP sidecar)
+
+[`sqlrite-mcp`](../../docs/mcp.md) exposes a database to Claude Desktop /
+any MCP client read-only, so an operator can ask *"any device offline >
+10 min?"* in natural language.
+
+> **Cross-process caveat.** SQLRite's MVCC is **in-process only** —
+> cross-process access still serializes through an exclusive file lock
+> ([Limitations](../../docs/concurrent-writes.md#limitations)). So
+> `sqlrite-mcp` **cannot** open the live `events.sqlrite` while the
+> collector holds it for writing. Point it at a **snapshot** instead:
+
+```bash
+# Snapshot the buffer (stop the collector, or just copy the file):
+cp events.sqlrite snapshot.sqlrite
+sqlrite-mcp --read-only snapshot.sqlrite      # cargo install sqlrite-mcp
+```
+
+The `docker-compose.yml` ships a `mcp` profile that does exactly this
+against a snapshot copy — see the comments there. Then wire its stdio
+into your MCP client per [`docs/mcp.md`](../../docs/mcp.md).
+
+---
+
+## Layout
+
+```
+cmd/collector/      the service: HTTP front door + uploader wiring
+cmd/loadgen/        load generator + the three measurement experiments
+internal/store/     the durable buffer (schema, writes, both write modes)
+internal/uploader/  background drain goroutine + pluggable Sink
+internal/server/    HTTP handlers + backpressure
+Dockerfile          multi-stage: build libsqlrite_c → build Go → slim runtime
+docker-compose.yml  collector + optional read-only MCP sidecar (profile)
+Makefile            lib / build / test / run / loadtest / bench / docker
+```
+
+## Tests
+
+```bash
+make test     # builds libsqlrite_c, then go test ./...
+```
+
+Covers the quote-escaping chokepoint, reopen-without-data-loss, the
+chunked large-checkpoint path (which would otherwise hit the 4 KiB MVCC
+cap), a deterministic `BEGIN CONCURRENT` write-write conflict + retry, the
+many-writers-no-drops invariant, the uploader's success/failure/recovery
+cycle, and the HTTP layer (validation, batch accept, 503 backpressure,
+healthz/stats). CI builds + tests this example on Linux and macOS against
+the in-repo engine (`go-collector` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)).
+
+## See also
+
+- [`docs/concurrent-writes.md`](../../docs/concurrent-writes.md) — the MVCC / `BEGIN CONCURRENT` reference, including the limitations this example documents
+- [`sdk/go/README.md`](../../sdk/go/README.md) — the Go driver, sibling handles, and the retryable-error sentinels
+- [`examples/go/`](../go/) — the bare-bones Go SDK quick-start tour (this is the full app)

--- a/examples/go-collector/cmd/collector/main.go
+++ b/examples/go-collector/cmd/collector/main.go
@@ -1,0 +1,135 @@
+// Command collector is the SQLRite edge/IoT event collector (SQLR-43).
+//
+// It accepts telemetry over HTTP from many concurrent producers, writes
+// each event into a local file-backed SQLRite database using Phase 11
+// BEGIN CONCURRENT transactions, and drains the buffer to a pluggable
+// sink from a background goroutine — all writing the same database
+// concurrently.
+//
+//	go run ./cmd/collector -db events.sqlrite -addr :8080
+//
+// Prerequisite: build the engine's C library once from the repo root so
+// cgo can link it:
+//
+//	cargo build --release -p sqlrite-ffi
+//
+// See the README for the full run + demo + throughput story.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/server"
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/uploader"
+)
+
+var (
+	errWebhookURL  = errors.New("-webhook-url is required when -sink=webhook")
+	errUnknownSink = errors.New("unknown -sink (want: log | webhook)")
+)
+
+func main() {
+	var (
+		dbPath     = flag.String("db", "events.sqlrite", "database file path")
+		addr       = flag.String("addr", ":8080", "HTTP listen address")
+		mode       = flag.String("mode", "concurrent", "write mode: concurrent | serialized")
+		indexed    = flag.Bool("indexed", false, "create a secondary index on events(device_id)")
+		maxConns   = flag.Int("max-conns", 8, "database/sql connection pool ceiling")
+		maxBacklog = flag.Int64("max-backlog", 50000, "reject writes (503) once backlog reaches this; 0 = unlimited")
+		interval   = flag.Duration("upload-interval", time.Second, "uploader drain interval")
+		batch      = flag.Int("upload-batch", 200, "max events per uploader cycle")
+		sinkKind   = flag.String("sink", "log", "upload sink: log | webhook")
+		webhookURL = flag.String("webhook-url", "", "webhook sink URL (required when -sink=webhook)")
+		flakyEvery = flag.Int64("flaky-every", 0, "wrap the sink to fail every Nth cycle (demo backpressure); 0 = off")
+	)
+	flag.Parse()
+
+	logger := log.New(os.Stdout, "collector ", log.LstdFlags|log.Lmsgprefix)
+
+	wm := store.Concurrent
+	if *mode == "serialized" {
+		wm = store.Serialized
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	st, err := store.Open(ctx, store.Options{
+		Path:         *dbPath,
+		Mode:         wm,
+		Indexed:      *indexed,
+		MaxOpenConns: *maxConns,
+	})
+	if err != nil {
+		logger.Fatalf("open store: %v", err)
+	}
+	defer st.Close()
+	logger.Printf("store ready: path=%s mode=%s indexed=%v", *dbPath, wm, *indexed)
+
+	sink, err := buildSink(*sinkKind, *webhookURL, *flakyEvery, logger)
+	if err != nil {
+		logger.Fatalf("configure sink: %v", err)
+	}
+
+	up := uploader.New(st, sink, uploader.Config{
+		Interval:  *interval,
+		BatchSize: *batch,
+		Logger:    logger,
+	})
+	go up.Run(ctx)
+
+	srv := server.New(st, up, server.Config{MaxBacklog: *maxBacklog, Logger: logger})
+	httpServer := &http.Server{
+		Addr:              *addr,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		logger.Printf("listening on %s", *addr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatalf("http server: %v", err)
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Printf("shutting down…")
+
+	// Stop accepting new requests, then let the uploader's final drain
+	// (triggered by the cancelled ctx) run.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		logger.Printf("http shutdown: %v", err)
+	}
+	// Give the uploader goroutine a moment to finish its final drain.
+	time.Sleep(500 * time.Millisecond)
+}
+
+func buildSink(kind, url string, flakyEvery int64, logger *log.Logger) (uploader.Sink, error) {
+	var base uploader.Sink
+	switch kind {
+	case "log", "":
+		base = uploader.LogSink{Logger: logger}
+	case "webhook":
+		if url == "" {
+			return nil, errWebhookURL
+		}
+		base = uploader.WebhookSink{URL: url, Client: &http.Client{Timeout: 10 * time.Second}}
+	default:
+		return nil, errUnknownSink
+	}
+	if flakyEvery > 0 {
+		return &uploader.FlakySink{Inner: base, FailEvery: flakyEvery}, nil
+	}
+	return base, nil
+}

--- a/examples/go-collector/cmd/loadgen/main.go
+++ b/examples/go-collector/cmd/loadgen/main.go
@@ -1,0 +1,508 @@
+// Command loadgen drives the collector two ways:
+//
+//   - HTTP correctness load (-target): fire N concurrent producers at a
+//     running collector's POST /events for a duration, assert every
+//     write was accepted (no drops), and report achieved req/s. This is
+//     the "concurrent-writes correctness" demo the README leans on.
+//
+//   - In-process throughput matrix (-bench): open the store directly
+//     and measure sustained events/sec for each {write-mode} × {indexed}
+//     combination. This isolates the database write path from HTTP
+//     overhead and produces the measured numbers in the README. It is
+//     the honest answer to "what did concurrent writes buy us, and what
+//     does a secondary index cost?"
+//
+// Examples:
+//
+//	go run ./cmd/loadgen -target http://localhost:8080 -workers 64 -duration 30s
+//	go run ./cmd/loadgen -bench -workers 32 -duration 10s
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+)
+
+func main() {
+	var (
+		target     = flag.String("target", "", "collector base URL for HTTP load (e.g. http://localhost:8080)")
+		bench      = flag.Bool("bench", false, "run the in-process throughput matrix instead of HTTP load")
+		contention = flag.Bool("contention", false, "measure insert latency under a concurrent checkpoint writer (serialized vs concurrent)")
+		disjoint   = flag.Bool("disjoint", false, "MVCC best case: writers update disjoint row ranges in batched transactions (fair single-writer BEGIN/COMMIT baseline)")
+		workers    = flag.Int("workers", 32, "number of concurrent producers")
+		duration   = flag.Duration("duration", 10*time.Second, "how long to drive load")
+		devices    = flag.Int("devices", 100, "number of distinct simulated devices")
+	)
+	flag.Parse()
+
+	switch {
+	case *bench:
+		runBench(*workers, *duration, *devices)
+	case *contention:
+		runContention(*workers, *duration, *devices)
+	case *disjoint:
+		runDisjoint(*workers, *duration)
+	case *target != "":
+		os.Exit(runHTTP(*target, *workers, *duration, *devices))
+	default:
+		fmt.Fprintln(os.Stderr, "specify -target <url> (HTTP load), -bench (throughput matrix), or -contention (latency under a concurrent writer)")
+		flag.Usage()
+		os.Exit(2)
+	}
+}
+
+// sampleEvent builds a realistic-ish telemetry event for device n.
+func sampleEvent(deviceN, seq int) store.Event {
+	payload, _ := json.Marshal(map[string]any{
+		"temp_c":   20 + (seq % 15),
+		"humidity": 40 + (seq % 50),
+		"seq":      seq,
+		"note":     "it's fine", // exercises the quote-escaping path
+	})
+	kind := "telemetry"
+	if seq%17 == 0 {
+		kind = "error"
+	}
+	return store.Event{
+		DeviceID: fmt.Sprintf("sensor-%03d", deviceN),
+		Kind:     kind,
+		Payload:  payload,
+		TS:       time.Now().UnixMilli(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP correctness load
+
+func runHTTP(target string, workers int, duration time.Duration, devices int) int {
+	url := target + "/events"
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	var ok, failed, busy503 atomic.Int64
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	start := time.Now()
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			seq := 0
+			for ctx.Err() == nil {
+				ev := sampleEvent((worker+seq)%devices, seq)
+				seq++
+				body, _ := json.Marshal(ev)
+				req, _ := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				resp, err := client.Do(req)
+				if err != nil {
+					if ctx.Err() != nil {
+						return // shutdown, not a drop
+					}
+					failed.Add(1)
+					continue
+				}
+				io.Copy(io.Discard, resp.Body)
+				resp.Body.Close()
+				switch {
+				case resp.StatusCode == http.StatusOK:
+					ok.Add(1)
+				case resp.StatusCode == http.StatusServiceUnavailable:
+					busy503.Add(1) // backpressure, not a drop — producer should retry
+				default:
+					failed.Add(1)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	accepted := ok.Load()
+	fmt.Printf("\nHTTP load against %s\n", url)
+	fmt.Printf("  workers:        %d\n", workers)
+	fmt.Printf("  duration:       %s\n", elapsed.Round(time.Millisecond))
+	fmt.Printf("  accepted (200): %d  (%.0f events/sec)\n", accepted, float64(accepted)/elapsed.Seconds())
+	fmt.Printf("  backpressure (503): %d\n", busy503.Load())
+	fmt.Printf("  failed:         %d\n", failed.Load())
+
+	// Cross-check against the server's own counters.
+	if stats := fetchStats(client, target); stats != "" {
+		fmt.Printf("  server /stats:  %s\n", stats)
+	}
+
+	if failed.Load() > 0 {
+		fmt.Println("\nFAIL: some writes were dropped (non-200, non-503).")
+		return 1
+	}
+	fmt.Println("\nOK: no writes dropped.")
+	return 0
+}
+
+func fetchStats(client *http.Client, target string) string {
+	resp, err := client.Get(target + "/stats")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return string(bytes.TrimSpace(b))
+}
+
+// ---------------------------------------------------------------------------
+// In-process throughput matrix
+
+type benchResult struct {
+	mode    store.WriteMode
+	indexed bool
+	events  int64
+	elapsed time.Duration
+	stats   store.Stats
+}
+
+func runBench(workers int, duration time.Duration, devices int) {
+	combos := []struct {
+		mode    store.WriteMode
+		indexed bool
+	}{
+		{store.Serialized, false},
+		{store.Concurrent, false},
+		{store.Concurrent, true},
+	}
+
+	tmp, err := os.MkdirTemp("", "go-collector-bench")
+	if err != nil {
+		log.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	fmt.Printf("\nThroughput matrix (workers=%d, duration=%s, devices=%d)\n", workers, duration, devices)
+	fmt.Println("Each cell: a fresh DB, N goroutines inserting events as fast as they can.")
+	fmt.Println()
+	fmt.Printf("%-22s %-8s %14s %12s\n", "write mode", "indexed", "events/sec", "conflicts")
+	fmt.Println("-------------------------------------------------------------------")
+
+	var results []benchResult
+	for i, c := range combos {
+		dbPath := filepath.Join(tmp, fmt.Sprintf("bench-%d.sqlrite", i))
+		res := benchOne(dbPath, c.mode, c.indexed, workers, duration, devices)
+		results = append(results, res)
+		fmt.Printf("%-22s %-8v %14.0f %12d\n",
+			res.mode.String(), res.indexed,
+			float64(res.events)/res.elapsed.Seconds(),
+			res.stats.Conflicts)
+	}
+
+	// Headline comparison: concurrent vs serialized (both index-less).
+	var ser, con float64
+	for _, r := range results {
+		if r.mode == store.Serialized && !r.indexed {
+			ser = float64(r.events) / r.elapsed.Seconds()
+		}
+		if r.mode == store.Concurrent && !r.indexed {
+			con = float64(r.events) / r.elapsed.Seconds()
+		}
+	}
+	if ser > 0 {
+		fmt.Printf("\nconcurrent / serialized speedup: %.2fx\n", con/ser)
+	}
+}
+
+func benchOne(dbPath string, mode store.WriteMode, indexed bool, workers int, duration time.Duration, devices int) benchResult {
+	ctx := context.Background()
+	st, err := store.Open(ctx, store.Options{
+		Path:         dbPath,
+		Mode:         mode,
+		Indexed:      indexed,
+		MaxOpenConns: workers,
+	})
+	if err != nil {
+		log.Fatalf("open store (%s, indexed=%v): %v", mode, indexed, err)
+	}
+	defer st.Close()
+
+	runCtx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+
+	var count atomic.Int64
+	var wg sync.WaitGroup
+	start := time.Now()
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			seq := 0
+			for runCtx.Err() == nil {
+				ev := sampleEvent((worker+seq)%devices, seq)
+				seq++
+				if _, err := st.InsertEvent(runCtx, ev); err != nil {
+					if runCtx.Err() != nil {
+						return
+					}
+					log.Printf("insert: %v", err)
+					return
+				}
+				count.Add(1)
+			}
+		}(w)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	return benchResult{
+		mode:    mode,
+		indexed: indexed,
+		events:  count.Load(),
+		elapsed: elapsed,
+		stats:   st.Stats(),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Latency under contention — the honest headline measurement.
+//
+// This is where concurrent writes actually pay off for the collector.
+// A "checkpointer" goroutine repeatedly runs a big multi-statement
+// write transaction (the shape the uploader uses: UPDATE a wide row
+// range + an audit INSERT), while inserter goroutines push single
+// events and time each insert.
+//
+//   - Serialized mode holds one lock for the checkpointer's ENTIRE
+//     transaction, so every insert that arrives mid-checkpoint stalls
+//     until it commits → fat tail latency (head-of-line blocking).
+//   - Concurrent mode gives the checkpointer its own BEGIN CONCURRENT
+//     transaction; insert statements interleave with the checkpointer's
+//     statements instead of waiting for the whole transaction → a much
+//     tighter tail.
+//
+// Raw throughput is ~the same either way (see -bench); the difference
+// this measures is insert *tail latency* while a background writer is
+// busy — the property the example is really about.
+func runContention(workers int, duration time.Duration, devices int) {
+	const seed = 1000      // pre-inserted rows the checkpointer churns
+	const checkpoint = 500 // rows touched per checkpoint transaction
+
+	fmt.Printf("\nInsert latency under a concurrent checkpoint writer "+
+		"(workers=%d, duration=%s)\n", workers, duration)
+	fmt.Println("A background writer runs a wide multi-statement transaction in a loop")
+	fmt.Println("while producers insert events. Lower tail latency is better.")
+	fmt.Println()
+	fmt.Printf("%-14s %12s %12s %12s %12s\n", "write mode", "p50", "p90", "p99", "max")
+	fmt.Println("----------------------------------------------------------------------")
+
+	for _, mode := range []store.WriteMode{store.Serialized, store.Concurrent} {
+		lat := contentionOne(mode, workers, duration, devices, seed, checkpoint)
+		fmt.Printf("%-14s %12s %12s %12s %12s\n",
+			mode.String(),
+			pctl(lat, 0.50).Round(time.Microsecond),
+			pctl(lat, 0.90).Round(time.Microsecond),
+			pctl(lat, 0.99).Round(time.Microsecond),
+			pctl(lat, 1.0).Round(time.Microsecond),
+		)
+	}
+}
+
+func contentionOne(mode store.WriteMode, workers int, duration time.Duration, devices, seed, checkpoint int) []time.Duration {
+	ctx := context.Background()
+	tmp, _ := os.MkdirTemp("", "contention")
+	defer os.RemoveAll(tmp)
+
+	st, err := store.Open(ctx, store.Options{
+		Path:         filepath.Join(tmp, "c.sqlrite"),
+		Mode:         mode,
+		MaxOpenConns: workers + 2,
+	})
+	if err != nil {
+		log.Fatalf("open: %v", err)
+	}
+	defer st.Close()
+
+	// Seed rows for the checkpointer to churn.
+	for i := 0; i < seed; i++ {
+		st.InsertEvent(ctx, sampleEvent(i%devices, i))
+	}
+	pending, _ := st.FetchPending(ctx, checkpoint)
+	ids := make([]int64, len(pending))
+	for i, p := range pending {
+		ids[i] = p.ID
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+
+	// Checkpointer: repeated wide multi-statement transactions.
+	var cpWG sync.WaitGroup
+	cpWG.Add(1)
+	go func() {
+		defer cpWG.Done()
+		for runCtx.Err() == nil {
+			run := store.UploadRun{StartedAt: 1, FinishedAt: 2, EventCount: len(ids), Status: "success"}
+			// nil batch → no device upserts; just the wide UPDATE + audit row.
+			_ = st.CommitUpload(runCtx, run, ids, nil)
+		}
+	}()
+
+	// Inserters: time each insert.
+	var mu sync.Mutex
+	var samples []time.Duration
+	var insWG sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		insWG.Add(1)
+		go func(w int) {
+			defer insWG.Done()
+			local := make([]time.Duration, 0, 1024)
+			seq := 0
+			for runCtx.Err() == nil {
+				start := time.Now()
+				if _, err := st.InsertEvent(runCtx, sampleEvent((w+seq)%devices, seq)); err != nil {
+					if runCtx.Err() != nil {
+						break
+					}
+					continue
+				}
+				local = append(local, time.Since(start))
+				seq++
+			}
+			mu.Lock()
+			samples = append(samples, local...)
+			mu.Unlock()
+		}(w)
+	}
+	insWG.Wait()
+	cancel()
+	cpWG.Wait()
+	return samples
+}
+
+// ---------------------------------------------------------------------------
+// Disjoint-row batched writers — the textbook MVCC best case.
+//
+// The docs claim "disjoint-row writers run in parallel." This is the
+// fairest test of that: each writer owns its own contiguous range of
+// rows and updates them in batched transactions, so there are zero
+// conflicts. Both modes amortize the O(N) per-commit save over the
+// whole batch:
+//
+//   - serialized issues an explicit BEGIN … COMMIT under one lock, so
+//     writers fully serialize (the honest single-writer baseline — not
+//     the autocommit-per-row strawman).
+//   - concurrent issues BEGIN CONCURRENT on independent sibling
+//     connections, so the transactions can interleave.
+//
+// If v0 MVCC buys throughput anywhere, it's here. (Spoiler: the global
+// per-database mutex + the per-transaction table clone mean it doesn't,
+// yet — but this measures it honestly rather than asserting it.)
+func runDisjoint(workers int, duration time.Duration) {
+	const rangeSize = 100 // rows each writer owns
+	const batch = 20      // updates per transaction
+
+	fmt.Printf("\nDisjoint-row batched writers (workers=%d, duration=%s, "+
+		"range=%d rows/writer, %d updates/txn)\n", workers, duration, rangeSize, batch)
+	fmt.Println("Each writer updates only its own rows — zero conflicts. Higher is better.")
+	fmt.Println()
+	fmt.Printf("%-14s %14s %12s\n", "write mode", "updates/sec", "conflicts")
+	fmt.Println("--------------------------------------------------")
+
+	for _, mode := range []store.WriteMode{store.Serialized, store.Concurrent} {
+		ups, conflicts, elapsed := disjointOne(mode, workers, duration, rangeSize, batch)
+		fmt.Printf("%-14s %14.0f %12d\n", mode.String(),
+			float64(ups)/elapsed.Seconds(), conflicts)
+	}
+}
+
+func disjointOne(mode store.WriteMode, workers int, duration time.Duration, rangeSize, batch int) (int64, int64, time.Duration) {
+	ctx := context.Background()
+	tmp, _ := os.MkdirTemp("", "disjoint")
+	defer os.RemoveAll(tmp)
+
+	st, err := store.Open(ctx, store.Options{
+		Path:         filepath.Join(tmp, "d.sqlrite"),
+		Mode:         mode,
+		MaxOpenConns: workers + 2,
+	})
+	if err != nil {
+		log.Fatalf("open: %v", err)
+	}
+	defer st.Close()
+
+	// Seed workers*rangeSize rows with known ids 1..M.
+	total := workers * rangeSize
+	for i := 0; i < total; i++ {
+		if _, err := st.InsertEvent(ctx, sampleEvent(i, i)); err != nil {
+			log.Fatalf("seed: %v", err)
+		}
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+
+	var updates atomic.Int64
+	var wg sync.WaitGroup
+	start := time.Now()
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			base := int64(w*rangeSize) + 1 // ids base..base+rangeSize-1
+			off := 0
+			for runCtx.Err() == nil {
+				stmts := make([]string, 0, batch+2)
+				if mode == store.Serialized {
+					stmts = append(stmts, "BEGIN")
+				}
+				for b := 0; b < batch; b++ {
+					id := base + int64((off+b)%rangeSize)
+					stmts = append(stmts, fmt.Sprintf("UPDATE events SET ts = ts + 1 WHERE id = %d", id))
+				}
+				if mode == store.Serialized {
+					stmts = append(stmts, "COMMIT")
+				}
+				off += batch
+				if err := st.RunTxn(runCtx, stmts...); err != nil {
+					if runCtx.Err() != nil {
+						return
+					}
+					log.Printf("txn: %v", err)
+					return
+				}
+				updates.Add(int64(batch))
+			}
+		}(w)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	return updates.Load(), st.Stats().Conflicts, elapsed
+}
+
+// pctl returns the q-quantile (0..1) of a latency sample. q=1.0 is max.
+func pctl(d []time.Duration, q float64) time.Duration {
+	if len(d) == 0 {
+		return 0
+	}
+	cp := make([]time.Duration, len(d))
+	copy(cp, d)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	idx := int(q * float64(len(cp)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(cp) {
+		idx = len(cp) - 1
+	}
+	return cp[idx]
+}

--- a/examples/go-collector/docker-compose.yml
+++ b/examples/go-collector/docker-compose.yml
@@ -1,0 +1,61 @@
+# docker-compose for the SQLRite edge/IoT collector.
+#
+# Run from the repo root (the build context must be the root):
+#
+#   docker compose -f examples/go-collector/docker-compose.yml up --build
+#
+# The collector writes to a named volume so the durable buffer survives
+# container restarts — the same property a real edge box relies on.
+
+services:
+  collector:
+    build:
+      # Build context is the repository root, two levels up.
+      context: ../..
+      dockerfile: examples/go-collector/Dockerfile
+    image: sqlrite-collector
+    ports:
+      - "8080:8080"
+    volumes:
+      - collector-data:/data
+    command:
+      - "-db"
+      - "/data/events.sqlrite"
+      - "-addr"
+      - ":8080"
+      - "-max-backlog"
+      - "100000"
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/loadgen", "-target", "http://localhost:8080", "-duration", "1s", "-workers", "1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # OPTIONAL "ask the collector" sidecar. Disabled by default (profile).
+  #
+  # IMPORTANT — single-writer across processes. SQLRite's MVCC is
+  # in-process only; cross-process access still serializes through an
+  # exclusive file lock (docs/concurrent-writes.md → Limitations). So
+  # sqlrite-mcp CANNOT open the live events.sqlrite read-only while the
+  # collector holds it open for writing. Use this against a *snapshot*:
+  # stop the collector (or copy events.sqlrite to a snapshot path) and
+  # point the MCP server at that. Launch interactively for stdio MCP:
+  #
+  #   docker compose -f examples/go-collector/docker-compose.yml \
+  #     --profile mcp run --rm mcp
+  #
+  # then wire its stdio into Claude Desktop / Cursor. See the README.
+  mcp:
+    profiles: ["mcp"]
+    image: rust:1-bookworm
+    volumes:
+      - collector-data:/data:ro
+    working_dir: /data
+    # Builds + runs the MCP server read-only against a snapshot copy.
+    command: >
+      bash -lc "cargo install sqlrite-mcp >/dev/null 2>&1 || true;
+                cp -n /data/events.sqlrite /tmp/snapshot.sqlrite;
+                sqlrite-mcp --read-only /tmp/snapshot.sqlrite"
+
+volumes:
+  collector-data:

--- a/examples/go-collector/go.mod
+++ b/examples/go-collector/go.mod
@@ -1,0 +1,26 @@
+// Go module for the SQLRite edge/IoT event collector example (SQLR-43).
+//
+// This is an end-to-end example app under the SQLR-38 umbrella, not a
+// per-SDK quick-start tour (that's `examples/go/`). It embeds the
+// SQLRite engine through the Go `database/sql` driver in `sdk/go`,
+// which calls into the `libsqlrite_c` cdylib shipped by `sqlrite-ffi`
+// over cgo.
+//
+// While developing from a repo clone we point at the sibling `sdk/go`
+// module via a `replace` directive — the same shape `examples/go`
+// uses. A standalone consumer would instead `require` a tagged
+// `sdk/go/v*` release and point cgo at a prebuilt `libsqlrite_c`
+// tarball (see this example's README + `sdk/go/README.md`).
+//
+// Pinned engine version: sqlrite-engine 0.10.2 (the workspace head at
+// the time this example was written). cgo links whatever `libsqlrite_c`
+// you built from this checkout — `cargo build --release -p sqlrite-ffi`.
+//
+// Go 1.21 is the floor, matching `sdk/go`.
+module github.com/joaoh82/rust_sqlite/examples/go-collector
+
+go 1.21
+
+require github.com/joaoh82/rust_sqlite/sdk/go v0.0.0
+
+replace github.com/joaoh82/rust_sqlite/sdk/go => ../../sdk/go

--- a/examples/go-collector/internal/server/server.go
+++ b/examples/go-collector/internal/server/server.go
@@ -1,0 +1,155 @@
+// Package server is the HTTP front door: POST /events writes into the
+// durable buffer, GET /healthz and GET /stats expose ops state, and a
+// backlog ceiling drives 503 backpressure when the buffer fills.
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/uploader"
+)
+
+// Config tunes the server's backpressure policy.
+type Config struct {
+	MaxBacklog int64 // reject writes with 503 once backlog reaches this (0 = unlimited)
+	Logger     *log.Logger
+}
+
+// Server wires the store + uploader behind an http.Handler.
+type Server struct {
+	store *store.Store
+	up    *uploader.Uploader
+	cfg   Config
+	log   *log.Logger
+}
+
+// New builds a Server.
+func New(s *store.Store, up *uploader.Uploader, cfg Config) *Server {
+	lg := cfg.Logger
+	if lg == nil {
+		lg = log.Default()
+	}
+	return &Server{store: s, up: up, cfg: cfg, log: lg}
+}
+
+// Handler returns the routed http.Handler.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/events", s.handleEvents)
+	mux.HandleFunc("/healthz", s.handleHealthz)
+	mux.HandleFunc("/stats", s.handleStats)
+	return mux
+}
+
+// eventRequest accepts either a single event object or a JSON array of
+// them, so the demo client can post one-at-a-time or in small batches.
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Backpressure: the buffer is a finite disk-backed queue. When it's
+	// full we shed load with 503 rather than growing unbounded — the
+	// producer is expected to retry with backoff.
+	if s.cfg.MaxBacklog > 0 && s.store.Backlog() >= s.cfg.MaxBacklog {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":   "buffer full",
+			"backlog": s.store.Backlog(),
+		})
+		return
+	}
+
+	defer r.Body.Close()
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+
+	// Peek the first token to decide object vs array without buffering
+	// the whole body twice.
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	var events []store.Event
+	if len(raw) > 0 && raw[0] == '[' {
+		if err := json.Unmarshal(raw, &events); err != nil {
+			http.Error(w, "invalid JSON array of events", http.StatusBadRequest)
+			return
+		}
+	} else {
+		var ev store.Event
+		if err := json.Unmarshal(raw, &ev); err != nil {
+			http.Error(w, "invalid JSON event", http.StatusBadRequest)
+			return
+		}
+		events = []store.Event{ev}
+	}
+
+	now := time.Now().UnixMilli()
+	ids := make([]int64, 0, len(events))
+	for i := range events {
+		if events[i].DeviceID == "" {
+			http.Error(w, "device_id is required", http.StatusBadRequest)
+			return
+		}
+		if events[i].Kind == "" {
+			http.Error(w, "kind is required", http.StatusBadRequest)
+			return
+		}
+		if events[i].TS == 0 {
+			events[i].TS = now // server-stamp receipt time
+		}
+		id, err := s.store.InsertEvent(r.Context(), events[i])
+		if err != nil {
+			if errors.Is(err, store.ErrBadPayload) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			s.log.Printf("insert event: %v", err)
+			http.Error(w, "failed to store event", http.StatusInternalServerError)
+			return
+		}
+		ids = append(ids, id)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"accepted": len(ids),
+		"ids":      ids,
+	})
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	health := s.up.Health()
+	backlogOK := s.cfg.MaxBacklog == 0 || s.store.Backlog() < s.cfg.MaxBacklog
+	ok := health.Healthy && backlogOK
+
+	status := http.StatusOK
+	if !ok {
+		status = http.StatusServiceUnavailable
+	}
+	writeJSON(w, status, map[string]any{
+		"ok":         ok,
+		"uploader":   health,
+		"backlog":    s.store.Backlog(),
+		"backlog_ok": backlogOK,
+	})
+}
+
+func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"store":    s.store.Stats(),
+		"uploader": s.up.Health(),
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/examples/go-collector/internal/server/server_test.go
+++ b/examples/go-collector/internal/server/server_test.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/uploader"
+)
+
+func newTestServer(t *testing.T, maxBacklog int64) (*httptest.Server, *store.Store) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "srv.sqlrite")
+	st, err := store.Open(context.Background(), store.Options{Path: path, Mode: store.Concurrent})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	// Uploader is built but not Run() — backlog stays put so we can
+	// exercise backpressure deterministically. A non-running uploader
+	// reports healthy by default.
+	up := uploader.New(st, uploader.LogSink{}, uploader.Config{Logger: log.New(io.Discard, "", 0)})
+	srv := New(st, up, Config{MaxBacklog: maxBacklog, Logger: log.New(io.Discard, "", 0)})
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() { ts.Close(); st.Close() })
+	return ts, st
+}
+
+func postEvent(t *testing.T, base string, body string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(base+"/events", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST /events: %v", err)
+	}
+	return resp
+}
+
+func TestPostEventOK(t *testing.T) {
+	ts, st := newTestServer(t, 0)
+	resp := postEvent(t, ts.URL, `{"device_id":"sensor-1","kind":"telemetry","payload":{"temp":21}}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Accepted int     `json:"accepted"`
+		IDs      []int64 `json:"ids"`
+	}
+	json.NewDecoder(resp.Body).Decode(&out)
+	if out.Accepted != 1 || len(out.IDs) != 1 {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+	if got, _ := st.CountEvents(context.Background()); got != 1 {
+		t.Fatalf("CountEvents = %d, want 1", got)
+	}
+}
+
+func TestPostEventArray(t *testing.T) {
+	ts, _ := newTestServer(t, 0)
+	resp := postEvent(t, ts.URL, `[{"device_id":"a","kind":"k"},{"device_id":"b","kind":"k"}]`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Accepted int `json:"accepted"`
+	}
+	json.NewDecoder(resp.Body).Decode(&out)
+	if out.Accepted != 2 {
+		t.Fatalf("accepted = %d, want 2", out.Accepted)
+	}
+}
+
+func TestPostEventValidation(t *testing.T) {
+	ts, _ := newTestServer(t, 0)
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"malformed json", `{not json`, http.StatusBadRequest},
+		{"missing device_id", `{"kind":"k"}`, http.StatusBadRequest},
+		{"missing kind", `{"device_id":"d"}`, http.StatusBadRequest},
+		{"bad payload", `{"device_id":"d","kind":"k","payload":"not-an-object-but-string-is-valid-json"}`, http.StatusOK},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp := postEvent(t, ts.URL, c.body)
+			defer resp.Body.Close()
+			if resp.StatusCode != c.want {
+				b, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d (body: %s)", resp.StatusCode, c.want, b)
+			}
+		})
+	}
+}
+
+func TestBackpressure503(t *testing.T) {
+	ts, _ := newTestServer(t, 3) // buffer ceiling of 3
+
+	for i := 0; i < 3; i++ {
+		resp := postEvent(t, ts.URL, `{"device_id":"d","kind":"k"}`)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("fill %d: status = %d, want 200", i, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+	// Buffer is full → 503.
+	resp := postEvent(t, ts.URL, `{"device_id":"d","kind":"k"}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("over-limit status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestHealthzAndStats(t *testing.T) {
+	ts, _ := newTestServer(t, 2)
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("healthz status = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Fill past the ceiling, then healthz should flip to 503.
+	for i := 0; i < 2; i++ {
+		postEvent(t, ts.URL, `{"device_id":"d","kind":"k"}`).Body.Close()
+	}
+	resp, _ = http.Get(ts.URL + "/healthz")
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("healthz after fill = %d, want 503", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// /stats always 200 and reports the store snapshot.
+	resp, _ = http.Get(ts.URL + "/stats")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stats status = %d, want 200", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(body, []byte(`"mode":"concurrent"`)) {
+		t.Fatalf("stats body missing mode: %s", body)
+	}
+}

--- a/examples/go-collector/internal/store/sqlquote.go
+++ b/examples/go-collector/internal/store/sqlquote.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// The SQLRite Go driver does not support parameter binding — it rejects
+// any non-empty argument slice and tells you to inline values into the
+// SQL string (see sdk/go/sqlrite.go `rejectParamsForNow`). That makes
+// these two helpers load-bearing: every value the collector sends to
+// the engine flows through one of them, so this file is the single
+// chokepoint that keeps inlined SQL safe against quote-injection and
+// malformed JSON.
+
+// quoteText renders a Go string as a SQL single-quoted text literal,
+// doubling embedded single quotes per SQLRite's escaping rule
+// (docs/supported-sql.md → "Value literals accepted": `'it”s'`).
+func quoteText(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// maxPayloadBytes bounds the compacted JSON payload of a single event.
+//
+// This isn't arbitrary: under MVCC every committed row is encoded into a
+// WAL log-record frame whose body is capped at 4 KiB
+// (docs/concurrent-writes.md → Durability; verified: a commit whose
+// encoded batch exceeds the cap fails with "encoded batch exceeds
+// 4096-byte frame body cap"). A single event row's record carries its
+// whole image — payload + the other columns + per-record framing — so an
+// unbounded payload would make even the hot-path single-row INSERT fail
+// at COMMIT. Capping the payload well under 4 KiB guarantees any one row
+// commits, which in turn lets the checkpoint mark rows one-at-a-time as
+// its safe floor (see Store.writeAdaptive). The headroom below 4096
+// covers the device_id / kind columns and the framing overhead.
+const maxPayloadBytes = 3072
+
+// quoteJSON validates that payload is well-formed JSON and returns it
+// as a SQL text literal for a JSON column, or the bareword NULL when
+// the payload is empty. SQLRite validates JSON columns at INSERT time
+// (serde_json) and rejects malformed input with a typed error; we
+// pre-validate here so a bad client payload becomes a clean 400 rather
+// than a 500 bubbling up from the engine. The payload is compacted to
+// canonical form first, which both shortens the inlined literal and
+// strips any stray control characters that survived JSON parsing.
+//
+// Oversized payloads are rejected here (see maxPayloadBytes) so they
+// surface as a clean client error rather than an opaque MVCC frame-cap
+// failure at COMMIT.
+func quoteJSON(payload json.RawMessage) (string, error) {
+	if len(bytes.TrimSpace(payload)) == 0 {
+		return "NULL", nil
+	}
+	if !json.Valid(payload) {
+		return "", fmt.Errorf("payload is not valid JSON")
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, payload); err != nil {
+		return "", fmt.Errorf("compact payload: %w", err)
+	}
+	if buf.Len() > maxPayloadBytes {
+		return "", fmt.Errorf("payload too large: %d bytes (max %d under the MVCC 4 KiB commit-record cap)",
+			buf.Len(), maxPayloadBytes)
+	}
+	return quoteText(buf.String()), nil
+}

--- a/examples/go-collector/internal/store/store.go
+++ b/examples/go-collector/internal/store/store.go
@@ -1,0 +1,649 @@
+// Package store is the durable buffer at the heart of the collector:
+// a thin layer over a file-backed SQLRite database that an HTTP write
+// path and a background uploader hammer concurrently.
+//
+// The whole example exists to exercise SQLRite's Phase 11 concurrent
+// writes (SQLR-22). Two write strategies live behind one API:
+//
+//   - WriteMode == Concurrent: every write runs in its own
+//     `BEGIN CONCURRENT` transaction on a sibling connection pulled
+//     from the `database/sql` pool, with the canonical retry-on-Busy
+//     loop. This is the mode the collector ships with.
+//   - WriteMode == Serialized: every write runs through a single
+//     connection guarded by a Go mutex — the naive "one big lock
+//     around the DB" shape you'd be stuck with before concurrent
+//     writes shipped. It exists so the loadgen can measure the
+//     difference honestly (see cmd/loadgen).
+//
+// Engine constraints that shaped the schema and SQL (all from
+// docs/supported-sql.md + docs/concurrent-writes.md):
+//
+//   - No parameter binding in the Go SDK → values are inlined via the
+//     helpers in sqlquote.go.
+//   - `CREATE TABLE IF NOT EXISTS` is not honored and `sqlrite_master`
+//     isn't queryable → migrate() probes for the events table with a
+//     SELECT and only runs DDL on a fresh database.
+//   - `CREATE INDEX` is rejected once `journal_mode = mvcc` → all DDL,
+//     including the optional secondary index, runs at migrate time
+//     before MVCC is switched on.
+//   - A single BEGIN CONCURRENT commit batch is capped at 4 KiB → event
+//     payloads are bounded at ingest (see maxPayloadBytes) so any one
+//     row commits, and the uploader's checkpoint marks rows in
+//     adaptively-sized chunks that halve on a cap error (see
+//     CommitUpload / writeAdaptive) rather than one wide transaction.
+//   - AUTOINCREMENT rowids collide under MVCC (two concurrent inserts
+//     can allocate the same rowid → Busy) → event ids are assigned
+//     application-side from an atomic counter seeded off MAX(id).
+//   - `IS NULL` never uses an index → the uploader's backlog scan is a
+//     full scan by design; the optional index is on device_id, which
+//     genuinely accelerates per-device diagnostic queries.
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	sqlrite "github.com/joaoh82/rust_sqlite/sdk/go"
+)
+
+// WriteMode selects how writes reach the engine. See the package doc.
+type WriteMode int
+
+const (
+	// Concurrent runs each write in its own BEGIN CONCURRENT transaction
+	// on a pooled sibling connection, retrying on Busy.
+	Concurrent WriteMode = iota
+	// Serialized funnels every write through one connection under a Go
+	// mutex — the pre-Phase-11 "giant lock" baseline.
+	Serialized
+)
+
+func (m WriteMode) String() string {
+	if m == Serialized {
+		return "serialized"
+	}
+	return "concurrent"
+}
+
+// Errors surfaced to callers.
+var (
+	// ErrBadPayload wraps a client payload that isn't valid JSON.
+	ErrBadPayload = errors.New("invalid event payload")
+	// ErrRetryExhausted means a BEGIN CONCURRENT write hit Busy more
+	// times than the configured budget. In practice this never fires
+	// for disjoint-row workloads; it's a backstop against livelock.
+	ErrRetryExhausted = errors.New("write retry budget exhausted")
+)
+
+// Event is one telemetry record. The id is assigned by the store; the
+// client supplies the rest. TS is unix-millis — clients may stamp it,
+// or leave it 0 and the server fills in receipt time.
+type Event struct {
+	ID       int64           `json:"id,omitempty"`
+	DeviceID string          `json:"device_id"`
+	Kind     string          `json:"kind"`
+	Payload  json.RawMessage `json:"payload,omitempty"`
+	TS       int64           `json:"ts,omitempty"`
+}
+
+// UploadRun is the audit-trail row the uploader writes per cycle.
+type UploadRun struct {
+	StartedAt  int64
+	FinishedAt int64
+	EventCount int
+	Status     string // "success" | "error"
+	Error      string
+}
+
+// Options configures Open.
+type Options struct {
+	Path         string    // database file path (must be file-backed for sibling sharing)
+	Mode         WriteMode // Concurrent (default) or Serialized
+	Indexed      bool      // create a secondary index on events(device_id) at setup
+	MaxOpenConns int       // database/sql pool ceiling (default 8)
+	MaxRetries   int       // BEGIN CONCURRENT retry budget (default 100)
+	MarkChunk    int       // rows per checkpoint commit (default 20; see CommitUpload)
+}
+
+// Store owns the database handle and the in-process counters that back
+// /stats and the backpressure decision without a round-trip to disk.
+type Store struct {
+	db   *sql.DB
+	opts Options
+
+	nextID    atomic.Int64 // app-assigned event ids
+	nextRunID atomic.Int64 // app-assigned upload_runs ids
+	nextDevID atomic.Int64 // app-assigned devices ids
+
+	backlog   atomic.Int64 // events with uploaded_at IS NULL
+	written   atomic.Int64 // total events accepted
+	uploaded  atomic.Int64 // total events marked uploaded
+	conflicts atomic.Int64 // BEGIN CONCURRENT Busy retries observed
+
+	// Serialized mode pins one connection under serMu.
+	serMu   sync.Mutex
+	serConn *sql.Conn
+
+	// devices in-memory key→rowid map, maintained by the uploader off
+	// the hot path. Guarded by devMu.
+	devMu sync.Mutex
+	devs  map[string]int64
+}
+
+// Open creates/opens the database, applies the schema on first use, and
+// (in Concurrent mode) switches the database into MVCC. DDL runs before
+// the MVCC switch because CREATE INDEX is rejected once
+// journal_mode = mvcc; see migrate for the fresh-vs-reopen detection.
+func Open(ctx context.Context, opts Options) (*Store, error) {
+	if opts.MaxOpenConns <= 0 {
+		opts.MaxOpenConns = 8
+	}
+	if opts.MaxRetries <= 0 {
+		opts.MaxRetries = 100
+	}
+	if opts.MarkChunk <= 0 {
+		// Keep each checkpoint commit comfortably under the engine's
+		// 4 KiB MVCC commit-batch frame cap (see CommitUpload). A wide
+		// event row encodes to ~120 bytes in the MVCC log, so 20 rows
+		// (~2.4 KiB) leaves healthy headroom.
+		opts.MarkChunk = 20
+	}
+	db, err := sql.Open(sqlrite.DriverName, opts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", opts.Path, err)
+	}
+	db.SetMaxOpenConns(opts.MaxOpenConns)
+	db.SetMaxIdleConns(opts.MaxOpenConns)
+
+	s := &Store{db: db, opts: opts, devs: make(map[string]int64)}
+
+	if err := s.migrate(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := s.seed(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if opts.Mode == Serialized {
+		c, err := db.Conn(ctx)
+		if err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("pin serialized conn: %w", err)
+		}
+		s.serConn = c
+	}
+	return s, nil
+}
+
+// Close releases the pinned connection (if any) and the pool.
+func (s *Store) Close() error {
+	if s.serConn != nil {
+		_ = s.serConn.Close()
+	}
+	return s.db.Close()
+}
+
+// migrate creates the schema on a fresh database and is a no-op on
+// reopen. Two engine constraints (both verified against the v0 engine)
+// shape this:
+//
+//   - `CREATE TABLE IF NOT EXISTS` is NOT honored — a second create of
+//     an existing table errors "table already exists" — and the
+//     `sqlrite_master` catalog isn't queryable. So we detect a fresh
+//     database by probing for the events table with a cheap SELECT and
+//     only run DDL when it's absent.
+//   - `CREATE INDEX` is rejected once `journal_mode = mvcc`. All DDL
+//     (tables + the optional index) therefore runs on the fresh path,
+//     in WAL mode, *before* the MVCC switch. On reopen the index already
+//     exists, so we never re-issue it.
+func (s *Store) migrate(ctx context.Context) error {
+	fresh := !s.tableExists(ctx, "events")
+
+	if fresh {
+		ddl := []string{
+			`CREATE TABLE events (
+				id           INTEGER PRIMARY KEY,
+				device_id    TEXT NOT NULL,
+				kind         TEXT NOT NULL,
+				payload_json JSON,
+				ts           INTEGER NOT NULL,
+				uploaded_at  INTEGER
+			)`,
+			`CREATE TABLE devices (
+				id           INTEGER PRIMARY KEY,
+				device_key   TEXT NOT NULL,
+				label        TEXT,
+				last_seen_at INTEGER
+			)`,
+			`CREATE TABLE upload_runs (
+				id          INTEGER PRIMARY KEY,
+				started_at  INTEGER NOT NULL,
+				finished_at INTEGER,
+				event_count INTEGER NOT NULL,
+				status      TEXT NOT NULL,
+				error       TEXT
+			)`,
+		}
+		if s.opts.Indexed {
+			// Single-column B-tree index (composite indexes are
+			// unsupported). Accelerates per-device diagnostic queries
+			// (`WHERE device_id = '...'`); the trade is extra index
+			// maintenance on every concurrent write, which the loadgen
+			// measures. The index choice is fixed at DB-creation time —
+			// reopening with a different -indexed flag does not add or
+			// drop it (we'd have to CREATE INDEX under MVCC, which the
+			// engine rejects).
+			ddl = append(ddl,
+				`CREATE INDEX idx_events_device ON events (device_id)`)
+		}
+		for _, q := range ddl {
+			if _, err := s.db.ExecContext(ctx, q); err != nil {
+				return fmt.Errorf("migrate: %w", err)
+			}
+		}
+	}
+
+	// PRAGMA journal_mode is idempotent — safe to set on both the fresh
+	// and reopen paths regardless of whether the mode persisted.
+	if s.opts.Mode == Concurrent {
+		if _, err := s.db.ExecContext(ctx, "PRAGMA journal_mode = mvcc"); err != nil {
+			return fmt.Errorf("enable mvcc: %w", err)
+		}
+	}
+	return nil
+}
+
+// tableExists probes for a table with a zero-row SELECT. The engine has
+// no queryable catalog and rejects `CREATE TABLE IF NOT EXISTS`, so this
+// probe is how we tell a fresh database from a reopened one. A query
+// error (the engine returns "Table '<name>' not found") means absent.
+func (s *Store) tableExists(ctx context.Context, name string) bool {
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf("SELECT id FROM %s LIMIT 1", name))
+	if err != nil {
+		return false
+	}
+	_ = rows.Close()
+	return true
+}
+
+// seed primes the atomic id counters and the backlog gauge from
+// whatever's already on disk, so reopening a populated buffer doesn't
+// reuse ids or lose the un-uploaded count.
+func (s *Store) seed(ctx context.Context) error {
+	maxID, err := s.scalarMax(ctx, "events")
+	if err != nil {
+		return err
+	}
+	s.nextID.Store(maxID)
+
+	maxRun, err := s.scalarMax(ctx, "upload_runs")
+	if err != nil {
+		return err
+	}
+	s.nextRunID.Store(maxRun)
+
+	maxDev, err := s.scalarMax(ctx, "devices")
+	if err != nil {
+		return err
+	}
+	s.nextDevID.Store(maxDev)
+
+	var backlog int64
+	row := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE uploaded_at IS NULL")
+	if err := row.Scan(&backlog); err != nil {
+		return fmt.Errorf("seed backlog: %w", err)
+	}
+	s.backlog.Store(backlog)
+
+	// Load known devices into the in-memory map.
+	rows, err := s.db.QueryContext(ctx, "SELECT id, device_key FROM devices")
+	if err != nil {
+		return fmt.Errorf("seed devices: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		var key string
+		if err := rows.Scan(&id, &key); err != nil {
+			return fmt.Errorf("seed devices scan: %w", err)
+		}
+		s.devs[key] = id
+	}
+	return rows.Err()
+}
+
+// scalarMax returns MAX(id) for a table, or 0 when the table is empty
+// (MAX over no rows is NULL). COALESCE isn't supported by the engine,
+// so we scan into a nullable.
+func (s *Store) scalarMax(ctx context.Context, table string) (int64, error) {
+	var v sql.NullInt64
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf("SELECT MAX(id) FROM %s", table))
+	if err := row.Scan(&v); err != nil {
+		return 0, fmt.Errorf("max(id) from %s: %w", table, err)
+	}
+	if !v.Valid {
+		return 0, nil
+	}
+	return v.Int64, nil
+}
+
+// InsertEvent durably appends one event and returns its assigned id.
+// This is the hot path — a single INSERT per call, one durable commit.
+func (s *Store) InsertEvent(ctx context.Context, ev Event) (int64, error) {
+	jsonLit, err := quoteJSON(ev.Payload)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", ErrBadPayload, err)
+	}
+	id := s.nextID.Add(1)
+	q := fmt.Sprintf(
+		"INSERT INTO events (id, device_id, kind, payload_json, ts, uploaded_at) "+
+			"VALUES (%d, %s, %s, %s, %d, NULL)",
+		id, quoteText(ev.DeviceID), quoteText(ev.Kind), jsonLit, ev.TS,
+	)
+	if err := s.write(ctx, q); err != nil {
+		return 0, err
+	}
+	s.written.Add(1)
+	s.backlog.Add(1)
+	return id, nil
+}
+
+// FetchPending returns up to limit un-uploaded events, oldest first.
+// Reads run outside any transaction, so they see the latest committed
+// state. The WHERE uploaded_at IS NULL is a full scan by design (NULLs
+// aren't indexed) — fine for a bounded edge buffer.
+func (s *Store) FetchPending(ctx context.Context, limit int) ([]Event, error) {
+	q := fmt.Sprintf(
+		"SELECT id, device_id, kind, payload_json, ts FROM events "+
+			"WHERE uploaded_at IS NULL ORDER BY id LIMIT %d", limit)
+	rows, err := s.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("fetch pending: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Event
+	for rows.Next() {
+		var ev Event
+		var payload sql.NullString
+		if err := rows.Scan(&ev.ID, &ev.DeviceID, &ev.Kind, &payload, &ev.TS); err != nil {
+			return nil, fmt.Errorf("scan pending: %w", err)
+		}
+		if payload.Valid {
+			ev.Payload = json.RawMessage(payload.String)
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+// CommitUpload records the outcome of one uploader cycle: it marks the
+// shipped events uploaded (when any), upserts the devices they came
+// from, and always writes an upload_runs audit row — even for a failed
+// run, so the failure is durably recorded. Passing markIDs == nil
+// records a failed/empty run without marking anything uploaded.
+//
+// Why this isn't one big transaction. SQLRite's MVCC durability frame
+// caps a single BEGIN CONCURRENT commit batch at 4 KiB (verified: a
+// wide-row UPDATE over ~150 rows overflows it with
+// "encoded batch exceeds 4096-byte frame body cap"). So instead of one
+// transaction marking the whole batch, we mark in chunks of MarkChunk
+// rows — each chunk its own transaction — which keeps every commit
+// under the cap. This relaxes the checkpoint from atomic to
+// incremental: a failure partway leaves the earlier chunks marked and
+// the rest buffered for the next cycle. Combined with the uploader
+// shipping before marking, that's standard at-least-once delivery (a
+// row can ship twice but never be lost). The audit row is written in
+// the final chunk.
+//
+// In Serialized mode there is no MVCC frame and therefore no cap, but
+// chunking is still correct (just more BEGIN/COMMITs), so we take the
+// same path in both modes for simplicity.
+func (s *Store) CommitUpload(ctx context.Context, run UploadRun, markIDs []int64, batch []Event) error {
+	// Per-row mark statements (not a single IN-list) so chunking by
+	// statement count maps directly to rows-per-commit.
+	var marks []string
+	for _, id := range markIDs {
+		marks = append(marks, fmt.Sprintf(
+			"UPDATE events SET uploaded_at = %d WHERE id = %d", run.FinishedAt, id))
+	}
+
+	// Tail statements: device upserts + the audit row, run after the
+	// marks in their own (final) chunk(s).
+	tail := s.deviceUpserts(batch)
+	runID := s.nextRunID.Add(1)
+	tail = append(tail, fmt.Sprintf(
+		"INSERT INTO upload_runs (id, started_at, finished_at, event_count, status, error) "+
+			"VALUES (%d, %d, %d, %d, %s, %s)",
+		runID, run.StartedAt, run.FinishedAt, run.EventCount,
+		quoteText(run.Status), nullableText(run.Error)))
+
+	// Mark events in adaptively-sized chunks. writeAdaptive returns the
+	// committed prefix count (== events marked, since marks are 1:1 with
+	// rows) even on error, so the gauges stay accurate on a partial
+	// failure.
+	marked, err := s.writeAdaptive(ctx, marks, s.opts.MarkChunk)
+	if marked > 0 {
+		s.uploaded.Add(int64(marked))
+		s.backlog.Add(-int64(marked))
+	}
+	if err != nil {
+		return err
+	}
+
+	// Tail (device upserts + audit row) — same adaptive chunking. These
+	// aren't event marks, so their committed count doesn't touch the
+	// backlog/uploaded gauges.
+	if _, err := s.writeAdaptive(ctx, tail, s.opts.MarkChunk); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeAdaptive runs stmts as a sequence of transactions, starting at
+// `chunk` statements per commit and **halving on a frame-cap error**
+// down to a floor of one statement per commit. This is how the
+// checkpoint stays under SQLRite's 4 KiB MVCC commit-batch cap without
+// the caller having to know the encoded size of each row up front: it
+// optimistically batches, and only pays the split cost when a batch
+// actually overflows. Because every single event row is bounded under
+// the cap (see maxPayloadBytes), the one-statement floor always commits.
+//
+// Returns the number of statements successfully committed (a prefix of
+// stmts) so the caller can keep its gauges accurate even when a later
+// chunk fails for a non-cap reason.
+func (s *Store) writeAdaptive(ctx context.Context, stmts []string, chunk int) (int, error) {
+	if chunk < 1 {
+		chunk = 1
+	}
+	done := 0
+	for done < len(stmts) {
+		end := done + chunk
+		if end > len(stmts) {
+			end = len(stmts)
+		}
+		err := s.write(ctx, stmts[done:end]...)
+		if err != nil {
+			if isFrameCapError(err) && end-done > 1 {
+				// This batch overflowed the MVCC frame; shrink and retry
+				// the same prefix. The smaller chunk size sticks for the
+				// rest of the checkpoint.
+				chunk = (end - done) / 2
+				continue
+			}
+			return done, err
+		}
+		done = end
+	}
+	return done, nil
+}
+
+// isFrameCapError reports whether err is SQLRite's MVCC commit-batch
+// size-cap error. The FFI surfaces it as a General error with a stable
+// message fragment; matching the fragment is the only handle we have
+// (it isn't a distinct status code).
+func isFrameCapError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "frame body cap")
+}
+
+// deviceUpserts builds the per-device INSERT/UPDATE statements for the
+// distinct devices in a batch, assigning row ids for unseen devices.
+// Caller runs them inside the upload transaction.
+func (s *Store) deviceUpserts(batch []Event) []string {
+	latest := make(map[string]int64) // device_key → newest ts in batch
+	for _, ev := range batch {
+		if ev.TS > latest[ev.DeviceID] {
+			latest[ev.DeviceID] = ev.TS
+		}
+	}
+	s.devMu.Lock()
+	defer s.devMu.Unlock()
+
+	var stmts []string
+	for key, ts := range latest {
+		if id, ok := s.devs[key]; ok {
+			stmts = append(stmts, fmt.Sprintf(
+				"UPDATE devices SET last_seen_at = %d WHERE id = %d", ts, id))
+			continue
+		}
+		id := s.nextDevID.Add(1)
+		s.devs[key] = id
+		stmts = append(stmts, fmt.Sprintf(
+			"INSERT INTO devices (id, device_key, label, last_seen_at) "+
+				"VALUES (%d, %s, %s, %d)",
+			id, quoteText(key), quoteText(key), ts))
+	}
+	return stmts
+}
+
+// RunTxn executes an arbitrary set of statements as one transaction
+// through the configured write strategy. Exposed for the loadgen
+// experiments (cmd/loadgen) so they can drive multi-statement
+// transactions of varying shapes; the collector itself goes through the
+// typed methods above.
+func (s *Store) RunTxn(ctx context.Context, stmts ...string) error {
+	return s.write(ctx, stmts...)
+}
+
+// write dispatches one or more statements through the configured write
+// strategy. Concurrent wraps them in a retrying BEGIN CONCURRENT;
+// Serialized funnels them through the single locked connection.
+func (s *Store) write(ctx context.Context, stmts ...string) error {
+	if s.opts.Mode == Serialized {
+		return s.serializedWrite(ctx, stmts...)
+	}
+	return s.concurrentWrite(ctx, stmts...)
+}
+
+func (s *Store) serializedWrite(ctx context.Context, stmts ...string) error {
+	s.serMu.Lock()
+	defer s.serMu.Unlock()
+	for _, q := range stmts {
+		if _, err := s.serConn.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("serialized write: %w", err)
+		}
+	}
+	return nil
+}
+
+// concurrentWrite is the canonical SQLRite retry loop (see
+// docs/concurrent-writes.md): pin a sibling connection, BEGIN
+// CONCURRENT, apply the statements, COMMIT; on a retryable Busy the
+// engine has already rolled the transaction back, so we just loop with
+// a fresh BEGIN CONCURRENT.
+func (s *Store) concurrentWrite(ctx context.Context, stmts ...string) error {
+	c, err := s.db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire conn: %w", err)
+	}
+	defer c.Close()
+
+	for attempt := 0; attempt < s.opts.MaxRetries; attempt++ {
+		if _, err := c.ExecContext(ctx, "BEGIN CONCURRENT"); err != nil {
+			return fmt.Errorf("begin concurrent: %w", err)
+		}
+		err := s.applyAndCommit(ctx, c, stmts)
+		if err == nil {
+			return nil
+		}
+		if sqlrite.IsRetryable(err) {
+			// Engine already dropped the transaction on a Busy COMMIT.
+			s.conflicts.Add(1)
+			continue
+		}
+		// Hard error: a statement (not the commit) failed, leaving the
+		// transaction open. Roll back before surfacing.
+		_, _ = c.ExecContext(ctx, "ROLLBACK")
+		return err
+	}
+	return fmt.Errorf("%w after %d attempts", ErrRetryExhausted, s.opts.MaxRetries)
+}
+
+func (s *Store) applyAndCommit(ctx context.Context, c *sql.Conn, stmts []string) error {
+	for _, q := range stmts {
+		if _, err := c.ExecContext(ctx, q); err != nil {
+			return err
+		}
+	}
+	_, err := c.ExecContext(ctx, "COMMIT")
+	return err
+}
+
+// nullableText renders s as a SQL text literal, or NULL when empty.
+func nullableText(s string) string {
+	if s == "" {
+		return "NULL"
+	}
+	return quoteText(s)
+}
+
+// ---------------------------------------------------------------------------
+// Stats / gauges (cheap, atomic — no disk round-trip)
+
+// Stats is a point-in-time snapshot for /stats and /healthz.
+type Stats struct {
+	Mode       string `json:"mode"`
+	Indexed    bool   `json:"indexed"`
+	Written    int64  `json:"events_written"`
+	Uploaded   int64  `json:"events_uploaded"`
+	Backlog    int64  `json:"backlog"`
+	Conflicts  int64  `json:"commit_conflicts"`
+	DeviceSeen int    `json:"devices_seen"`
+}
+
+// Stats returns the in-memory gauges.
+func (s *Store) Stats() Stats {
+	s.devMu.Lock()
+	n := len(s.devs)
+	s.devMu.Unlock()
+	return Stats{
+		Mode:       s.opts.Mode.String(),
+		Indexed:    s.opts.Indexed,
+		Written:    s.written.Load(),
+		Uploaded:   s.uploaded.Load(),
+		Backlog:    s.backlog.Load(),
+		Conflicts:  s.conflicts.Load(),
+		DeviceSeen: n,
+	}
+}
+
+// Backlog returns the number of un-uploaded events.
+func (s *Store) Backlog() int64 { return s.backlog.Load() }
+
+// CountEvents runs a COUNT(*) against the database — the authoritative
+// total, used by tests to cross-check the in-memory gauges.
+func (s *Store) CountEvents(ctx context.Context) (int64, error) {
+	var n int64
+	row := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events")
+	if err := row.Scan(&n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}

--- a/examples/go-collector/internal/store/store_test.go
+++ b/examples/go-collector/internal/store/store_test.go
@@ -1,0 +1,349 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	sqlrite "github.com/joaoh82/rust_sqlite/sdk/go"
+)
+
+func tempStore(t *testing.T, mode WriteMode, indexed bool) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.sqlrite")
+	st, err := Open(context.Background(), Options{Path: path, Mode: mode, Indexed: indexed, MaxOpenConns: 8})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func ev(device, kind string, ts int64) Event {
+	return Event{DeviceID: device, Kind: kind, Payload: json.RawMessage(`{"v":1,"note":"it's ok"}`), TS: ts}
+}
+
+func TestInsertAndFetchPending(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		if _, err := st.InsertEvent(ctx, ev("sensor-1", "telemetry", int64(i))); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+	if got := st.Backlog(); got != 5 {
+		t.Fatalf("backlog = %d, want 5", got)
+	}
+	pending, err := st.FetchPending(ctx, 10)
+	if err != nil {
+		t.Fatalf("fetch pending: %v", err)
+	}
+	if len(pending) != 5 {
+		t.Fatalf("pending = %d, want 5", len(pending))
+	}
+	// Oldest-first, ids assigned 1..5, payload round-trips.
+	for i, p := range pending {
+		if p.ID != int64(i+1) {
+			t.Errorf("pending[%d].ID = %d, want %d", i, p.ID, i+1)
+		}
+		if !json.Valid(p.Payload) {
+			t.Errorf("pending[%d] payload not valid JSON: %s", i, p.Payload)
+		}
+	}
+}
+
+func TestQuoteEscaping(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	ctx := context.Background()
+	// device id + a payload string both carrying single quotes must
+	// survive the inline-SQL round trip intact.
+	in := Event{DeviceID: "o'brien-rig", Kind: "te'st", Payload: json.RawMessage(`{"msg":"don't panic"}`), TS: 1}
+	id, err := st.InsertEvent(ctx, in)
+	if err != nil {
+		t.Fatalf("insert with quotes: %v", err)
+	}
+	pending, _ := st.FetchPending(ctx, 10)
+	if len(pending) != 1 || pending[0].ID != id {
+		t.Fatalf("expected 1 pending event with id %d, got %+v", id, pending)
+	}
+	if pending[0].DeviceID != "o'brien-rig" {
+		t.Errorf("device id mangled: %q", pending[0].DeviceID)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(pending[0].Payload, &got); err != nil {
+		t.Fatalf("payload not round-tripped: %v (%s)", err, pending[0].Payload)
+	}
+	if got["msg"] != "don't panic" {
+		t.Errorf("payload msg = %q, want %q", got["msg"], "don't panic")
+	}
+}
+
+func TestBadPayloadRejected(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	bad := Event{DeviceID: "d", Kind: "k", Payload: json.RawMessage(`{not json`), TS: 1}
+	_, err := st.InsertEvent(context.Background(), bad)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON payload")
+	}
+	if !errors.Is(err, ErrBadPayload) {
+		t.Fatalf("want ErrBadPayload, got %v", err)
+	}
+}
+
+// TestOversizedPayloadRejected guards the hot path against a payload big
+// enough to overflow the MVCC 4 KiB commit-record cap. Without the
+// ingest-side size check this would fail opaquely at COMMIT; we want a
+// clean ErrBadPayload at insert time instead.
+func TestOversizedPayloadRejected(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	big := make([]byte, 5000)
+	for i := range big {
+		big[i] = 'a'
+	}
+	payload, _ := json.Marshal(map[string]string{"blob": string(big)})
+	_, err := st.InsertEvent(context.Background(), Event{DeviceID: "d", Kind: "k", Payload: payload, TS: 1})
+	if err == nil {
+		t.Fatal("expected error for oversized payload")
+	}
+	if !errors.Is(err, ErrBadPayload) {
+		t.Fatalf("want ErrBadPayload, got %v", err)
+	}
+	// A payload just under the cap must still be accepted.
+	ok := make([]byte, 2000)
+	for i := range ok {
+		ok[i] = 'b'
+	}
+	okPayload, _ := json.Marshal(map[string]string{"blob": string(ok)})
+	if _, err := st.InsertEvent(context.Background(), Event{DeviceID: "d", Kind: "k", Payload: okPayload, TS: 2}); err != nil {
+		t.Fatalf("under-cap payload should be accepted: %v", err)
+	}
+}
+
+func TestCommitUploadMarksAndAudits(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		st.InsertEvent(ctx, ev("sensor-x", "telemetry", int64(i+1)))
+	}
+	pending, _ := st.FetchPending(ctx, 10)
+	ids := []int64{pending[0].ID, pending[1].ID, pending[2].ID}
+
+	run := UploadRun{StartedAt: 1, FinishedAt: 2, EventCount: 3, Status: "success"}
+	if err := st.CommitUpload(ctx, run, ids, pending); err != nil {
+		t.Fatalf("commit upload: %v", err)
+	}
+	if got := st.Backlog(); got != 0 {
+		t.Fatalf("backlog after upload = %d, want 0", got)
+	}
+	left, _ := st.FetchPending(ctx, 10)
+	if len(left) != 0 {
+		t.Fatalf("still %d pending after upload", len(left))
+	}
+	// Audit row + device upsert landed.
+	if n := scalar(t, st, "SELECT COUNT(*) FROM upload_runs"); n != 1 {
+		t.Errorf("upload_runs count = %d, want 1", n)
+	}
+	if n := scalar(t, st, "SELECT COUNT(*) FROM devices"); n != 1 {
+		t.Errorf("devices count = %d, want 1", n)
+	}
+}
+
+func TestSeedReopenContinuesIDs(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "reopen.sqlrite")
+
+	st, err := Open(ctx, Options{Path: path, Mode: Concurrent})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		st.InsertEvent(ctx, ev("d", "k", int64(i+1)))
+	}
+	st.Close()
+
+	st2, err := Open(ctx, Options{Path: path, Mode: Concurrent})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer st2.Close()
+	if got := st2.Backlog(); got != 4 {
+		t.Fatalf("reopened backlog = %d, want 4", got)
+	}
+	id, err := st2.InsertEvent(ctx, ev("d", "k", 99))
+	if err != nil {
+		t.Fatalf("insert after reopen: %v", err)
+	}
+	if id != 5 {
+		t.Fatalf("next id after reopen = %d, want 5 (no reuse)", id)
+	}
+}
+
+// TestLargeCheckpointUnderMVCCCap drives a checkpoint far larger than
+// the engine's 4 KiB MVCC commit-batch cap. A naive single-transaction
+// mark would fail with "encoded batch exceeds 4096-byte frame body cap";
+// the chunked CommitUpload must drain all of it.
+func TestLargeCheckpointUnderMVCCCap(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	ctx := context.Background()
+
+	const n = 300 // well past the ~100-row single-commit ceiling
+	for i := 0; i < n; i++ {
+		// Wide-ish payload so each row's MVCC record is realistic.
+		ev := Event{
+			DeviceID: fmt.Sprintf("sensor-%03d", i%50),
+			Kind:     "telemetry",
+			Payload:  json.RawMessage(`{"temp_c":21,"humidity":47,"seq":12345,"note":"all systems nominal here"}`),
+			TS:       int64(i + 1),
+		}
+		if _, err := st.InsertEvent(ctx, ev); err != nil {
+			t.Fatalf("seed insert %d: %v", i, err)
+		}
+	}
+	pending, err := st.FetchPending(ctx, n)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(pending) != n {
+		t.Fatalf("pending = %d, want %d", len(pending), n)
+	}
+	ids := make([]int64, len(pending))
+	for i, p := range pending {
+		ids[i] = p.ID
+	}
+
+	run := UploadRun{StartedAt: 1, FinishedAt: 2, EventCount: n, Status: "success"}
+	if err := st.CommitUpload(ctx, run, ids, pending); err != nil {
+		t.Fatalf("commit large checkpoint: %v", err)
+	}
+	if got := st.Backlog(); got != 0 {
+		t.Fatalf("backlog after large checkpoint = %d, want 0 (chunking failed under the MVCC cap)", got)
+	}
+	left, _ := st.FetchPending(ctx, n)
+	if len(left) != 0 {
+		t.Fatalf("%d events still pending after large checkpoint", len(left))
+	}
+}
+
+// TestConcurrentWritersNoDrops is the correctness heart of the example:
+// many goroutines writing through BEGIN CONCURRENT must all land.
+func TestConcurrentWritersNoDrops(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	ctx := context.Background()
+
+	const writers, each = 8, 50
+	var wg sync.WaitGroup
+	errs := make(chan error, writers*each)
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				if _, err := st.InsertEvent(ctx, ev(fmt.Sprintf("sensor-%d", w), "telemetry", int64(i))); err != nil {
+					errs <- err
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent insert error: %v", err)
+	}
+
+	want := int64(writers * each)
+	if got, _ := st.CountEvents(ctx); got != want {
+		t.Fatalf("CountEvents = %d, want %d (events dropped!)", got, want)
+	}
+	if got := st.Backlog(); got != want {
+		t.Fatalf("backlog = %d, want %d", got, want)
+	}
+}
+
+// TestForcedConflictRetry deterministically drives a write-write
+// conflict and proves the COMMIT surfaces a retryable Busy, then a
+// fresh BEGIN CONCURRENT succeeds — the retry loop the store relies on.
+func TestForcedConflictRetry(t *testing.T) {
+	st := tempStore(t, Concurrent, false)
+	ctx := context.Background()
+	st.InsertEvent(ctx, ev("d", "orig", 1)) // id = 1
+
+	c1, err := st.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn1: %v", err)
+	}
+	defer c1.Close()
+	c2, err := st.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("conn2: %v", err)
+	}
+	defer c2.Close()
+
+	mustExec(t, c1, ctx, "BEGIN CONCURRENT")
+	mustExec(t, c2, ctx, "BEGIN CONCURRENT")
+	mustExec(t, c1, ctx, "UPDATE events SET kind = 'a' WHERE id = 1")
+	mustExec(t, c2, ctx, "UPDATE events SET kind = 'b' WHERE id = 1")
+	mustExec(t, c1, ctx, "COMMIT") // winner
+
+	_, err = c2.ExecContext(ctx, "COMMIT") // loser → Busy
+	if err == nil {
+		t.Fatal("expected Busy on conflicting COMMIT, got nil")
+	}
+	if !sqlrite.IsRetryable(err) {
+		t.Fatalf("expected retryable error, got %v", err)
+	}
+
+	// Retry on a fresh BEGIN CONCURRENT lands.
+	mustExec(t, c2, ctx, "BEGIN CONCURRENT")
+	mustExec(t, c2, ctx, "UPDATE events SET kind = 'b' WHERE id = 1")
+	mustExec(t, c2, ctx, "COMMIT")
+
+	if got := scalarText(t, st, "SELECT kind FROM events WHERE id = 1"); got != "b" {
+		t.Fatalf("final kind = %q, want %q", got, "b")
+	}
+}
+
+func TestSerializedModeWrites(t *testing.T) {
+	st := tempStore(t, Serialized, false)
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		if _, err := st.InsertEvent(ctx, ev("d", "k", int64(i))); err != nil {
+			t.Fatalf("serialized insert: %v", err)
+		}
+	}
+	if got, _ := st.CountEvents(ctx); got != 10 {
+		t.Fatalf("serialized CountEvents = %d, want 10", got)
+	}
+}
+
+// --- helpers ---
+
+func scalar(t *testing.T, st *Store, q string) int64 {
+	t.Helper()
+	var n int64
+	if err := st.db.QueryRowContext(context.Background(), q).Scan(&n); err != nil {
+		t.Fatalf("scalar %q: %v", q, err)
+	}
+	return n
+}
+
+func scalarText(t *testing.T, st *Store, q string) string {
+	t.Helper()
+	var s string
+	if err := st.db.QueryRowContext(context.Background(), q).Scan(&s); err != nil {
+		t.Fatalf("scalarText %q: %v", q, err)
+	}
+	return s
+}
+
+func mustExec(t *testing.T, c *sql.Conn, ctx context.Context, q string) {
+	t.Helper()
+	if _, err := c.ExecContext(ctx, q); err != nil {
+		t.Fatalf("exec %q: %v", q, err)
+	}
+}

--- a/examples/go-collector/internal/uploader/sink.go
+++ b/examples/go-collector/internal/uploader/sink.go
@@ -1,0 +1,95 @@
+// Package uploader drains the durable buffer to a remote sink in the
+// background, concurrently with the HTTP write path. The Sink interface
+// is deliberately tiny and pluggable — the point of the example is the
+// concurrent buffer, not any particular upstream.
+package uploader
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+)
+
+// Sink is where batches of buffered events go once the network is up.
+// Implementations must be safe for the single uploader goroutine.
+type Sink interface {
+	Name() string
+	Upload(ctx context.Context, batch []store.Event) error
+}
+
+// LogSink is the zero-config default: it logs the batch size and
+// succeeds. Useful for the demo and for running without any upstream.
+type LogSink struct {
+	Logger *log.Logger
+}
+
+func (s LogSink) Name() string { return "log" }
+
+func (s LogSink) Upload(_ context.Context, batch []store.Event) error {
+	if s.Logger != nil {
+		s.Logger.Printf("uploaded %d events", len(batch))
+	}
+	return nil
+}
+
+// WebhookSink POSTs the batch as a JSON array to a URL. Any non-2xx
+// response (or transport error) fails the cycle, leaving the events in
+// the buffer to be retried next tick — exactly the unreliable-network
+// story this example is about.
+type WebhookSink struct {
+	URL    string
+	Client *http.Client
+}
+
+func (s WebhookSink) Name() string { return "webhook(" + s.URL + ")" }
+
+func (s WebhookSink) Upload(ctx context.Context, batch []store.Event) error {
+	body, err := json.Marshal(batch)
+	if err != nil {
+		return fmt.Errorf("marshal batch: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	client := s.Client
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("post batch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("sink returned %s", resp.Status)
+	}
+	return nil
+}
+
+// FlakySink wraps another sink and fails every Nth call, to demonstrate
+// backpressure and buffer growth during an upstream outage. Deterministic
+// (counter-based) so tests can rely on it.
+type FlakySink struct {
+	Inner     Sink
+	FailEvery int64 // fail when call count % FailEvery == 0; 0 disables
+	calls     atomic.Int64
+}
+
+func (s *FlakySink) Name() string { return "flaky/" + s.Inner.Name() }
+
+func (s *FlakySink) Upload(ctx context.Context, batch []store.Event) error {
+	n := s.calls.Add(1)
+	if s.FailEvery > 0 && n%s.FailEvery == 0 {
+		return fmt.Errorf("flaky sink: simulated upstream failure on call %d", n)
+	}
+	return s.Inner.Upload(ctx, batch)
+}

--- a/examples/go-collector/internal/uploader/uploader.go
+++ b/examples/go-collector/internal/uploader/uploader.go
@@ -1,0 +1,175 @@
+package uploader
+
+import (
+	"context"
+	"log"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+)
+
+// Config tunes the uploader loop.
+type Config struct {
+	Interval  time.Duration // how often to drain (default 1s)
+	BatchSize int           // max events per cycle (default 200)
+	Logger    *log.Logger
+}
+
+// Uploader is the background goroutine that drains the buffer to a Sink.
+// It writes upload checkpoints (upload_runs + uploaded_at marks) through
+// the same store the HTTP path writes events into — that concurrency is
+// the whole point of the example.
+type Uploader struct {
+	store *store.Store
+	sink  Sink
+	cfg   Config
+	log   *log.Logger
+
+	mu        sync.Mutex
+	healthy   bool
+	lastErr   string
+	lastRunAt time.Time
+
+	runs     atomic.Int64
+	failures atomic.Int64
+}
+
+// New builds an Uploader. It starts out healthy (no failures yet).
+func New(s *store.Store, sink Sink, cfg Config) *Uploader {
+	if cfg.Interval <= 0 {
+		cfg.Interval = time.Second
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 200
+	}
+	lg := cfg.Logger
+	if lg == nil {
+		lg = log.Default()
+	}
+	return &Uploader{store: s, sink: sink, cfg: cfg, log: lg, healthy: true}
+}
+
+// Run drains on a ticker until ctx is cancelled. Blocks; run it in a
+// goroutine. A final drain attempt runs on shutdown so a clean stop
+// doesn't strand a buffered tail.
+func (u *Uploader) Run(ctx context.Context) {
+	ticker := time.NewTicker(u.cfg.Interval)
+	defer ticker.Stop()
+	u.log.Printf("uploader started: sink=%s interval=%s batch=%d",
+		u.sink.Name(), u.cfg.Interval, u.cfg.BatchSize)
+	for {
+		select {
+		case <-ctx.Done():
+			// Best-effort final drain with a fresh, short-lived context.
+			drainCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			u.cycle(drainCtx)
+			cancel()
+			u.log.Printf("uploader stopped after %d runs (%d failures)",
+				u.runs.Load(), u.failures.Load())
+			return
+		case <-ticker.C:
+			u.cycle(ctx)
+		}
+	}
+}
+
+// cycle runs one drain: fetch a batch, ship it, record the checkpoint.
+// A successful ship marks the batch uploaded; a failed ship records the
+// failure in upload_runs and leaves the events buffered for next time.
+func (u *Uploader) cycle(ctx context.Context) {
+	startedAt := time.Now().UnixMilli()
+	batch, err := u.store.FetchPending(ctx, u.cfg.BatchSize)
+	if err != nil {
+		u.markUnhealthy("fetch pending: " + err.Error())
+		return
+	}
+	if len(batch) == 0 {
+		u.markHealthy()
+		return
+	}
+
+	ids := make([]int64, len(batch))
+	for i, ev := range batch {
+		ids[i] = ev.ID
+	}
+
+	u.runs.Add(1)
+	if uploadErr := u.sink.Upload(ctx, batch); uploadErr != nil {
+		u.failures.Add(1)
+		run := store.UploadRun{
+			StartedAt:  startedAt,
+			FinishedAt: time.Now().UnixMilli(),
+			EventCount: len(batch),
+			Status:     "error",
+			Error:      uploadErr.Error(),
+		}
+		// Record the failed run; do NOT mark events uploaded (nil ids).
+		if err := u.store.CommitUpload(ctx, run, nil, batch); err != nil {
+			u.log.Printf("uploader: failed to record errored run: %v", err)
+		}
+		u.markUnhealthy("upload: " + uploadErr.Error())
+		return
+	}
+
+	run := store.UploadRun{
+		StartedAt:  startedAt,
+		FinishedAt: time.Now().UnixMilli(),
+		EventCount: len(batch),
+		Status:     "success",
+	}
+	if err := u.store.CommitUpload(ctx, run, ids, batch); err != nil {
+		// The events shipped but we couldn't checkpoint — they'll be
+		// re-shipped next cycle. At-least-once delivery; document it.
+		u.markUnhealthy("commit checkpoint: " + err.Error())
+		return
+	}
+	u.markHealthy()
+}
+
+func (u *Uploader) markHealthy() {
+	u.mu.Lock()
+	u.healthy = true
+	u.lastErr = ""
+	u.lastRunAt = time.Now()
+	u.mu.Unlock()
+}
+
+func (u *Uploader) markUnhealthy(msg string) {
+	u.mu.Lock()
+	u.healthy = false
+	u.lastErr = msg
+	u.lastRunAt = time.Now()
+	u.mu.Unlock()
+	u.log.Printf("uploader unhealthy: %s", msg)
+}
+
+// Health is a snapshot of the uploader's state for /healthz and /stats.
+type Health struct {
+	Healthy   bool   `json:"healthy"`
+	LastError string `json:"last_error,omitempty"`
+	Runs      int64  `json:"runs"`
+	Failures  int64  `json:"failures"`
+	SinkName  string `json:"sink"`
+}
+
+// Health returns the current uploader health snapshot.
+func (u *Uploader) Health() Health {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return Health{
+		Healthy:   u.healthy,
+		LastError: u.lastErr,
+		Runs:      u.runs.Load(),
+		Failures:  u.failures.Load(),
+		SinkName:  u.sink.Name(),
+	}
+}
+
+// Healthy reports whether the last cycle succeeded.
+func (u *Uploader) Healthy() bool {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.healthy
+}

--- a/examples/go-collector/internal/uploader/uploader_test.go
+++ b/examples/go-collector/internal/uploader/uploader_test.go
@@ -1,0 +1,126 @@
+package uploader
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/joaoh82/rust_sqlite/examples/go-collector/internal/store"
+)
+
+type fakeSink struct {
+	mu   sync.Mutex
+	got  []store.Event
+	fail bool
+}
+
+func (f *fakeSink) Name() string { return "fake" }
+
+func (f *fakeSink) Upload(_ context.Context, batch []store.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fail {
+		return errors.New("simulated failure")
+	}
+	f.got = append(f.got, batch...)
+	return nil
+}
+
+func (f *fakeSink) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.got)
+}
+
+func newStore(t *testing.T) *store.Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "up.sqlrite")
+	st, err := store.Open(context.Background(), store.Options{Path: path, Mode: store.Concurrent})
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func quietLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+func seedEvents(t *testing.T, st *store.Store, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		_, err := st.InsertEvent(context.Background(), store.Event{
+			DeviceID: "sensor-1", Kind: "telemetry",
+			Payload: json.RawMessage(`{"v":1}`), TS: int64(i + 1),
+		})
+		if err != nil {
+			t.Fatalf("seed insert: %v", err)
+		}
+	}
+}
+
+func TestUploaderDrainsBuffer(t *testing.T) {
+	st := newStore(t)
+	seedEvents(t, st, 5)
+	sink := &fakeSink{}
+	u := New(st, sink, Config{Logger: quietLogger()})
+
+	u.cycle(context.Background())
+
+	if sink.count() != 5 {
+		t.Fatalf("sink received %d events, want 5", sink.count())
+	}
+	if got := st.Backlog(); got != 0 {
+		t.Fatalf("backlog after drain = %d, want 0", got)
+	}
+	if !u.Healthy() {
+		t.Fatal("uploader should be healthy after a clean drain")
+	}
+}
+
+func TestUploaderFailureLeavesBuffer(t *testing.T) {
+	st := newStore(t)
+	seedEvents(t, st, 3)
+	sink := &fakeSink{fail: true}
+	u := New(st, sink, Config{Logger: quietLogger()})
+
+	u.cycle(context.Background())
+
+	if got := st.Backlog(); got != 3 {
+		t.Fatalf("backlog after failed drain = %d, want 3 (events must stay buffered)", got)
+	}
+	if u.Healthy() {
+		t.Fatal("uploader should be unhealthy after an upload failure")
+	}
+	if h := u.Health(); h.Failures != 1 {
+		t.Fatalf("failures = %d, want 1", h.Failures)
+	}
+	// A subsequent successful cycle clears the backlog and recovers.
+	sink.fail = false
+	u.cycle(context.Background())
+	if got := st.Backlog(); got != 0 {
+		t.Fatalf("backlog after recovery = %d, want 0", got)
+	}
+	if !u.Healthy() {
+		t.Fatal("uploader should recover to healthy after a clean drain")
+	}
+}
+
+func TestFlakySink(t *testing.T) {
+	inner := &fakeSink{}
+	flaky := &FlakySink{Inner: inner, FailEvery: 2}
+	ctx := context.Background()
+	if err := flaky.Upload(ctx, nil); err != nil {
+		t.Fatalf("call 1 should succeed: %v", err)
+	}
+	if err := flaky.Upload(ctx, nil); err == nil {
+		t.Fatal("call 2 should fail (FailEvery=2)")
+	}
+	if err := flaky.Upload(ctx, nil); err != nil {
+		t.Fatalf("call 3 should succeed: %v", err)
+	}
+}

--- a/web/src/app/examples/page.tsx
+++ b/web/src/app/examples/page.tsx
@@ -85,6 +85,18 @@ const itemListJsonLd = {
           "The full SQLRite engine compiled to WebAssembly, running entirely in the browser. SQL editor, sample datasets, HNSW vector search, CSV export, and shareable links — no server, no install.",
       },
     },
+    {
+      "@type": "ListItem",
+      position: 5,
+      item: {
+        "@type": "SoftwareSourceCode",
+        name: "Edge / IoT event collector — Go",
+        url: `${SITE.repo}/tree/main/examples/go-collector`,
+        programmingLanguage: "Go",
+        description:
+          "A Go HTTP collector that buffers telemetry from many concurrent producers into a local .sqlrite file while a background uploader drains it — both writing the same database via BEGIN CONCURRENT (Phase 11 MVCC). Demonstrates multi-writer concurrency + row-level conflict detection with measured throughput.",
+      },
+    },
   ],
 };
 
@@ -172,6 +184,22 @@ const EXAMPLES: Example[] = [
     repoPath: "examples/wasm-playground",
     features: ["WASM SDK", "HNSW", "CodeMirror 6", "OPFS"],
     liveUrl: "/playground",
+  },
+  {
+    status: "shipped",
+    title: "Edge / IoT event collector — Go",
+    blurb:
+      "A Go service that buffers telemetry from many concurrent HTTP producers into a local .sqlrite file, while a background uploader goroutine drains it to a remote sink — both writing the same database at once via BEGIN CONCURRENT (Phase 11 MVCC). The .sqlrite file is the durable buffer between an unreliable network and the upstream system: it survives reboots and stays queryable with SQL on-device.",
+    bullets: [
+      "HTTP write path and uploader each hold their own BEGIN CONCURRENT transaction against one engine via the Go driver's sibling-handle registry — multi-writer concurrency a single-writer DB can't express",
+      "Row-level conflict detection + the canonical retry-on-ErrBusy loop; zero dropped events under 32 concurrent producers (verified by the load generator)",
+      "Honest, measured throughput: on v0 BEGIN CONCURRENT is ~0.9× a single mutex (the win is capability + correctness, not raw speed) — the README ships all three measurement tables and explains why",
+      "Documents the v0 engine sharp edges it designs around: no param binding, 4 KiB MVCC commit cap, app-assigned ids under MVCC, reopen detection without a queryable catalog",
+      "Backpressure (503) + /healthz + /stats; Dockerfile + compose with an optional read-only sqlrite-mcp sidecar; Linux + macOS CI against the in-repo engine",
+    ],
+    language: "Go 1.21+",
+    repoPath: "examples/go-collector",
+    features: ["Go SDK (cgo)", "BEGIN CONCURRENT", "MVCC", "sqlrite-ffi"],
   },
 ];
 
@@ -360,8 +388,8 @@ export default function ExamplesIndexPage() {
               fontSize: 14,
             }}
           >
-            One more example in flight: a Go edge/IoT event collector.
-            See <Link href="/docs">/docs</Link> for the engine reference.
+            All five umbrella examples have shipped. See{" "}
+            <Link href="/docs">/docs</Link> for the engine reference.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## What

The fifth and final app under the [SQLR-38 example-apps umbrella](https://github.com/joaoh82/rust_sqlite): a **Go edge/IoT event collector** in [`examples/go-collector/`](https://github.com/joaoh82/rust_sqlite/tree/sqlr-43-go-collector/examples/go-collector). It accepts telemetry over HTTP from many concurrent producers, buffers each event in a local `.sqlrite` file, and runs a background uploader goroutine that drains the buffer to a pluggable sink — **both writing the same database concurrently via `BEGIN CONCURRENT`** (Phase 11 MVCC, SQLR-22).

Blocker confirmed cleared before starting: SQLR-22 (concurrent writes) is `done`; engine at v0.10.2; Go SDK exposes siblings + `ErrBusy`/`IsRetryable`.

## The honest headline (please read)

Concurrent writes here is a **capability + correctness** feature, **not** a throughput win. I measured it three ways and shipped the numbers as found:

| Workload | serialized (1 mutex) | concurrent (`BEGIN CONCURRENT`) |
|---|---:|---:|
| Insert throughput | **156/s** | 142/s (0.91×) |
| Insert p99 latency under a checkpoint writer | **164 ms** | 333 ms (~2× worse) |
| Disjoint-row batched txns (MVCC best case) | **2,655/s** | 2,018/s (0.76×) |

Root causes are all documented v0 limitations: global per-DB `Arc<Mutex<Database>>`, per-tx double table-clone, per-commit O(N) B-tree rebuild. The genuine win — proven by the load generator — is **independent in-process writers + row-level conflict detection + zero dropped events** under 32 concurrent producers, which single-writer can't express. The README ships all three tables with reproduce commands and a "why it isn't faster yet" section.

## Designed around verified v0 engine sharp edges

Each found by testing and documented inline + in the README: no Go-SDK param binding (inlined/escaped SQL), `CREATE TABLE IF NOT EXISTS` not honored (SELECT-probe for fresh-vs-reopen), `CREATE INDEX` rejected under MVCC (DDL before the `journal_mode` switch), the **4 KiB MVCC commit-batch cap** (chunked checkpoint commits), AUTOINCREMENT collisions under MVCC (app-assigned ids).

## Included

- `cmd/collector` (HTTP + uploader), `cmd/loadgen` (load test + 3 measurement experiments), `internal/{store,uploader,server}`
- Backpressure (503) + `/healthz` + `/stats`; pluggable + flaky sinks
- Dockerfile + docker-compose (with optional read-only `sqlrite-mcp` sidecar against a snapshot) + Makefile
- Unit/integration tests across all packages (conflict+retry, no-drops, reopen, chunked-checkpoint, backpressure)
- New `go-collector` CI job (Linux + macOS) against the in-repo engine
- Examples index + sqlritedb.com Examples card + `docs/concurrent-writes.md` cross-link

## Verification

`cargo build -p sqlrite-ffi`, `gofmt -l`, `go vet ./...`, `go test ./...` all clean. E2E: 627 concurrent POSTs → 627 uploaded → backlog 0, **0 dropped**, clean restart-reopen with id continuation. Not run: web `/examples` typecheck (no `node_modules`; card mirrors existing entries) and `docker build` (heavy; reviewed by hand).

## Follow-ups (recommended)

- v0 MVCC perf gap (BEGIN CONCURRENT slower than single mutex) — quantified by this example; unblocked by the parked COW-clone + checkpoint-drain work.
- Engine ergonomics: `CREATE TABLE IF NOT EXISTS` not honored + `sqlrite_master` not SQL-queryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)