### PR TITLE
fix(release): scope sqlrite-engine crate with include allowlist (fixes crates.io 413)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,28 @@ description = "Light version of SQLite developed with Rust. Published as `sqlrit
 repository = "https://github.com/joaoh82/rust_sqlite"
 license = "MIT"
 
+# Allowlist of files that ship in the published crate. The package root
+# IS the workspace root, so without this `cargo publish` sweeps the
+# ENTIRE repo tree — every sibling member, plus `web/`, `images/`, and
+# the `examples/desktop-journal/docs/` demo media. That ballooned the
+# v0.11.0 tarball to ~25 MiB and crates.io rejected it (HTTP 413, 10 MiB
+# cap) after SQLR-42/43 landed the playground wasm + the journal
+# demo.gif/.mp4. An allowlist (vs. a fragile `exclude`) keeps the crate
+# small no matter what large files land elsewhere in the repo later.
+#
+# What's listed: the library + REPL bin sources (`src/**`), the three
+# `[[example]]` targets declared below (their `.rs` files must be in the
+# tarball or `cargo publish`'s verify step fails to parse the manifest),
+# and the readme/license. `Cargo.toml` is always included implicitly.
+include = [
+    "src/**/*",
+    "examples/rust/quickstart.rs",
+    "examples/hybrid-retrieval/hybrid_retrieval.rs",
+    "examples/rust/concurrent_writers.rs",
+    "README.md",
+    "LICENSE",
+]
+
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Problem

The v0.11.0 publish run failed at **Publish sqlrite crate to crates.io** ([run 26738895572](https://github.com/joaoh82/rust_sqlite/actions/runs/26738895572)):

```
error: failed to publish sqlrite-engine v0.11.0 to registry at https://crates.io
the remote server responded with an error (status 413 Payload Too Large): max upload size is: 10485760
```

That cascaded: `sqlrite-mcp` (needs the engine) and the umbrella finalize were skipped.

## Root cause

The engine `[package]` is the **workspace root** and had no `include`/`exclude`, so `cargo publish` packaged the *entire repo tree*. Uncompressed it was ~25 MiB, dominated by files that have no business in the library crate:

| file | size | from |
|---|---|---|
| `examples/desktop-journal/docs/demo.gif` | 9.0 MiB | SQLR-43 |
| `examples/desktop-journal/docs/demo.mp4` | 8.7 MiB | SQLR-43 |
| `web/public/playground/pkg/sqlrite_wasm_bg.wasm` | 2.1 MiB | SQLR-42 |
| screenshots, lockfiles, `images/`, … | rest | — |

SQLR-42 and SQLR-43 are exactly the two PRs merged since v0.10.2, which is why the previous (patch) releases stayed under the 10 MiB cap and this minor release was the first to trip it.

## Fix

Add an `include` allowlist to the engine `[package]` — ship only `src/**`, the three declared `[[example]]` targets, README, and LICENSE. An allowlist (vs. a fragile `exclude` list) means future large files anywhere in the repo can't silently re-bloat the crate.

The three `[[example]]` `.rs` files are included deliberately: their paths are declared as targets in `Cargo.toml`, so they must exist in the tarball or `cargo publish`'s verify step fails to parse the manifest.

## Verification (local)

- `cargo package -p sqlrite-engine` → **376 KiB** `.crate` (was ~25 MiB uncompressed) and the packaged crate **compiles clean** against the already-published `sqlrite-ask 0.11.0`.
- Packaged file list is `src/**` + the 3 example targets + README/LICENSE (+ cargo's auto Cargo.toml/Cargo.lock). No media, no `web/`, no `images/`.

## How the v0.11.0 release gets completed after this merges

`sqlrite-ask`, `@joaoh82/sqlrite`, `@joaoh82/sqlrite-wasm`, Python wheels (PyPI), C FFI, the Go SDK, and the desktop apps **already published** at 0.11.0. Only `sqlrite-engine` + `sqlrite-mcp` are missing. A full `release.yml` re-dispatch would collide with those already-published artifacts (the npm/PyPI/etc. jobs have no already-exists guard), so the missing two are published surgically from fixed `main`:

```sh
cargo publish -p sqlrite-engine      # now 376 KiB → accepted
# wait for the crates.io index to carry 0.11.0, then:
cargo publish -p sqlrite-mcp
```

Follow-ups filed separately: make `release.yml` publish jobs idempotent (skip-if-already-published) so partial-failure recovery is a clean re-dispatch; set up the `sqlrite-notes` npm trusted publisher; consider moving the journal demo media out of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)