### PR TITLE
release: v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ask"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-desktop"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-engine"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-ffi"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -4866,7 +4866,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-journal"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-mcp"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "clap",
  "libc",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-nodejs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "sqlrite-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "pyo3",
  "sqlrite-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ resolver = "3"
 # `package =` key so the import name stays `sqlrite` internally:
 #     sqlrite = { package = "sqlrite-engine", path = "…" }
 name = "sqlrite-engine"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -172,4 +172,4 @@ fs2 = { version = "0.4", optional = true }
 # crate publishes to crates.io, and a path-only dep without a
 # version field fails the manifest verification step. See PR #58
 # retrospective in docs/roadmap.md.
-sqlrite-ask = { version = "0.11.0", path = "sqlrite-ask", optional = true }
+sqlrite-ask = { version = "0.12.0", path = "sqlrite-ask", optional = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -50,7 +50,7 @@ duckdb = ["dep:duckdb"]
 # The engine. Default features off (no rustyline / clap / `ask`), but
 # `file-locks` is on so the comparison runs the same lock-acquisition
 # path that any real SQLRite consumer pays.
-sqlrite = { package = "sqlrite-engine", path = "..", version = "0.11.0", default-features = false, features = ["file-locks"] }
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.12.0", default-features = false, features = ["file-locks"] }
 
 # SQLite via rusqlite, with `bundled` so the comparison is against a
 # known SQLite version (not whatever happens to be on the host).

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqlrite-desktop-frontend",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-desktop"
-version = "0.11.0"
+version = "0.12.0"
 description = "SQLRite desktop app — Tauri 2 shell around the engine"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SQLRite",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "com.sqlrite.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/examples/desktop-journal/src-tauri/Cargo.toml
+++ b/examples/desktop-journal/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-journal"
-version = "0.11.0"
+version = "0.12.0"
 description = "Local-first journaling desktop app backed by SQLRite (example app)"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
@@ -20,7 +20,7 @@ tauri-build = { version = "2", features = [] }
 # `version = "0.10.1"` is the floor for downstream packagers that take
 # the example out of the monorepo. Bump in lockstep with the engine
 # release via `scripts/bump-version.sh`.
-sqlrite = { package = "sqlrite-engine", path = "../../..", version = "0.11.0" }
+sqlrite = { package = "sqlrite-engine", path = "../../..", version = "0.12.0" }
 
 tauri = { version = "2", features = [] }
 # Dialog plugin powers the "Open…" / "Save As…" / "Export…" pickers.

--- a/examples/nodejs-notes/package.json
+++ b/examples/nodejs-notes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlrite-notes",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Example: a Node.js CLI that ingests a folder of markdown notes into SQLRite (hybrid HNSW + BM25 retrieval), then exposes the database to Claude Desktop / any MCP client via sqlrite-mcp.",
   "type": "module",
   "engines": {
@@ -19,7 +19,7 @@
     "test": "node --test 'test/**/*.test.mjs'"
   },
   "dependencies": {
-    "@joaoh82/sqlrite": "^0.11.0"
+    "@joaoh82/sqlrite": "^0.12.0"
   },
   "keywords": [
     "sqlrite",

--- a/sdk/nodejs/Cargo.toml
+++ b/sdk/nodejs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-nodejs"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joaoh82/sqlrite",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Node.js bindings for SQLRite — a small, embeddable SQLite clone written in Rust.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-python"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sqlrite"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python bindings for SQLRite — a small, embeddable SQLite clone written in Rust."
 authors = [{ name = "Joao Henrique Machado Silva", email = "joaoh82@gmail.com" }]
 license = { text = "MIT" }

--- a/sdk/wasm/Cargo.toml
+++ b/sdk/wasm/Cargo.toml
@@ -7,7 +7,7 @@
 
 [package]
 name = "sqlrite-wasm"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -46,7 +46,7 @@ sqlrite = { package = "sqlrite-engine", path = "../..", default-features = false
 # builds for wasm32). Per Q9, the WASM SDK never makes the HTTP call
 # itself — the JS caller does that. Browser → backend → LLM provider
 # → JS hands the raw response back to `db.askParse()`.
-sqlrite-ask = { version = "0.11.0", path = "../../sqlrite-ask", default-features = false }
+sqlrite-ask = { version = "0.12.0", path = "../../sqlrite-ask", default-features = false }
 
 # wasm-bindgen + friends. `serde-serialize` on wasm-bindgen gives
 # us `serde_wasm_bindgen` interop for structured row objects.

--- a/sqlrite-ask/Cargo.toml
+++ b/sqlrite-ask/Cargo.toml
@@ -10,7 +10,7 @@
 # Published to crates.io as `sqlrite-ask`. Joins the lockstep release
 # wave (`sqlrite-ask-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-ask"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-ffi/Cargo.toml
+++ b/sqlrite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlrite-ffi"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/sqlrite-mcp/Cargo.toml
+++ b/sqlrite-mcp/Cargo.toml
@@ -18,7 +18,7 @@
 # Published to crates.io as `sqlrite-mcp`. Joins the lockstep
 # release wave (`sqlrite-mcp-vX.Y.Z` tag) — see `docs/release-plan.md`.
 name = "sqlrite-mcp"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Joao Henrique Machado Silva <joaoh82@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"
@@ -52,7 +52,7 @@ ask = ["sqlrite/ask"]
 # off (which excludes the `cli` feature and its rustyline/clap pull
 # weight) and only enable `ask` when our own `ask` feature is on.
 # Keeps the MCP binary small + boot-fast.
-sqlrite = { package = "sqlrite-engine", path = "..", version = "0.11.0", default-features = false }
+sqlrite = { package = "sqlrite-engine", path = "..", version = "0.12.0", default-features = false }
 
 # JSON-RPC + tool I/O. The MCP wire format is JSON in / JSON out;
 # tool argument schemas are JSON; tool results are JSON. serde +


### PR DESCRIPTION
## Release v0.12.0

Version bump across all 14 product manifests (engine, ffi, ask, mcp, python, nodejs, wasm, desktop, examples) + `Cargo.lock` refresh.

### Headline change since 0.11.0
- **`JOIN ... USING (col)` / `NATURAL JOIN` / `CROSS JOIN`** (SQLR-5, #158) — completes the JOIN surface. `USING`/`NATURAL` dedup the joined-on column in `SELECT *` per SQLite; `CROSS` is the cross product.

Also folded in since the 0.11.0 tag: release-pipeline hardening (#154, #156) and release-docs (#155, #157).

### Compatibility
Backward-compatible for embedders — the public `Connection` / `Statement` / `Rows` / `Value` API is unchanged. The only struct that changed shape (`JoinClause`) is internal to `crate::sql::parser`.

### Publish
Merging this PR lands a `release: v0.12.0` commit on `main`, which the `release.yml` detect job recognizes (regex `^release: v\d+\.\d+\.\d+$`, with the squash-merge ` (#N)` suffix stripped) → tags all products and publishes crates / npm / PyPI / Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)