### PR TITLE
docs(release): bump displayed version to 0.12.0 (site + install snippets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,8 @@ Expressions in `WHERE` and `UPDATE`'s `SET` RHS:
 
 ```toml
 [dependencies]
-sqlrite-engine = "0.11"
-sqlrite-ask    = "0.11"
+sqlrite-engine = "0.12"
+sqlrite-ask    = "0.12"
 ```
 
 ```rust

--- a/docs/ask.md
+++ b/docs/ask.md
@@ -131,8 +131,8 @@ If `SQLRITE_LLM_API_KEY` is missing, the panel surfaces a clean "missing API key
 
 ```toml
 [dependencies]
-sqlrite-engine = "0.11"
-sqlrite-ask    = "0.11"
+sqlrite-engine = "0.12"
+sqlrite-ask    = "0.12"
 ```
 
 ```rust

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -153,8 +153,8 @@ The retryable-error branch is the headline new flow: pick a backoff policy that 
 [dependencies]
 # `ask` is a default feature on sqlrite-engine; opt out with
 # default-features = false if you don't want the LLM stack pulled in.
-sqlrite-engine = "0.11"
-sqlrite-ask    = "0.11"
+sqlrite-engine = "0.12"
+sqlrite-ask    = "0.12"
 ```
 
 ```rust

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -1,7 +1,7 @@
 export const SITE = {
   url: "https://sqlritedb.com",
   twitterHandle: "@CodePolyglot",
-  version: "0.11.0",
+  version: "0.12.0",
   repo: "https://github.com/joaoh82/rust_sqlite",
   discord: "https://discord.gg/dHPmw89zAE",
   docsRs: "https://docs.rs/sqlrite-engine",


### PR DESCRIPTION
## Summary

Follow-up to the v0.12.0 release (#159). The release pipeline bumps the package manifests but not the **displayed** version surfaces, so this brings those in line (same set of files as the 0.11.0 precedent, #155):

- **`web/src/lib/site.ts`** — `SITE.version` `0.11.0 → 0.12.0`. Single source of truth the marketing site reads: hero badge, docs page header, SDK showcase cards, and the `softwareVersion` in structured data (`web/src/app/page.tsx` derives it from `SITE.version`).
- **`README.md` / `docs/embedding.md` / `docs/ask.md`** — Rust install snippets `sqlrite-engine = "0.11"` / `sqlrite-ask = "0.11"` → `"0.12"`, so a copy-paste resolves the current release.

Left untouched intentionally: `env_logger 0.11` / `thiserror`/`sqlparser` dep references, and historical `0.1x` mentions in `release-plan.md` / `release-secrets.md` / `design-decisions.md` / `phase-8-plan.md` (those describe past waves, not the current version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)