### PR TITLE
fix(release): bump sqlrite-journal example in bump-version.sh (unblocks 0.11.0)

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -6,8 +6,8 @@
 #     scripts/bump-version.sh 0.2.0
 #
 # Rewrites the version field in every manifest that carries one
-# (nine Cargo.toml / pyproject.toml files, plus four JSON manifests
-# — thirteen files total). Also rewrites the engine npm dep pin in
+# (ten Cargo.toml / pyproject.toml files, plus four JSON manifests
+# — fourteen files total). Also rewrites the engine npm dep pin in
 # `examples/nodejs-notes/package.json` so the published example
 # resolves the matching engine. Then you run `cargo build` yourself
 # to refresh Cargo.lock. Idempotent: running twice with the same version
@@ -77,6 +77,16 @@ TOML_FILES=(
     "sdk/nodejs/Cargo.toml"
     "sdk/wasm/Cargo.toml"
     "desktop/src-tauri/Cargo.toml"
+    # `sqlrite-journal` is the second Tauri desktop app (the
+    # concurrent-writes journal example, SQLR-43). It's a workspace
+    # member that pins `sqlrite-engine` via a path+version dep, so —
+    # exactly like `desktop/src-tauri` — both its package version and
+    # that dep pin have to track the bump. Omitting it survived patch
+    # releases (a `^0.10.1` pin still matched `0.10.x`) but broke the
+    # first MINOR bump: `0.11.0` falls outside `^0.10.1`, so the
+    # workspace lock refresh failed to select a version (release-pr run
+    # 26737256013). Keep it here so the dep pin never lags the engine.
+    "examples/desktop-journal/src-tauri/Cargo.toml"
 )
 
 # Files that pin `sqlrite-engine` (or any other workspace member) but


### PR DESCRIPTION
## Problem

Dispatching the **Release PR** workflow for `0.11.0` failed at the "Refresh Cargo.lock" step ([release-pr run 26737256013](https://github.com/joaoh82/rust_sqlite/actions/runs/26737256013)):

```
error: failed to select a version for the requirement `sqlrite-engine = "^0.10.1"`
candidate versions found which didn't match: 0.11.0
required by package `sqlrite-journal` (examples/desktop-journal/src-tauri)
```

## Root cause

`examples/desktop-journal/src-tauri/Cargo.toml` (`sqlrite-journal`, the SQLR-43 concurrent-writes journal example) is a **workspace member** that pins the engine via a path+version dep:

```toml
sqlrite = { package = "sqlrite-engine", path = "../../..", version = "0.10.1" }
```

…but it was never added to `bump-version.sh`'s file lists. Every prior release was a **patch** bump, and `^0.10.1` still matched `0.10.2`/`0.10.3`, so the stale pin resolved fine. `0.11.0` is the first **minor** bump — it falls outside `^0.10.1`, so the whole-workspace lock refresh can't select a version. The existing `--exclude sqlrite-journal` (eb4662c) only skips *building* it; cargo still resolves the full workspace graph for the lockfile.

## Fix

Add the journal manifest to `TOML_FILES` — the same full-bump treatment the sibling `desktop/src-tauri` Tauri app already gets. The existing sweep then rewrites both its package version and its engine dep pin on every bump, so the pin can never lag the engine again (patch *or* minor).

## Verification (local, in a worktree)

- `bash scripts/bump-version.sh 0.11.0` → journal manifest now shows `version = "0.11.0"` and `sqlrite-engine … version = "0.11.0"`; the script's own verification loop passes.
- `cargo build --workspace --exclude sqlrite-desktop --exclude sqlrite-journal` (the exact CI lock-refresh command) resolves cleanly; `Cargo.lock` lands `sqlrite-engine 0.11.0`.
- This PR ships **only** the script change — the bump artifacts were reverted; the actual bump is the Release-PR workflow's job once this merges.

## After merge

Re-dispatch `release-pr.yml` with `0.11.0` to open the (now-passing) Release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)