### PR TITLE
docs(release): bump displayed version to 0.11.0 (site + install snippets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ Expressions in `WHERE` and `UPDATE`'s `SET` RHS:
 
 ```toml
 [dependencies]
-sqlrite-engine = "0.1"
-sqlrite-ask    = "0.1"
+sqlrite-engine = "0.11"
+sqlrite-ask    = "0.11"
 ```
 
 ```rust

--- a/docs/ask.md
+++ b/docs/ask.md
@@ -131,8 +131,8 @@ If `SQLRITE_LLM_API_KEY` is missing, the panel surfaces a clean "missing API key
 
 ```toml
 [dependencies]
-sqlrite-engine = "0.1"
-sqlrite-ask    = "0.1"
+sqlrite-engine = "0.11"
+sqlrite-ask    = "0.11"
 ```
 
 ```rust

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -153,8 +153,8 @@ The retryable-error branch is the headline new flow: pick a backoff policy that 
 [dependencies]
 # `ask` is a default feature on sqlrite-engine; opt out with
 # default-features = false if you don't want the LLM stack pulled in.
-sqlrite-engine = "0.1"
-sqlrite-ask    = "0.1"
+sqlrite-engine = "0.11"
+sqlrite-ask    = "0.11"
 ```
 
 ```rust

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -1,7 +1,7 @@
 export const SITE = {
   url: "https://sqlritedb.com",
   twitterHandle: "@CodePolyglot",
-  version: "0.10.0",
+  version: "0.11.0",
   repo: "https://github.com/joaoh82/rust_sqlite",
   discord: "https://discord.gg/dHPmw89zAE",
   docsRs: "https://docs.rs/sqlrite-engine",


### PR DESCRIPTION
Now that **v0.11.0 is live** across crates.io (`sqlrite-engine`, `sqlrite-ask`, `sqlrite-mcp`), npm, PyPI, WASM, and Go, update the version strings that consumers see.

## Changes

- **`web/src/lib/site.ts`** — `SITE.version` `0.10.0` → `0.11.0`. This is the single source of truth the marketing site reads; it drives the hero badge, the `/docs` header, the SDK-showcase cards, and the structured-data `softwareVersion`. (It was stale at `0.10.0` even through the whole 0.10.x line.)
- **`README.md`, `docs/embedding.md`, `docs/ask.md`** — the Rust install snippets pinned `sqlrite-engine = "0.1"` / `sqlrite-ask = "0.1"`. In Cargo, `"0.1"` means `>=0.1.0, <0.2.0`, which **excludes** `0.11.0` — so a copy-paste resolved an ancient `0.1.x`. Bumped to `"0.11"` so the documented pin installs the current release.

## Scope notes

- Historical blog posts under `web/content/blog/*.mdx` and the roadmap narrative (`docs/roadmap.md`, `docs/_index.md`) mention older `0.x` versions as part of dated/phase history — intentionally left untouched (not "current version" surfaces).
- Pure string-value / doc edits; no logic or type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)